### PR TITLE
Update jackson CVE-2020-28491

### DIFF
--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -4,8 +4,8 @@
 ** cron-utils; version 9.1.3 -- https://github.com/jmrozanec/cron-utils/tree/9.1.3
 ** EasyMock; version 4.0.1 -- https://mvnrepository.com/artifact/org.easymock/easymock/4.0.1
 ** elasticsearch 6.5.4; version 6.5.4 -- https://github.com/elastic/elasticsearch/tree/v6.5.4
-** Jackson Core; version 2.8.10 -- https://github.com/FasterXML/jackson-core/tree/jackson-core-2.8.10
-** Jackson Date Format; version 2.8.10 -- https://github.com/FasterXML/jackson-dataformats-binary
+** Jackson Core; version 2.12.3 -- https://github.com/FasterXML/jackson-core/tree/jackson-core-2.8.10
+** Jackson Date Format; version 2.12.3 -- https://github.com/FasterXML/jackson-dataformats-binary
 ** joda-time; version 2.9.9 -- https://github.com/JodaOrg/joda-time/tree/v2.9.9
 ** Kolin 1.2.6; version 1.2.60 -- https://github.com/JetBrains/kotlin/tree/1.2.60
 ** kotlin-test; version 1.2.60 -- https://github.com/JetBrains/kotlin/tree/1.2.60


### PR DESCRIPTION
This affects the package com.fasterxml.jackson.dataformat:jackson-dataformat-cbor from 0 and before 2.11.4, from 2.12.0-rc1 and before 2.12.1. Unchecked allocation of byte buffer can cause a java.lang.OutOfMemoryError exception.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).