### PR TITLE
Adding Rest APIs Backward Compatibility with ODFE

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -143,8 +143,12 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
         @JvmField val UI_METADATA_EXCLUDE = arrayOf("monitor.${Monitor.UI_METADATA_FIELD}")
         @JvmField val MONITOR_BASE_URI = "/_plugins/_alerting/monitors"
         @JvmField val DESTINATION_BASE_URI = "/_plugins/_alerting/destinations"
+        @JvmField val LEGACY_MONITOR_BASE_URI = "_opendistro/_alerting/monitors"
+        @JvmField val LEGACY_DESTINATION_BASE_URI = "_opendistro/_alerting/destinations"
         @JvmField val EMAIL_ACCOUNT_BASE_URI = "$DESTINATION_BASE_URI/email_accounts"
         @JvmField val EMAIL_GROUP_BASE_URI = "$DESTINATION_BASE_URI/email_groups"
+        @JvmField val LEGACY_EMAIL_ACCOUNT_BASE_URI = "$LEGACY_DESTINATION_BASE_URI/email_accounts"
+        @JvmField val LEGACY_EMAIL_GROUP_BASE_URI = "$LEGACY_DESTINATION_BASE_URI/email_groups"
         @JvmField val ALERTING_JOB_TYPES = listOf("monitor")
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -143,12 +143,12 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
         @JvmField val UI_METADATA_EXCLUDE = arrayOf("monitor.${Monitor.UI_METADATA_FIELD}")
         @JvmField val MONITOR_BASE_URI = "/_plugins/_alerting/monitors"
         @JvmField val DESTINATION_BASE_URI = "/_plugins/_alerting/destinations"
-        @JvmField val LEGACY_MONITOR_BASE_URI = "/_opendistro/_alerting/monitors"
-        @JvmField val LEGACY_DESTINATION_BASE_URI = "/_opendistro/_alerting/destinations"
+        @JvmField val LEGACY_OPENDISTRO_MONITOR_BASE_URI = "/_opendistro/_alerting/monitors"
+        @JvmField val LEGACY_OPENDISTRO_DESTINATION_BASE_URI = "/_opendistro/_alerting/destinations"
         @JvmField val EMAIL_ACCOUNT_BASE_URI = "$DESTINATION_BASE_URI/email_accounts"
         @JvmField val EMAIL_GROUP_BASE_URI = "$DESTINATION_BASE_URI/email_groups"
-        @JvmField val LEGACY_EMAIL_ACCOUNT_BASE_URI = "$LEGACY_DESTINATION_BASE_URI/email_accounts"
-        @JvmField val LEGACY_EMAIL_GROUP_BASE_URI = "$LEGACY_DESTINATION_BASE_URI/email_groups"
+        @JvmField val LEGACY_OPENDISTRO_EMAIL_ACCOUNT_BASE_URI = "$LEGACY_OPENDISTRO_DESTINATION_BASE_URI/email_accounts"
+        @JvmField val LEGACY_OPENDISTRO_EMAIL_GROUP_BASE_URI = "$LEGACY_OPENDISTRO_DESTINATION_BASE_URI/email_groups"
         @JvmField val ALERTING_JOB_TYPES = listOf("monitor")
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -141,8 +141,8 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
     companion object {
         @JvmField val OPEN_SEARCH_DASHBOARDS_USER_AGENT = "OpenSearch-Dashboards"
         @JvmField val UI_METADATA_EXCLUDE = arrayOf("monitor.${Monitor.UI_METADATA_FIELD}")
-        @JvmField val MONITOR_BASE_URI = "/_opendistro/_alerting/monitors"
-        @JvmField val DESTINATION_BASE_URI = "/_opendistro/_alerting/destinations"
+        @JvmField val MONITOR_BASE_URI = "/_plugins/_alerting/monitors"
+        @JvmField val DESTINATION_BASE_URI = "/_plugins/_alerting/destinations"
         @JvmField val EMAIL_ACCOUNT_BASE_URI = "$DESTINATION_BASE_URI/email_accounts"
         @JvmField val EMAIL_GROUP_BASE_URI = "$DESTINATION_BASE_URI/email_groups"
         @JvmField val ALERTING_JOB_TYPES = listOf("monitor")

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -143,8 +143,8 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
         @JvmField val UI_METADATA_EXCLUDE = arrayOf("monitor.${Monitor.UI_METADATA_FIELD}")
         @JvmField val MONITOR_BASE_URI = "/_plugins/_alerting/monitors"
         @JvmField val DESTINATION_BASE_URI = "/_plugins/_alerting/destinations"
-        @JvmField val LEGACY_MONITOR_BASE_URI = "_opendistro/_alerting/monitors"
-        @JvmField val LEGACY_DESTINATION_BASE_URI = "_opendistro/_alerting/destinations"
+        @JvmField val LEGACY_MONITOR_BASE_URI = "/_opendistro/_alerting/monitors"
+        @JvmField val LEGACY_DESTINATION_BASE_URI = "/_opendistro/_alerting/destinations"
         @JvmField val EMAIL_ACCOUNT_BASE_URI = "$DESTINATION_BASE_URI/email_accounts"
         @JvmField val EMAIL_GROUP_BASE_URI = "$DESTINATION_BASE_URI/email_groups"
         @JvmField val LEGACY_EMAIL_ACCOUNT_BASE_URI = "$LEGACY_DESTINATION_BASE_URI/email_accounts"

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestAcknowledgeAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestAcknowledgeAlertAction.kt
@@ -69,7 +69,7 @@ class RestAcknowledgeAlertAction : BaseRestHandler() {
                 POST,
                 "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}/_acknowledge/alerts",
                 POST,
-                "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/{monitorID}/_acknowledge/alerts"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_MONITOR_BASE_URI}/{monitorID}/_acknowledge/alerts"
             )
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestAcknowledgeAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestAcknowledgeAlertAction.kt
@@ -26,13 +26,13 @@
 
 package org.opensearch.alerting.resthandler
 
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import org.opensearch.action.support.WriteRequest.RefreshPolicy
 import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.action.AcknowledgeAlertAction
 import org.opensearch.alerting.action.AcknowledgeAlertRequest
 import org.opensearch.alerting.util.REFRESH
-import org.apache.logging.log4j.LogManager
-import org.apache.logging.log4j.Logger
-import org.opensearch.action.support.WriteRequest.RefreshPolicy
 import org.opensearch.client.node.NodeClient
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
@@ -69,7 +69,8 @@ class RestAcknowledgeAlertAction : BaseRestHandler() {
                 POST,
                 "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}/_acknowledge/alerts",
                 POST,
-                "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/{monitorID}/_acknowledge/alerts")
+                "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/{monitorID}/_acknowledge/alerts"
+            )
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestAcknowledgeAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestAcknowledgeAlertAction.kt
@@ -38,6 +38,7 @@ import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
+import org.opensearch.rest.RestHandler.ReplacedRoute
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestRequest.Method.POST
@@ -61,6 +62,16 @@ class RestAcknowledgeAlertAction : BaseRestHandler() {
         return listOf(
                 // Acknowledge alerts
                 Route(POST, "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}/_acknowledge/alerts")
+        )
+    }
+
+    override fun replacedRoutes(): MutableList<ReplacedRoute> {
+        return mutableListOf(
+            ReplacedRoute(
+                POST,
+                "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}/_acknowledge/alerts",
+                POST,
+                "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/{monitorID}/_acknowledge/alerts")
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestAcknowledgeAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestAcknowledgeAlertAction.kt
@@ -59,13 +59,11 @@ class RestAcknowledgeAlertAction : BaseRestHandler() {
     }
 
     override fun routes(): List<Route> {
-        return listOf(
-                // Acknowledge alerts
-                Route(POST, "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}/_acknowledge/alerts")
-        )
+        return listOf()
     }
 
     override fun replacedRoutes(): MutableList<ReplacedRoute> {
+        // Acknowledge alerts
         return mutableListOf(
             ReplacedRoute(
                 POST,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteDestinationAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteDestinationAction.kt
@@ -36,6 +36,7 @@ import org.opensearch.action.support.WriteRequest
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
+import org.opensearch.rest.RestHandler
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.action.RestToXContentListener
@@ -55,6 +56,17 @@ class RestDeleteDestinationAction : BaseRestHandler() {
     override fun routes(): List<Route> {
         return listOf(
                 Route(RestRequest.Method.DELETE, "${AlertingPlugin.DESTINATION_BASE_URI}/{destinationID}")
+        )
+    }
+
+    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+        return mutableListOf(
+            RestHandler.ReplacedRoute(
+                RestRequest.Method.DELETE,
+                "${AlertingPlugin.DESTINATION_BASE_URI}/{destinationID}",
+                RestRequest.Method.DELETE,
+                "${AlertingPlugin.LEGACY_DESTINATION_BASE_URI}/{destinationID}"
+            )
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteDestinationAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteDestinationAction.kt
@@ -26,13 +26,13 @@
 
 package org.opensearch.alerting.resthandler
 
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import org.opensearch.action.support.WriteRequest
 import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.action.DeleteDestinationAction
 import org.opensearch.alerting.action.DeleteDestinationRequest
 import org.opensearch.alerting.util.REFRESH
-import org.apache.logging.log4j.LogManager
-import org.apache.logging.log4j.Logger
-import org.opensearch.action.support.WriteRequest
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteDestinationAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteDestinationAction.kt
@@ -63,7 +63,7 @@ class RestDeleteDestinationAction : BaseRestHandler() {
                 RestRequest.Method.DELETE,
                 "${AlertingPlugin.DESTINATION_BASE_URI}/{destinationID}",
                 RestRequest.Method.DELETE,
-                "${AlertingPlugin.LEGACY_DESTINATION_BASE_URI}/{destinationID}"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_DESTINATION_BASE_URI}/{destinationID}"
             )
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteDestinationAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteDestinationAction.kt
@@ -36,7 +36,7 @@ import org.opensearch.alerting.util.REFRESH
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
-import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestHandler.ReplacedRoute
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.action.RestToXContentListener
@@ -57,9 +57,9 @@ class RestDeleteDestinationAction : BaseRestHandler() {
         return listOf()
     }
 
-    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+    override fun replacedRoutes(): MutableList<ReplacedRoute> {
         return mutableListOf(
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 RestRequest.Method.DELETE,
                 "${AlertingPlugin.DESTINATION_BASE_URI}/{destinationID}",
                 RestRequest.Method.DELETE,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteDestinationAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteDestinationAction.kt
@@ -54,9 +54,7 @@ class RestDeleteDestinationAction : BaseRestHandler() {
     }
 
     override fun routes(): List<Route> {
-        return listOf(
-                Route(RestRequest.Method.DELETE, "${AlertingPlugin.DESTINATION_BASE_URI}/{destinationID}")
-        )
+        return listOf()
     }
 
     override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteEmailAccountAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteEmailAccountAction.kt
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.Logger
 import org.opensearch.action.support.WriteRequest
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
+import org.opensearch.rest.RestHandler
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.action.RestToXContentListener
@@ -54,6 +55,17 @@ class RestDeleteEmailAccountAction : BaseRestHandler() {
     override fun routes(): List<Route> {
         return listOf(
                 Route(RestRequest.Method.DELETE, "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}")
+        )
+    }
+
+    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+        return mutableListOf(
+            RestHandler.ReplacedRoute(
+                RestRequest.Method.DELETE,
+                "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}",
+                RestRequest.Method.DELETE,
+                "${AlertingPlugin.LEGACY_EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}"
+            )
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteEmailAccountAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteEmailAccountAction.kt
@@ -35,7 +35,7 @@ import org.opensearch.alerting.action.DeleteEmailAccountRequest
 import org.opensearch.alerting.util.REFRESH
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
-import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestHandler.ReplacedRoute
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.action.RestToXContentListener
@@ -56,9 +56,9 @@ class RestDeleteEmailAccountAction : BaseRestHandler() {
         return listOf()
     }
 
-    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+    override fun replacedRoutes(): MutableList<ReplacedRoute> {
         return mutableListOf(
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 RestRequest.Method.DELETE,
                 "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}",
                 RestRequest.Method.DELETE,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteEmailAccountAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteEmailAccountAction.kt
@@ -62,7 +62,7 @@ class RestDeleteEmailAccountAction : BaseRestHandler() {
                 RestRequest.Method.DELETE,
                 "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}",
                 RestRequest.Method.DELETE,
-                "${AlertingPlugin.LEGACY_EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}"
             )
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteEmailAccountAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteEmailAccountAction.kt
@@ -53,9 +53,7 @@ class RestDeleteEmailAccountAction : BaseRestHandler() {
     }
 
     override fun routes(): List<Route> {
-        return listOf(
-                Route(RestRequest.Method.DELETE, "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}")
-        )
+        return listOf()
     }
 
     override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteEmailAccountAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteEmailAccountAction.kt
@@ -26,13 +26,13 @@
 
 package org.opensearch.alerting.resthandler
 
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import org.opensearch.action.support.WriteRequest
 import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.action.DeleteEmailAccountAction
 import org.opensearch.alerting.action.DeleteEmailAccountRequest
 import org.opensearch.alerting.util.REFRESH
-import org.apache.logging.log4j.LogManager
-import org.apache.logging.log4j.Logger
-import org.opensearch.action.support.WriteRequest
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.RestHandler

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteEmailGroupAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteEmailGroupAction.kt
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.Logger
 import org.opensearch.action.support.WriteRequest
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
+import org.opensearch.rest.RestHandler
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.action.RestToXContentListener
@@ -54,6 +55,17 @@ class RestDeleteEmailGroupAction : BaseRestHandler() {
     override fun routes(): List<Route> {
         return listOf(
                 Route(RestRequest.Method.DELETE, "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/{emailGroupID}")
+        )
+    }
+
+    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+        return mutableListOf(
+            RestHandler.ReplacedRoute(
+                RestRequest.Method.DELETE,
+                "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/{emailGroupID}",
+                RestRequest.Method.DELETE,
+                "${AlertingPlugin.LEGACY_EMAIL_GROUP_BASE_URI}/{emailGroupID}"
+            )
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteEmailGroupAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteEmailGroupAction.kt
@@ -35,7 +35,7 @@ import org.opensearch.alerting.action.DeleteEmailGroupRequest
 import org.opensearch.alerting.util.REFRESH
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
-import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestHandler.ReplacedRoute
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.action.RestToXContentListener
@@ -56,9 +56,9 @@ class RestDeleteEmailGroupAction : BaseRestHandler() {
         return listOf()
     }
 
-    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+    override fun replacedRoutes(): MutableList<ReplacedRoute> {
         return mutableListOf(
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 RestRequest.Method.DELETE,
                 "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/{emailGroupID}",
                 RestRequest.Method.DELETE,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteEmailGroupAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteEmailGroupAction.kt
@@ -26,13 +26,13 @@
 
 package org.opensearch.alerting.resthandler
 
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import org.opensearch.action.support.WriteRequest
 import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.action.DeleteEmailGroupAction
 import org.opensearch.alerting.action.DeleteEmailGroupRequest
 import org.opensearch.alerting.util.REFRESH
-import org.apache.logging.log4j.LogManager
-import org.apache.logging.log4j.Logger
-import org.opensearch.action.support.WriteRequest
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.RestHandler

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteEmailGroupAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteEmailGroupAction.kt
@@ -53,9 +53,7 @@ class RestDeleteEmailGroupAction : BaseRestHandler() {
     }
 
     override fun routes(): List<Route> {
-        return listOf(
-                Route(RestRequest.Method.DELETE, "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/{emailGroupID}")
-        )
+        return listOf()
     }
 
     override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteEmailGroupAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteEmailGroupAction.kt
@@ -62,7 +62,7 @@ class RestDeleteEmailGroupAction : BaseRestHandler() {
                 RestRequest.Method.DELETE,
                 "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/{emailGroupID}",
                 RestRequest.Method.DELETE,
-                "${AlertingPlugin.LEGACY_EMAIL_GROUP_BASE_URI}/{emailGroupID}"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_EMAIL_GROUP_BASE_URI}/{emailGroupID}"
             )
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteMonitorAction.kt
@@ -65,7 +65,7 @@ class RestDeleteMonitorAction : BaseRestHandler() {
                 DELETE,
                 "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}",
                 DELETE,
-                "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/{monitorID}"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_MONITOR_BASE_URI}/{monitorID}"
             )
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteMonitorAction.kt
@@ -36,7 +36,7 @@ import org.opensearch.alerting.util.REFRESH
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
-import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestHandler.ReplacedRoute
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestRequest.Method.DELETE
@@ -59,9 +59,9 @@ class RestDeleteMonitorAction : BaseRestHandler() {
         return listOf()
     }
 
-    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+    override fun replacedRoutes(): MutableList<ReplacedRoute> {
         return mutableListOf(
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 DELETE,
                 "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}",
                 DELETE,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteMonitorAction.kt
@@ -56,9 +56,7 @@ class RestDeleteMonitorAction : BaseRestHandler() {
     }
 
     override fun routes(): List<Route> {
-        return listOf(
-                Route(DELETE, "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}") // Delete a monitor
-        )
+        return listOf()
     }
 
     override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteMonitorAction.kt
@@ -36,6 +36,7 @@ import org.opensearch.action.support.WriteRequest.RefreshPolicy
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
+import org.opensearch.rest.RestHandler
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestRequest.Method.DELETE
@@ -57,6 +58,17 @@ class RestDeleteMonitorAction : BaseRestHandler() {
     override fun routes(): List<Route> {
         return listOf(
                 Route(DELETE, "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}") // Delete a monitor
+        )
+    }
+
+    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+        return mutableListOf(
+            RestHandler.ReplacedRoute(
+                DELETE,
+                "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}",
+                DELETE,
+                "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/{monitorID}"
+            )
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteMonitorAction.kt
@@ -25,14 +25,14 @@
  */
 package org.opensearch.alerting.resthandler
 
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import org.opensearch.action.support.WriteRequest.RefreshPolicy
 import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.action.DeleteMonitorAction
 import org.opensearch.alerting.action.DeleteMonitorRequest
 import org.opensearch.alerting.model.Alert
 import org.opensearch.alerting.util.REFRESH
-import org.apache.logging.log4j.LogManager
-import org.apache.logging.log4j.Logger
-import org.opensearch.action.support.WriteRequest.RefreshPolicy
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestExecuteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestExecuteMonitorAction.kt
@@ -37,6 +37,7 @@ import org.opensearch.common.xcontent.XContentParser.Token.START_OBJECT
 import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
+import org.opensearch.rest.RestHandler
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestRequest.Method.POST
@@ -53,6 +54,23 @@ class RestExecuteMonitorAction : BaseRestHandler() {
         return listOf(
                 Route(POST, "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}/_execute"),
                 Route(POST, "${AlertingPlugin.MONITOR_BASE_URI}/_execute")
+        )
+    }
+
+    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+        return mutableListOf(
+            RestHandler.ReplacedRoute(
+                POST,
+                "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}/_execute",
+                POST,
+                "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/{monitorID}/_execute"
+            ),
+            RestHandler.ReplacedRoute(
+                POST,
+                "${AlertingPlugin.MONITOR_BASE_URI}/_execute",
+                POST,
+                "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/_execute"
+            )
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestExecuteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestExecuteMonitorAction.kt
@@ -51,10 +51,7 @@ class RestExecuteMonitorAction : BaseRestHandler() {
     override fun getName(): String = "execute_monitor_action"
 
     override fun routes(): List<Route> {
-        return listOf(
-                Route(POST, "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}/_execute"),
-                Route(POST, "${AlertingPlugin.MONITOR_BASE_URI}/_execute")
-        )
+        return listOf()
     }
 
     override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestExecuteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestExecuteMonitorAction.kt
@@ -60,13 +60,13 @@ class RestExecuteMonitorAction : BaseRestHandler() {
                 POST,
                 "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}/_execute",
                 POST,
-                "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/{monitorID}/_execute"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_MONITOR_BASE_URI}/{monitorID}/_execute"
             ),
             ReplacedRoute(
                 POST,
                 "${AlertingPlugin.MONITOR_BASE_URI}/_execute",
                 POST,
-                "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/_execute"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_MONITOR_BASE_URI}/_execute"
             )
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestExecuteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestExecuteMonitorAction.kt
@@ -37,7 +37,7 @@ import org.opensearch.common.xcontent.XContentParser.Token.START_OBJECT
 import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
-import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestHandler.ReplacedRoute
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestRequest.Method.POST
@@ -54,15 +54,15 @@ class RestExecuteMonitorAction : BaseRestHandler() {
         return listOf()
     }
 
-    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+    override fun replacedRoutes(): MutableList<ReplacedRoute> {
         return mutableListOf(
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 POST,
                 "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}/_execute",
                 POST,
                 "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/{monitorID}/_execute"
             ),
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 POST,
                 "${AlertingPlugin.MONITOR_BASE_URI}/_execute",
                 POST,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestExecuteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestExecuteMonitorAction.kt
@@ -26,11 +26,11 @@
 
 package org.opensearch.alerting.resthandler
 
+import org.apache.logging.log4j.LogManager
 import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.action.ExecuteMonitorAction
 import org.opensearch.alerting.action.ExecuteMonitorRequest
 import org.opensearch.alerting.model.Monitor
-import org.apache.logging.log4j.LogManager
 import org.opensearch.client.node.NodeClient
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.xcontent.XContentParser.Token.START_OBJECT

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetAlertsAction.kt
@@ -61,7 +61,7 @@ class RestGetAlertsAction : BaseRestHandler() {
                 GET,
                 "${AlertingPlugin.MONITOR_BASE_URI}/alerts",
                 GET,
-                "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/alerts"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_MONITOR_BASE_URI}/alerts"
             )
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetAlertsAction.kt
@@ -34,7 +34,7 @@ import org.opensearch.alerting.model.Table
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
-import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestHandler.ReplacedRoute
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestRequest.Method.GET
@@ -55,9 +55,9 @@ class RestGetAlertsAction : BaseRestHandler() {
         return listOf()
     }
 
-    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+    override fun replacedRoutes(): MutableList<ReplacedRoute> {
         return mutableListOf(
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 GET,
                 "${AlertingPlugin.MONITOR_BASE_URI}/alerts",
                 GET,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetAlertsAction.kt
@@ -34,6 +34,7 @@ import org.apache.logging.log4j.LogManager
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
+import org.opensearch.rest.RestHandler
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestRequest.Method.GET
@@ -53,6 +54,17 @@ class RestGetAlertsAction : BaseRestHandler() {
     override fun routes(): List<Route> {
         return listOf(
                 Route(GET, "${AlertingPlugin.MONITOR_BASE_URI}/alerts")
+        )
+    }
+
+    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+        return mutableListOf(
+            RestHandler.ReplacedRoute(
+                GET,
+                "${AlertingPlugin.MONITOR_BASE_URI}/alerts",
+                GET,
+                "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/alerts"
+            )
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetAlertsAction.kt
@@ -26,11 +26,11 @@
 
 package org.opensearch.alerting.resthandler
 
+import org.apache.logging.log4j.LogManager
 import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.action.GetAlertsAction
 import org.opensearch.alerting.action.GetAlertsRequest
 import org.opensearch.alerting.model.Table
-import org.apache.logging.log4j.LogManager
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
@@ -79,17 +79,18 @@ class RestGetAlertsAction : BaseRestHandler() {
         val alertState = request.param("alertState", "ALL")
         val monitorId: String? = request.param("monitorId")
         val table = Table(
-                sortOrder,
-                sortString,
-                missing,
-                size,
-                startIndex,
-                searchString
+            sortOrder,
+            sortString,
+            missing,
+            size,
+            startIndex,
+            searchString
         )
 
         val getAlertsRequest = GetAlertsRequest(table, severityLevel, alertState, monitorId)
         return RestChannelConsumer {
-            channel -> client.execute(GetAlertsAction.INSTANCE, getAlertsRequest, RestToXContentListener(channel))
+            channel ->
+            client.execute(GetAlertsAction.INSTANCE, getAlertsRequest, RestToXContentListener(channel))
         }
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetAlertsAction.kt
@@ -52,9 +52,7 @@ class RestGetAlertsAction : BaseRestHandler() {
     }
 
     override fun routes(): List<Route> {
-        return listOf(
-                Route(GET, "${AlertingPlugin.MONITOR_BASE_URI}/alerts")
-        )
+        return listOf()
     }
 
     override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetDestinationsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetDestinationsAction.kt
@@ -35,7 +35,8 @@ import org.opensearch.alerting.util.context
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
-import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestHandler.ReplacedRoute
+import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.action.RestActions
 import org.opensearch.rest.action.RestToXContentListener
@@ -52,20 +53,20 @@ class RestGetDestinationsAction : BaseRestHandler() {
         return "get_destinations_action"
     }
 
-    override fun routes(): List<RestHandler.Route> {
+    override fun routes(): List<Route> {
         return listOf()
     }
 
-    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+    override fun replacedRoutes(): MutableList<ReplacedRoute> {
         return mutableListOf(
             // Get a specific destination
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 RestRequest.Method.GET,
                 "${AlertingPlugin.DESTINATION_BASE_URI}/{destinationID}",
                 RestRequest.Method.GET,
                 "${AlertingPlugin.LEGACY_DESTINATION_BASE_URI}/{destinationID}"
             ),
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 RestRequest.Method.GET,
                 AlertingPlugin.DESTINATION_BASE_URI,
                 RestRequest.Method.GET,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetDestinationsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetDestinationsAction.kt
@@ -53,15 +53,12 @@ class RestGetDestinationsAction : BaseRestHandler() {
     }
 
     override fun routes(): List<RestHandler.Route> {
-        return listOf(
-                // Get a specific destination
-                RestHandler.Route(RestRequest.Method.GET, "${AlertingPlugin.DESTINATION_BASE_URI}/{destinationID}"),
-                RestHandler.Route(RestRequest.Method.GET, AlertingPlugin.DESTINATION_BASE_URI)
-        )
+        return listOf()
     }
 
     override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
         return mutableListOf(
+            // Get a specific destination
             RestHandler.ReplacedRoute(
                 RestRequest.Method.GET,
                 "${AlertingPlugin.DESTINATION_BASE_URI}/{destinationID}",

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetDestinationsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetDestinationsAction.kt
@@ -64,13 +64,13 @@ class RestGetDestinationsAction : BaseRestHandler() {
                 RestRequest.Method.GET,
                 "${AlertingPlugin.DESTINATION_BASE_URI}/{destinationID}",
                 RestRequest.Method.GET,
-                "${AlertingPlugin.LEGACY_DESTINATION_BASE_URI}/{destinationID}"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_DESTINATION_BASE_URI}/{destinationID}"
             ),
             ReplacedRoute(
                 RestRequest.Method.GET,
                 AlertingPlugin.DESTINATION_BASE_URI,
                 RestRequest.Method.GET,
-                AlertingPlugin.LEGACY_DESTINATION_BASE_URI
+                AlertingPlugin.LEGACY_OPENDISTRO_DESTINATION_BASE_URI
             )
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetDestinationsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetDestinationsAction.kt
@@ -56,7 +56,24 @@ class RestGetDestinationsAction : BaseRestHandler() {
         return listOf(
                 // Get a specific destination
                 RestHandler.Route(RestRequest.Method.GET, "${AlertingPlugin.DESTINATION_BASE_URI}/{destinationID}"),
-                RestHandler.Route(RestRequest.Method.GET, "${AlertingPlugin.DESTINATION_BASE_URI}")
+                RestHandler.Route(RestRequest.Method.GET, AlertingPlugin.DESTINATION_BASE_URI)
+        )
+    }
+
+    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+        return mutableListOf(
+            RestHandler.ReplacedRoute(
+                RestRequest.Method.GET,
+                "${AlertingPlugin.DESTINATION_BASE_URI}/{destinationID}",
+                RestRequest.Method.GET,
+                "${AlertingPlugin.LEGACY_DESTINATION_BASE_URI}/{destinationID}"
+            ),
+            RestHandler.ReplacedRoute(
+                RestRequest.Method.GET,
+                AlertingPlugin.DESTINATION_BASE_URI,
+                RestRequest.Method.GET,
+                AlertingPlugin.LEGACY_DESTINATION_BASE_URI
+            )
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetDestinationsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetDestinationsAction.kt
@@ -26,12 +26,12 @@
 
 package org.opensearch.alerting.resthandler
 
+import org.apache.logging.log4j.LogManager
 import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.action.GetDestinationsAction
 import org.opensearch.alerting.action.GetDestinationsRequest
 import org.opensearch.alerting.model.Table
 import org.opensearch.alerting.util.context
-import org.apache.logging.log4j.LogManager
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
@@ -93,23 +93,24 @@ class RestGetDestinationsAction : BaseRestHandler() {
         val destinationType = request.param("destinationType", "ALL")
 
         val table = Table(
-                sortOrder,
-                sortString,
-                missing,
-                size,
-                startIndex,
-                searchString
+            sortOrder,
+            sortString,
+            missing,
+            size,
+            startIndex,
+            searchString
         )
 
         val getDestinationsRequest = GetDestinationsRequest(
-                destinationId,
-                RestActions.parseVersion(request),
-                srcContext,
-                table,
-                destinationType
+            destinationId,
+            RestActions.parseVersion(request),
+            srcContext,
+            table,
+            destinationType
         )
         return RestChannelConsumer {
-            channel -> client.execute(GetDestinationsAction.INSTANCE, getDestinationsRequest, RestToXContentListener(channel))
+            channel ->
+            client.execute(GetDestinationsAction.INSTANCE, getDestinationsRequest, RestToXContentListener(channel))
         }
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetEmailAccountAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetEmailAccountAction.kt
@@ -32,7 +32,7 @@ import org.opensearch.alerting.action.GetEmailAccountRequest
 import org.opensearch.alerting.util.context
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
-import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestHandler.ReplacedRoute
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.action.RestActions
@@ -53,15 +53,15 @@ class RestGetEmailAccountAction : BaseRestHandler() {
         return listOf()
     }
 
-    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+    override fun replacedRoutes(): MutableList<ReplacedRoute> {
         return mutableListOf(
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 RestRequest.Method.GET,
                 "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}",
                 RestRequest.Method.GET,
                 "${AlertingPlugin.LEGACY_EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}"
             ),
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 RestRequest.Method.HEAD,
                 "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}",
                 RestRequest.Method.HEAD,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetEmailAccountAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetEmailAccountAction.kt
@@ -50,10 +50,7 @@ class RestGetEmailAccountAction : BaseRestHandler() {
     }
 
     override fun routes(): List<Route> {
-        return listOf(
-                Route(RestRequest.Method.GET, "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}"),
-                Route(RestRequest.Method.HEAD, "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}")
-        )
+        return listOf()
     }
 
     override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetEmailAccountAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetEmailAccountAction.kt
@@ -32,6 +32,7 @@ import org.opensearch.alerting.action.GetEmailAccountRequest
 import org.opensearch.alerting.util.context
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
+import org.opensearch.rest.RestHandler
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.action.RestActions
@@ -52,6 +53,23 @@ class RestGetEmailAccountAction : BaseRestHandler() {
         return listOf(
                 Route(RestRequest.Method.GET, "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}"),
                 Route(RestRequest.Method.HEAD, "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}")
+        )
+    }
+
+    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+        return mutableListOf(
+            RestHandler.ReplacedRoute(
+                RestRequest.Method.GET,
+                "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}",
+                RestRequest.Method.GET,
+                "${AlertingPlugin.LEGACY_EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}"
+            ),
+            RestHandler.ReplacedRoute(
+                RestRequest.Method.HEAD,
+                "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}",
+                RestRequest.Method.HEAD,
+                "${AlertingPlugin.LEGACY_EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}"
+            )
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetEmailAccountAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetEmailAccountAction.kt
@@ -59,13 +59,13 @@ class RestGetEmailAccountAction : BaseRestHandler() {
                 RestRequest.Method.GET,
                 "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}",
                 RestRequest.Method.GET,
-                "${AlertingPlugin.LEGACY_EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}"
             ),
             ReplacedRoute(
                 RestRequest.Method.HEAD,
                 "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}",
                 RestRequest.Method.HEAD,
-                "${AlertingPlugin.LEGACY_EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}"
             )
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetEmailGroupAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetEmailGroupAction.kt
@@ -59,13 +59,13 @@ class RestGetEmailGroupAction : BaseRestHandler() {
                 RestRequest.Method.GET,
                 "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/{emailGroupID}",
                 RestRequest.Method.GET,
-                "${AlertingPlugin.LEGACY_EMAIL_GROUP_BASE_URI}/{emailGroupID}"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_EMAIL_GROUP_BASE_URI}/{emailGroupID}"
             ),
             ReplacedRoute(
                 RestRequest.Method.HEAD,
                 "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/{emailGroupID}",
                 RestRequest.Method.HEAD,
-                "${AlertingPlugin.LEGACY_EMAIL_GROUP_BASE_URI}/{emailGroupID}"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_EMAIL_GROUP_BASE_URI}/{emailGroupID}"
             )
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetEmailGroupAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetEmailGroupAction.kt
@@ -32,6 +32,7 @@ import org.opensearch.alerting.action.GetEmailGroupRequest
 import org.opensearch.alerting.util.context
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
+import org.opensearch.rest.RestHandler
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.action.RestActions
@@ -52,6 +53,23 @@ class RestGetEmailGroupAction : BaseRestHandler() {
         return listOf(
                 Route(RestRequest.Method.GET, "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/{emailGroupID}"),
                 Route(RestRequest.Method.HEAD, "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/{emailGroupID}")
+        )
+    }
+
+    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+        return mutableListOf(
+            RestHandler.ReplacedRoute(
+                RestRequest.Method.GET,
+                "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/{emailGroupID}",
+                RestRequest.Method.GET,
+                "${AlertingPlugin.LEGACY_EMAIL_GROUP_BASE_URI}/{emailGroupID}"
+            ),
+            RestHandler.ReplacedRoute(
+                RestRequest.Method.HEAD,
+                "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/{emailGroupID}",
+                RestRequest.Method.HEAD,
+                "${AlertingPlugin.LEGACY_EMAIL_GROUP_BASE_URI}/{emailGroupID}"
+            )
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetEmailGroupAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetEmailGroupAction.kt
@@ -50,10 +50,7 @@ class RestGetEmailGroupAction : BaseRestHandler() {
     }
 
     override fun routes(): List<Route> {
-        return listOf(
-                Route(RestRequest.Method.GET, "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/{emailGroupID}"),
-                Route(RestRequest.Method.HEAD, "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/{emailGroupID}")
-        )
+        return listOf()
     }
 
     override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetEmailGroupAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetEmailGroupAction.kt
@@ -32,7 +32,7 @@ import org.opensearch.alerting.action.GetEmailGroupRequest
 import org.opensearch.alerting.util.context
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
-import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestHandler.ReplacedRoute
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.action.RestActions
@@ -53,15 +53,15 @@ class RestGetEmailGroupAction : BaseRestHandler() {
         return listOf()
     }
 
-    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+    override fun replacedRoutes(): MutableList<ReplacedRoute> {
         return mutableListOf(
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 RestRequest.Method.GET,
                 "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/{emailGroupID}",
                 RestRequest.Method.GET,
                 "${AlertingPlugin.LEGACY_EMAIL_GROUP_BASE_URI}/{emailGroupID}"
             ),
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 RestRequest.Method.HEAD,
                 "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/{emailGroupID}",
                 RestRequest.Method.HEAD,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetMonitorAction.kt
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.LogManager
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
+import org.opensearch.rest.RestHandler
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestRequest.Method.GET
@@ -57,6 +58,23 @@ class RestGetMonitorAction : BaseRestHandler() {
                 // Get a specific monitor
                 Route(GET, "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}"),
                 Route(HEAD, "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}")
+        )
+    }
+
+    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+        return mutableListOf(
+            RestHandler.ReplacedRoute(
+                GET,
+                "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}",
+                GET,
+                "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/{monitorID}"
+            ),
+            RestHandler.ReplacedRoute(
+                HEAD,
+                "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}",
+                HEAD,
+                "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/{monitorID}"
+            )
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetMonitorAction.kt
@@ -25,11 +25,11 @@
  */
 package org.opensearch.alerting.resthandler
 
+import org.apache.logging.log4j.LogManager
 import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.action.GetMonitorAction
 import org.opensearch.alerting.action.GetMonitorRequest
 import org.opensearch.alerting.util.context
-import org.apache.logging.log4j.LogManager
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
@@ -89,7 +89,8 @@ class RestGetMonitorAction : BaseRestHandler() {
         }
         val getMonitorRequest = GetMonitorRequest(monitorId, RestActions.parseVersion(request), request.method(), srcContext)
         return RestChannelConsumer {
-            channel -> client.execute(GetMonitorAction.INSTANCE, getMonitorRequest, RestToXContentListener(channel))
+            channel ->
+            client.execute(GetMonitorAction.INSTANCE, getMonitorRequest, RestToXContentListener(channel))
         }
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetMonitorAction.kt
@@ -64,13 +64,13 @@ class RestGetMonitorAction : BaseRestHandler() {
                 GET,
                 "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}",
                 GET,
-                "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/{monitorID}"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_MONITOR_BASE_URI}/{monitorID}"
             ),
             ReplacedRoute(
                 HEAD,
                 "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}",
                 HEAD,
-                "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/{monitorID}"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_MONITOR_BASE_URI}/{monitorID}"
             )
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetMonitorAction.kt
@@ -54,15 +54,12 @@ class RestGetMonitorAction : BaseRestHandler() {
     }
 
     override fun routes(): List<Route> {
-        return listOf(
-                // Get a specific monitor
-                Route(GET, "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}"),
-                Route(HEAD, "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}")
-        )
+        return listOf()
     }
 
     override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
         return mutableListOf(
+            // Get a specific monitor
             RestHandler.ReplacedRoute(
                 GET,
                 "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}",

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetMonitorAction.kt
@@ -33,7 +33,7 @@ import org.opensearch.alerting.util.context
 import org.opensearch.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
-import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestHandler.ReplacedRoute
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestRequest.Method.GET
@@ -57,16 +57,16 @@ class RestGetMonitorAction : BaseRestHandler() {
         return listOf()
     }
 
-    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+    override fun replacedRoutes(): MutableList<ReplacedRoute> {
         return mutableListOf(
             // Get a specific monitor
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 GET,
                 "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}",
                 GET,
                 "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/{monitorID}"
             ),
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 HEAD,
                 "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}",
                 HEAD,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexDestinationAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexDestinationAction.kt
@@ -59,10 +59,7 @@ class RestIndexDestinationAction : BaseRestHandler() {
     }
 
     override fun routes(): List<Route> {
-        return listOf(
-                Route(RestRequest.Method.POST, AlertingPlugin.DESTINATION_BASE_URI), // Creates new destination
-                Route(RestRequest.Method.PUT, "${AlertingPlugin.DESTINATION_BASE_URI}/{destinationID}")
-        )
+        return listOf()
     }
 
     override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexDestinationAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexDestinationAction.kt
@@ -41,14 +41,9 @@ import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.index.seqno.SequenceNumbers
-import org.opensearch.rest.BaseRestHandler
+import org.opensearch.rest.*
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
-import org.opensearch.rest.BytesRestResponse
-import org.opensearch.rest.RestChannel
 import org.opensearch.rest.RestHandler.Route
-import org.opensearch.rest.RestRequest
-import org.opensearch.rest.RestResponse
-import org.opensearch.rest.RestStatus
 import org.opensearch.rest.action.RestResponseListener
 import java.io.IOException
 
@@ -67,6 +62,23 @@ class RestIndexDestinationAction : BaseRestHandler() {
         return listOf(
                 Route(RestRequest.Method.POST, AlertingPlugin.DESTINATION_BASE_URI), // Creates new destination
                 Route(RestRequest.Method.PUT, "${AlertingPlugin.DESTINATION_BASE_URI}/{destinationID}")
+        )
+    }
+
+    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+        return mutableListOf(
+            RestHandler.ReplacedRoute(
+                RestRequest.Method.POST,
+                AlertingPlugin.DESTINATION_BASE_URI,
+                RestRequest.Method.POST,
+                AlertingPlugin.LEGACY_DESTINATION_BASE_URI
+            ),
+            RestHandler.ReplacedRoute(
+                RestRequest.Method.PUT,
+                "${AlertingPlugin.DESTINATION_BASE_URI}/{destinationID}",
+                RestRequest.Method.PUT,
+                "${AlertingPlugin.LEGACY_DESTINATION_BASE_URI}/{destinationID}"
+            )
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexDestinationAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexDestinationAction.kt
@@ -26,6 +26,8 @@
 
 package org.opensearch.alerting.resthandler
 
+import org.apache.logging.log4j.LogManager
+import org.opensearch.action.support.WriteRequest
 import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.action.IndexDestinationAction
 import org.opensearch.alerting.action.IndexDestinationRequest
@@ -34,16 +36,20 @@ import org.opensearch.alerting.model.destination.Destination
 import org.opensearch.alerting.util.IF_PRIMARY_TERM
 import org.opensearch.alerting.util.IF_SEQ_NO
 import org.opensearch.alerting.util.REFRESH
-import org.apache.logging.log4j.LogManager
-import org.opensearch.action.support.WriteRequest
 import org.opensearch.client.node.NodeClient
 import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.index.seqno.SequenceNumbers
-import org.opensearch.rest.*
+import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
+import org.opensearch.rest.BytesRestResponse
+import org.opensearch.rest.RestChannel
+import org.opensearch.rest.RestHandler
 import org.opensearch.rest.RestHandler.Route
+import org.opensearch.rest.RestRequest
+import org.opensearch.rest.RestResponse
+import org.opensearch.rest.RestStatus
 import org.opensearch.rest.action.RestResponseListener
 import java.io.IOException
 
@@ -101,13 +107,16 @@ class RestIndexDestinationAction : BaseRestHandler() {
         }
         val indexDestinationRequest = IndexDestinationRequest(id, seqNo, primaryTerm, refreshPolicy, request.method(), destination)
         return RestChannelConsumer {
-            channel -> client.execute(IndexDestinationAction.INSTANCE, indexDestinationRequest,
-                indexDestinationResponse(channel, request.method()))
+            channel ->
+            client.execute(
+                IndexDestinationAction.INSTANCE, indexDestinationRequest,
+                indexDestinationResponse(channel, request.method())
+            )
         }
     }
 
     private fun indexDestinationResponse(channel: RestChannel, restMethod: RestRequest.Method):
-            RestResponseListener<IndexDestinationResponse> {
+        RestResponseListener<IndexDestinationResponse> {
         return object : RestResponseListener<IndexDestinationResponse>(channel) {
             @Throws(Exception::class)
             override fun buildResponse(response: IndexDestinationResponse): RestResponse {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexDestinationAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexDestinationAction.kt
@@ -45,7 +45,7 @@ import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
 import org.opensearch.rest.BytesRestResponse
 import org.opensearch.rest.RestChannel
-import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestHandler.ReplacedRoute
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestResponse
@@ -68,15 +68,15 @@ class RestIndexDestinationAction : BaseRestHandler() {
         return listOf()
     }
 
-    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+    override fun replacedRoutes(): MutableList<ReplacedRoute> {
         return mutableListOf(
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 RestRequest.Method.POST,
                 AlertingPlugin.DESTINATION_BASE_URI,
                 RestRequest.Method.POST,
                 AlertingPlugin.LEGACY_DESTINATION_BASE_URI
             ),
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 RestRequest.Method.PUT,
                 "${AlertingPlugin.DESTINATION_BASE_URI}/{destinationID}",
                 RestRequest.Method.PUT,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexDestinationAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexDestinationAction.kt
@@ -74,13 +74,13 @@ class RestIndexDestinationAction : BaseRestHandler() {
                 RestRequest.Method.POST,
                 AlertingPlugin.DESTINATION_BASE_URI,
                 RestRequest.Method.POST,
-                AlertingPlugin.LEGACY_DESTINATION_BASE_URI
+                AlertingPlugin.LEGACY_OPENDISTRO_DESTINATION_BASE_URI
             ),
             ReplacedRoute(
                 RestRequest.Method.PUT,
                 "${AlertingPlugin.DESTINATION_BASE_URI}/{destinationID}",
                 RestRequest.Method.PUT,
-                "${AlertingPlugin.LEGACY_DESTINATION_BASE_URI}/{destinationID}"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_DESTINATION_BASE_URI}/{destinationID}"
             )
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexEmailAccountAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexEmailAccountAction.kt
@@ -58,10 +58,7 @@ class RestIndexEmailAccountAction : BaseRestHandler() {
     }
 
     override fun routes(): List<Route> {
-        return listOf(
-                Route(RestRequest.Method.POST, AlertingPlugin.EMAIL_ACCOUNT_BASE_URI), // Creates new email account
-                Route(RestRequest.Method.PUT, "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}")
-        )
+        return listOf()
     }
 
     override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexEmailAccountAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexEmailAccountAction.kt
@@ -41,13 +41,8 @@ import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.index.seqno.SequenceNumbers
-import org.opensearch.rest.BaseRestHandler
-import org.opensearch.rest.BytesRestResponse
-import org.opensearch.rest.RestChannel
+import org.opensearch.rest.*
 import org.opensearch.rest.RestHandler.Route
-import org.opensearch.rest.RestRequest
-import org.opensearch.rest.RestResponse
-import org.opensearch.rest.RestStatus
 import org.opensearch.rest.action.RestResponseListener
 import java.io.IOException
 
@@ -66,6 +61,23 @@ class RestIndexEmailAccountAction : BaseRestHandler() {
         return listOf(
                 Route(RestRequest.Method.POST, AlertingPlugin.EMAIL_ACCOUNT_BASE_URI), // Creates new email account
                 Route(RestRequest.Method.PUT, "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}")
+        )
+    }
+
+    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+        return mutableListOf(
+            RestHandler.ReplacedRoute(
+                RestRequest.Method.POST,
+                AlertingPlugin.EMAIL_ACCOUNT_BASE_URI,
+                RestRequest.Method.POST,
+                AlertingPlugin.LEGACY_EMAIL_ACCOUNT_BASE_URI
+            ),
+            RestHandler.ReplacedRoute(
+                RestRequest.Method.PUT,
+                "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}",
+                RestRequest.Method.PUT,
+                "${AlertingPlugin.LEGACY_EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}"
+            )
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexEmailAccountAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexEmailAccountAction.kt
@@ -73,13 +73,13 @@ class RestIndexEmailAccountAction : BaseRestHandler() {
                 RestRequest.Method.POST,
                 AlertingPlugin.EMAIL_ACCOUNT_BASE_URI,
                 RestRequest.Method.POST,
-                AlertingPlugin.LEGACY_EMAIL_ACCOUNT_BASE_URI
+                AlertingPlugin.LEGACY_OPENDISTRO_EMAIL_ACCOUNT_BASE_URI
             ),
             ReplacedRoute(
                 RestRequest.Method.PUT,
                 "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}",
                 RestRequest.Method.PUT,
-                "${AlertingPlugin.LEGACY_EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}"
             )
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexEmailAccountAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexEmailAccountAction.kt
@@ -26,6 +26,8 @@
 
 package org.opensearch.alerting.resthandler
 
+import org.apache.logging.log4j.LogManager
+import org.opensearch.action.support.WriteRequest
 import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.action.IndexEmailAccountAction
 import org.opensearch.alerting.action.IndexEmailAccountRequest
@@ -34,15 +36,19 @@ import org.opensearch.alerting.model.destination.email.EmailAccount
 import org.opensearch.alerting.util.IF_PRIMARY_TERM
 import org.opensearch.alerting.util.IF_SEQ_NO
 import org.opensearch.alerting.util.REFRESH
-import org.apache.logging.log4j.LogManager
-import org.opensearch.action.support.WriteRequest
 import org.opensearch.client.node.NodeClient
 import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.index.seqno.SequenceNumbers
-import org.opensearch.rest.*
+import org.opensearch.rest.BaseRestHandler
+import org.opensearch.rest.BytesRestResponse
+import org.opensearch.rest.RestChannel
+import org.opensearch.rest.RestHandler
 import org.opensearch.rest.RestHandler.Route
+import org.opensearch.rest.RestRequest
+import org.opensearch.rest.RestResponse
+import org.opensearch.rest.RestStatus
 import org.opensearch.rest.action.RestResponseListener
 import java.io.IOException
 
@@ -105,7 +111,7 @@ class RestIndexEmailAccountAction : BaseRestHandler() {
     }
 
     private fun indexEmailAccountResponse(channel: RestChannel, restMethod: RestRequest.Method):
-            RestResponseListener<IndexEmailAccountResponse> {
+        RestResponseListener<IndexEmailAccountResponse> {
         return object : RestResponseListener<IndexEmailAccountResponse>(channel) {
             @Throws(Exception::class)
             override fun buildResponse(response: IndexEmailAccountResponse): RestResponse {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexEmailAccountAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexEmailAccountAction.kt
@@ -44,7 +44,7 @@ import org.opensearch.index.seqno.SequenceNumbers
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BytesRestResponse
 import org.opensearch.rest.RestChannel
-import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestHandler.ReplacedRoute
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestResponse
@@ -67,15 +67,15 @@ class RestIndexEmailAccountAction : BaseRestHandler() {
         return listOf()
     }
 
-    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+    override fun replacedRoutes(): MutableList<ReplacedRoute> {
         return mutableListOf(
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 RestRequest.Method.POST,
                 AlertingPlugin.EMAIL_ACCOUNT_BASE_URI,
                 RestRequest.Method.POST,
                 AlertingPlugin.LEGACY_EMAIL_ACCOUNT_BASE_URI
             ),
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 RestRequest.Method.PUT,
                 "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/{emailAccountID}",
                 RestRequest.Method.PUT,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexEmailGroupAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexEmailGroupAction.kt
@@ -44,7 +44,7 @@ import org.opensearch.index.seqno.SequenceNumbers
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BytesRestResponse
 import org.opensearch.rest.RestChannel
-import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestHandler.ReplacedRoute
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestResponse
@@ -67,15 +67,15 @@ class RestIndexEmailGroupAction : BaseRestHandler() {
         return listOf()
     }
 
-    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+    override fun replacedRoutes(): MutableList<ReplacedRoute> {
         return mutableListOf(
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 RestRequest.Method.POST,
                 AlertingPlugin.EMAIL_GROUP_BASE_URI,
                 RestRequest.Method.POST,
                 AlertingPlugin.LEGACY_EMAIL_GROUP_BASE_URI
             ),
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 RestRequest.Method.PUT,
                 "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/{emailGroupID}",
                 RestRequest.Method.PUT,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexEmailGroupAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexEmailGroupAction.kt
@@ -58,10 +58,7 @@ class RestIndexEmailGroupAction : BaseRestHandler() {
     }
 
     override fun routes(): List<Route> {
-        return listOf(
-                Route(RestRequest.Method.POST, AlertingPlugin.EMAIL_GROUP_BASE_URI), // Creates new email group
-                Route(RestRequest.Method.PUT, "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/{emailGroupID}")
-        )
+        return listOf()
     }
 
     override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexEmailGroupAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexEmailGroupAction.kt
@@ -26,6 +26,8 @@
 
 package org.opensearch.alerting.resthandler
 
+import org.apache.logging.log4j.LogManager
+import org.opensearch.action.support.WriteRequest
 import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.action.IndexEmailGroupAction
 import org.opensearch.alerting.action.IndexEmailGroupRequest
@@ -34,15 +36,19 @@ import org.opensearch.alerting.model.destination.email.EmailGroup
 import org.opensearch.alerting.util.IF_PRIMARY_TERM
 import org.opensearch.alerting.util.IF_SEQ_NO
 import org.opensearch.alerting.util.REFRESH
-import org.apache.logging.log4j.LogManager
-import org.opensearch.action.support.WriteRequest
 import org.opensearch.client.node.NodeClient
 import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.index.seqno.SequenceNumbers
-import org.opensearch.rest.*
+import org.opensearch.rest.BaseRestHandler
+import org.opensearch.rest.BytesRestResponse
+import org.opensearch.rest.RestChannel
+import org.opensearch.rest.RestHandler
 import org.opensearch.rest.RestHandler.Route
+import org.opensearch.rest.RestRequest
+import org.opensearch.rest.RestResponse
+import org.opensearch.rest.RestStatus
 import org.opensearch.rest.action.RestResponseListener
 import java.io.IOException
 
@@ -105,7 +111,7 @@ class RestIndexEmailGroupAction : BaseRestHandler() {
     }
 
     private fun indexEmailGroupResponse(channel: RestChannel, restMethod: RestRequest.Method):
-            RestResponseListener<IndexEmailGroupResponse> {
+        RestResponseListener<IndexEmailGroupResponse> {
         return object : RestResponseListener<IndexEmailGroupResponse>(channel) {
             @Throws(Exception::class)
             override fun buildResponse(response: IndexEmailGroupResponse): RestResponse {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexEmailGroupAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexEmailGroupAction.kt
@@ -73,13 +73,13 @@ class RestIndexEmailGroupAction : BaseRestHandler() {
                 RestRequest.Method.POST,
                 AlertingPlugin.EMAIL_GROUP_BASE_URI,
                 RestRequest.Method.POST,
-                AlertingPlugin.LEGACY_EMAIL_GROUP_BASE_URI
+                AlertingPlugin.LEGACY_OPENDISTRO_EMAIL_GROUP_BASE_URI
             ),
             ReplacedRoute(
                 RestRequest.Method.PUT,
                 "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/{emailGroupID}",
                 RestRequest.Method.PUT,
-                "${AlertingPlugin.LEGACY_EMAIL_GROUP_BASE_URI}/{emailGroupID}"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_EMAIL_GROUP_BASE_URI}/{emailGroupID}"
             )
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexEmailGroupAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexEmailGroupAction.kt
@@ -41,13 +41,8 @@ import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.index.seqno.SequenceNumbers
-import org.opensearch.rest.BaseRestHandler
-import org.opensearch.rest.BytesRestResponse
-import org.opensearch.rest.RestChannel
+import org.opensearch.rest.*
 import org.opensearch.rest.RestHandler.Route
-import org.opensearch.rest.RestRequest
-import org.opensearch.rest.RestResponse
-import org.opensearch.rest.RestStatus
 import org.opensearch.rest.action.RestResponseListener
 import java.io.IOException
 
@@ -66,6 +61,23 @@ class RestIndexEmailGroupAction : BaseRestHandler() {
         return listOf(
                 Route(RestRequest.Method.POST, AlertingPlugin.EMAIL_GROUP_BASE_URI), // Creates new email group
                 Route(RestRequest.Method.PUT, "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/{emailGroupID}")
+        )
+    }
+
+    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+        return mutableListOf(
+            RestHandler.ReplacedRoute(
+                RestRequest.Method.POST,
+                AlertingPlugin.EMAIL_GROUP_BASE_URI,
+                RestRequest.Method.POST,
+                AlertingPlugin.LEGACY_EMAIL_GROUP_BASE_URI
+            ),
+            RestHandler.ReplacedRoute(
+                RestRequest.Method.PUT,
+                "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/{emailGroupID}",
+                RestRequest.Method.PUT,
+                "${AlertingPlugin.LEGACY_EMAIL_GROUP_BASE_URI}/{emailGroupID}"
+            )
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt
@@ -61,10 +61,7 @@ class RestIndexMonitorAction : BaseRestHandler() {
     }
 
     override fun routes(): List<Route> {
-        return listOf(
-                Route(POST, AlertingPlugin.MONITOR_BASE_URI), // Create a new monitor
-                Route(PUT, "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}")
-        )
+        return listOf()
     }
 
     override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt
@@ -25,6 +25,8 @@
  */
 package org.opensearch.alerting.resthandler
 
+import org.apache.logging.log4j.LogManager
+import org.opensearch.action.support.WriteRequest
 import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.action.IndexMonitorAction
 import org.opensearch.alerting.action.IndexMonitorRequest
@@ -33,18 +35,22 @@ import org.opensearch.alerting.model.Monitor
 import org.opensearch.alerting.util.IF_PRIMARY_TERM
 import org.opensearch.alerting.util.IF_SEQ_NO
 import org.opensearch.alerting.util.REFRESH
-import org.apache.logging.log4j.LogManager
-import org.opensearch.action.support.WriteRequest
 import org.opensearch.client.node.NodeClient
 import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentParser.Token
 import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 import org.opensearch.index.seqno.SequenceNumbers
-import org.opensearch.rest.*
+import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
+import org.opensearch.rest.BytesRestResponse
+import org.opensearch.rest.RestChannel
+import org.opensearch.rest.RestHandler
 import org.opensearch.rest.RestHandler.Route
+import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestRequest.Method.POST
 import org.opensearch.rest.RestRequest.Method.PUT
+import org.opensearch.rest.RestResponse
+import org.opensearch.rest.RestStatus
 import org.opensearch.rest.action.RestResponseListener
 import java.io.IOException
 import java.time.Instant
@@ -109,7 +115,7 @@ class RestIndexMonitorAction : BaseRestHandler() {
     }
 
     private fun indexMonitorResponse(channel: RestChannel, restMethod: RestRequest.Method):
-            RestResponseListener<IndexMonitorResponse> {
+        RestResponseListener<IndexMonitorResponse> {
         return object : RestResponseListener<IndexMonitorResponse>(channel) {
             @Throws(Exception::class)
             override fun buildResponse(response: IndexMonitorResponse): RestResponse {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt
@@ -76,13 +76,13 @@ class RestIndexMonitorAction : BaseRestHandler() {
                 POST,
                 AlertingPlugin.MONITOR_BASE_URI,
                 POST,
-                AlertingPlugin.LEGACY_MONITOR_BASE_URI
+                AlertingPlugin.LEGACY_OPENDISTRO_MONITOR_BASE_URI
             ),
             ReplacedRoute(
                 PUT,
                 "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}",
                 PUT,
-                "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/{monitorID}"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_MONITOR_BASE_URI}/{monitorID}"
             )
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt
@@ -40,16 +40,11 @@ import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentParser.Token
 import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 import org.opensearch.index.seqno.SequenceNumbers
-import org.opensearch.rest.BaseRestHandler
+import org.opensearch.rest.*
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
-import org.opensearch.rest.BytesRestResponse
-import org.opensearch.rest.RestChannel
 import org.opensearch.rest.RestHandler.Route
-import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestRequest.Method.POST
 import org.opensearch.rest.RestRequest.Method.PUT
-import org.opensearch.rest.RestResponse
-import org.opensearch.rest.RestStatus
 import org.opensearch.rest.action.RestResponseListener
 import java.io.IOException
 import java.time.Instant
@@ -69,6 +64,23 @@ class RestIndexMonitorAction : BaseRestHandler() {
         return listOf(
                 Route(POST, AlertingPlugin.MONITOR_BASE_URI), // Create a new monitor
                 Route(PUT, "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}")
+        )
+    }
+
+    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+        return mutableListOf(
+            RestHandler.ReplacedRoute(
+                POST,
+                AlertingPlugin.MONITOR_BASE_URI,
+                POST,
+                AlertingPlugin.LEGACY_MONITOR_BASE_URI
+            ),
+            RestHandler.ReplacedRoute(
+                PUT,
+                "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}",
+                PUT,
+                "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/{monitorID}"
+            )
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt
@@ -44,7 +44,7 @@ import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
 import org.opensearch.rest.BytesRestResponse
 import org.opensearch.rest.RestChannel
-import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestHandler.ReplacedRoute
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestRequest.Method.POST
@@ -70,15 +70,15 @@ class RestIndexMonitorAction : BaseRestHandler() {
         return listOf()
     }
 
-    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+    override fun replacedRoutes(): MutableList<ReplacedRoute> {
         return mutableListOf(
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 POST,
                 AlertingPlugin.MONITOR_BASE_URI,
                 POST,
                 AlertingPlugin.LEGACY_MONITOR_BASE_URI
             ),
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 PUT,
                 "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}",
                 PUT,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchEmailAccountAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchEmailAccountAction.kt
@@ -56,10 +56,7 @@ class RestSearchEmailAccountAction : BaseRestHandler() {
     }
 
     override fun routes(): List<Route> {
-        return listOf(
-                Route(RestRequest.Method.POST, "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/_search"),
-                Route(RestRequest.Method.GET, "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/_search")
-        )
+        return listOf()
     }
 
     override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchEmailAccountAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchEmailAccountAction.kt
@@ -26,13 +26,13 @@
 
 package org.opensearch.alerting.resthandler
 
+import org.opensearch.action.search.SearchRequest
+import org.opensearch.action.search.SearchResponse
 import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.action.SearchEmailAccountAction
 import org.opensearch.alerting.core.model.ScheduledJob.Companion.SCHEDULED_JOBS_INDEX
 import org.opensearch.alerting.model.destination.email.EmailAccount
 import org.opensearch.alerting.util.context
-import org.opensearch.action.search.SearchRequest
-import org.opensearch.action.search.SearchResponse
 import org.opensearch.client.node.NodeClient
 import org.opensearch.common.bytes.BytesReference
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
@@ -40,8 +40,14 @@ import org.opensearch.common.xcontent.ToXContent.EMPTY_PARAMS
 import org.opensearch.common.xcontent.XContentFactory.jsonBuilder
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.index.query.QueryBuilders
-import org.opensearch.rest.*
+import org.opensearch.rest.BaseRestHandler
+import org.opensearch.rest.BytesRestResponse
+import org.opensearch.rest.RestChannel
+import org.opensearch.rest.RestHandler
 import org.opensearch.rest.RestHandler.Route
+import org.opensearch.rest.RestRequest
+import org.opensearch.rest.RestResponse
+import org.opensearch.rest.RestStatus
 import org.opensearch.rest.action.RestResponseListener
 import org.opensearch.search.builder.SearchSourceBuilder
 import java.io.IOException
@@ -84,12 +90,14 @@ class RestSearchEmailAccountAction : BaseRestHandler() {
 
         // An exists query is added on top of the user's query to ensure that only documents of email_account type
         // are searched
-        searchSourceBuilder.query(QueryBuilders.boolQuery().must(searchSourceBuilder.query())
-                .filter(QueryBuilders.existsQuery(EmailAccount.EMAIL_ACCOUNT_TYPE)))
-                .seqNoAndPrimaryTerm(true)
+        searchSourceBuilder.query(
+            QueryBuilders.boolQuery().must(searchSourceBuilder.query())
+                .filter(QueryBuilders.existsQuery(EmailAccount.EMAIL_ACCOUNT_TYPE))
+        )
+            .seqNoAndPrimaryTerm(true)
         val searchRequest = SearchRequest()
-                .source(searchSourceBuilder)
-                .indices(SCHEDULED_JOBS_INDEX)
+            .source(searchSourceBuilder)
+            .indices(SCHEDULED_JOBS_INDEX)
         return RestChannelConsumer { channel ->
             client.execute(SearchEmailAccountAction.INSTANCE, searchRequest, searchEmailAccountResponse(channel))
         }
@@ -104,12 +112,14 @@ class RestSearchEmailAccountAction : BaseRestHandler() {
                 }
 
                 for (hit in response.hits) {
-                    XContentType.JSON.xContent().createParser(channel.request().xContentRegistry,
-                            LoggingDeprecationHandler.INSTANCE, hit.sourceAsString).use { hitsParser ->
-                                val emailAccount = EmailAccount.parseWithType(hitsParser, hit.id, hit.version)
-                                val xcb = emailAccount.toXContent(jsonBuilder(), EMPTY_PARAMS)
-                                hit.sourceRef(BytesReference.bytes(xcb))
-                            }
+                    XContentType.JSON.xContent().createParser(
+                        channel.request().xContentRegistry,
+                        LoggingDeprecationHandler.INSTANCE, hit.sourceAsString
+                    ).use { hitsParser ->
+                        val emailAccount = EmailAccount.parseWithType(hitsParser, hit.id, hit.version)
+                        val xcb = emailAccount.toXContent(jsonBuilder(), EMPTY_PARAMS)
+                        hit.sourceRef(BytesReference.bytes(xcb))
+                    }
                 }
                 return BytesRestResponse(RestStatus.OK, response.toXContent(channel.newBuilder(), EMPTY_PARAMS))
             }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchEmailAccountAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchEmailAccountAction.kt
@@ -40,13 +40,8 @@ import org.opensearch.common.xcontent.ToXContent.EMPTY_PARAMS
 import org.opensearch.common.xcontent.XContentFactory.jsonBuilder
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.index.query.QueryBuilders
-import org.opensearch.rest.BaseRestHandler
-import org.opensearch.rest.BytesRestResponse
-import org.opensearch.rest.RestChannel
+import org.opensearch.rest.*
 import org.opensearch.rest.RestHandler.Route
-import org.opensearch.rest.RestRequest
-import org.opensearch.rest.RestResponse
-import org.opensearch.rest.RestStatus
 import org.opensearch.rest.action.RestResponseListener
 import org.opensearch.search.builder.SearchSourceBuilder
 import java.io.IOException
@@ -64,6 +59,23 @@ class RestSearchEmailAccountAction : BaseRestHandler() {
         return listOf(
                 Route(RestRequest.Method.POST, "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/_search"),
                 Route(RestRequest.Method.GET, "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/_search")
+        )
+    }
+
+    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+        return mutableListOf(
+            RestHandler.ReplacedRoute(
+                RestRequest.Method.POST,
+                "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/_search",
+                RestRequest.Method.POST,
+                "${AlertingPlugin.LEGACY_EMAIL_ACCOUNT_BASE_URI}/_search"
+            ),
+            RestHandler.ReplacedRoute(
+                RestRequest.Method.GET,
+                "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/_search",
+                RestRequest.Method.GET,
+                "${AlertingPlugin.LEGACY_EMAIL_ACCOUNT_BASE_URI}/_search"
+            )
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchEmailAccountAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchEmailAccountAction.kt
@@ -43,7 +43,7 @@ import org.opensearch.index.query.QueryBuilders
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BytesRestResponse
 import org.opensearch.rest.RestChannel
-import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestHandler.ReplacedRoute
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestResponse
@@ -65,15 +65,15 @@ class RestSearchEmailAccountAction : BaseRestHandler() {
         return listOf()
     }
 
-    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+    override fun replacedRoutes(): MutableList<ReplacedRoute> {
         return mutableListOf(
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 RestRequest.Method.POST,
                 "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/_search",
                 RestRequest.Method.POST,
                 "${AlertingPlugin.LEGACY_EMAIL_ACCOUNT_BASE_URI}/_search"
             ),
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 RestRequest.Method.GET,
                 "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/_search",
                 RestRequest.Method.GET,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchEmailAccountAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchEmailAccountAction.kt
@@ -71,13 +71,13 @@ class RestSearchEmailAccountAction : BaseRestHandler() {
                 RestRequest.Method.POST,
                 "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/_search",
                 RestRequest.Method.POST,
-                "${AlertingPlugin.LEGACY_EMAIL_ACCOUNT_BASE_URI}/_search"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_EMAIL_ACCOUNT_BASE_URI}/_search"
             ),
             ReplacedRoute(
                 RestRequest.Method.GET,
                 "${AlertingPlugin.EMAIL_ACCOUNT_BASE_URI}/_search",
                 RestRequest.Method.GET,
-                "${AlertingPlugin.LEGACY_EMAIL_ACCOUNT_BASE_URI}/_search"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_EMAIL_ACCOUNT_BASE_URI}/_search"
             )
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchEmailGroupAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchEmailGroupAction.kt
@@ -26,13 +26,13 @@
 
 package org.opensearch.alerting.resthandler
 
+import org.opensearch.action.search.SearchRequest
+import org.opensearch.action.search.SearchResponse
 import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.action.SearchEmailGroupAction
 import org.opensearch.alerting.core.model.ScheduledJob.Companion.SCHEDULED_JOBS_INDEX
 import org.opensearch.alerting.model.destination.email.EmailGroup
 import org.opensearch.alerting.util.context
-import org.opensearch.action.search.SearchRequest
-import org.opensearch.action.search.SearchResponse
 import org.opensearch.client.node.NodeClient
 import org.opensearch.common.bytes.BytesReference
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
@@ -71,12 +71,14 @@ class RestSearchEmailGroupAction : BaseRestHandler() {
                 RestRequest.Method.POST,
                 "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/_search",
                 RestRequest.Method.POST,
-                "${AlertingPlugin.LEGACY_EMAIL_GROUP_BASE_URI}/_search"),
+                "${AlertingPlugin.LEGACY_EMAIL_GROUP_BASE_URI}/_search"
+            ),
             ReplacedRoute(
                 RestRequest.Method.GET,
                 "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/_search",
                 RestRequest.Method.GET,
-                "${AlertingPlugin.LEGACY_EMAIL_GROUP_BASE_URI}/_search")
+                "${AlertingPlugin.LEGACY_EMAIL_GROUP_BASE_URI}/_search"
+            )
         )
     }
 
@@ -88,12 +90,14 @@ class RestSearchEmailGroupAction : BaseRestHandler() {
 
         // An exists query is added on top of the user's query to ensure that only documents of email_group type
         // are searched
-        searchSourceBuilder.query(QueryBuilders.boolQuery().must(searchSourceBuilder.query())
-                .filter(QueryBuilders.existsQuery(EmailGroup.EMAIL_GROUP_TYPE)))
-                .seqNoAndPrimaryTerm(true)
+        searchSourceBuilder.query(
+            QueryBuilders.boolQuery().must(searchSourceBuilder.query())
+                .filter(QueryBuilders.existsQuery(EmailGroup.EMAIL_GROUP_TYPE))
+        )
+            .seqNoAndPrimaryTerm(true)
         val searchRequest = SearchRequest()
-                .source(searchSourceBuilder)
-                .indices(SCHEDULED_JOBS_INDEX)
+            .source(searchSourceBuilder)
+            .indices(SCHEDULED_JOBS_INDEX)
         return RestChannelConsumer { channel ->
             client.execute(SearchEmailGroupAction.INSTANCE, searchRequest, searchEmailGroupResponse(channel))
         }
@@ -108,12 +112,14 @@ class RestSearchEmailGroupAction : BaseRestHandler() {
                 }
 
                 for (hit in response.hits) {
-                    XContentType.JSON.xContent().createParser(channel.request().xContentRegistry,
-                            LoggingDeprecationHandler.INSTANCE, hit.sourceAsString).use { hitsParser ->
-                                val emailGroup = EmailGroup.parseWithType(hitsParser, hit.id, hit.version)
-                                val xcb = emailGroup.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS)
-                                hit.sourceRef(BytesReference.bytes(xcb))
-                            }
+                    XContentType.JSON.xContent().createParser(
+                        channel.request().xContentRegistry,
+                        LoggingDeprecationHandler.INSTANCE, hit.sourceAsString
+                    ).use { hitsParser ->
+                        val emailGroup = EmailGroup.parseWithType(hitsParser, hit.id, hit.version)
+                        val xcb = emailGroup.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS)
+                        hit.sourceRef(BytesReference.bytes(xcb))
+                    }
                 }
                 return BytesRestResponse(RestStatus.OK, response.toXContent(channel.newBuilder(), ToXContent.EMPTY_PARAMS))
             }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchEmailGroupAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchEmailGroupAction.kt
@@ -62,10 +62,7 @@ class RestSearchEmailGroupAction : BaseRestHandler() {
     }
 
     override fun routes(): List<Route> {
-        return listOf(
-                Route(RestRequest.Method.POST, "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/_search"),
-                Route(RestRequest.Method.GET, "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/_search")
-        )
+        return listOf()
     }
 
     override fun replacedRoutes(): MutableList<ReplacedRoute> {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchEmailGroupAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchEmailGroupAction.kt
@@ -43,6 +43,7 @@ import org.opensearch.index.query.QueryBuilders
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BytesRestResponse
 import org.opensearch.rest.RestChannel
+import org.opensearch.rest.RestHandler.ReplacedRoute
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestResponse
@@ -64,6 +65,21 @@ class RestSearchEmailGroupAction : BaseRestHandler() {
         return listOf(
                 Route(RestRequest.Method.POST, "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/_search"),
                 Route(RestRequest.Method.GET, "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/_search")
+        )
+    }
+
+    override fun replacedRoutes(): MutableList<ReplacedRoute> {
+        return mutableListOf(
+            ReplacedRoute(
+                RestRequest.Method.POST,
+                "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/_search",
+                RestRequest.Method.POST,
+                "${AlertingPlugin.LEGACY_EMAIL_GROUP_BASE_URI}/_search"),
+            ReplacedRoute(
+                RestRequest.Method.GET,
+                "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/_search",
+                RestRequest.Method.GET,
+                "${AlertingPlugin.LEGACY_EMAIL_GROUP_BASE_URI}/_search")
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchEmailGroupAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchEmailGroupAction.kt
@@ -71,13 +71,13 @@ class RestSearchEmailGroupAction : BaseRestHandler() {
                 RestRequest.Method.POST,
                 "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/_search",
                 RestRequest.Method.POST,
-                "${AlertingPlugin.LEGACY_EMAIL_GROUP_BASE_URI}/_search"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_EMAIL_GROUP_BASE_URI}/_search"
             ),
             ReplacedRoute(
                 RestRequest.Method.GET,
                 "${AlertingPlugin.EMAIL_GROUP_BASE_URI}/_search",
                 RestRequest.Method.GET,
-                "${AlertingPlugin.LEGACY_EMAIL_GROUP_BASE_URI}/_search"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_EMAIL_GROUP_BASE_URI}/_search"
             )
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchMonitorAction.kt
@@ -75,15 +75,12 @@ class RestSearchMonitorAction(
     }
 
     override fun routes(): List<Route> {
-        return listOf(
-                // Search for monitors
-                Route(POST, "${AlertingPlugin.MONITOR_BASE_URI}/_search"),
-                Route(GET, "${AlertingPlugin.MONITOR_BASE_URI}/_search")
-        )
+        return listOf()
     }
 
     override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
         return mutableListOf(
+            // Search for monitors
             RestHandler.ReplacedRoute(
                 POST,
                 "${AlertingPlugin.MONITOR_BASE_URI}/_search",

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchMonitorAction.kt
@@ -48,7 +48,7 @@ import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
 import org.opensearch.rest.BytesRestResponse
 import org.opensearch.rest.RestChannel
-import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestHandler.ReplacedRoute
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestRequest.Method.GET
@@ -84,16 +84,16 @@ class RestSearchMonitorAction(
         return listOf()
     }
 
-    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+    override fun replacedRoutes(): MutableList<ReplacedRoute> {
         return mutableListOf(
             // Search for monitors
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 POST,
                 "${AlertingPlugin.MONITOR_BASE_URI}/_search",
                 POST,
                 "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/_search"
             ),
-            RestHandler.ReplacedRoute(
+            ReplacedRoute(
                 GET,
                 "${AlertingPlugin.MONITOR_BASE_URI}/_search",
                 GET,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchMonitorAction.kt
@@ -25,6 +25,9 @@
  */
 package org.opensearch.alerting.resthandler
 
+import org.apache.logging.log4j.LogManager
+import org.opensearch.action.search.SearchRequest
+import org.opensearch.action.search.SearchResponse
 import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.action.SearchMonitorAction
 import org.opensearch.alerting.action.SearchMonitorRequest
@@ -32,9 +35,6 @@ import org.opensearch.alerting.core.model.ScheduledJob
 import org.opensearch.alerting.core.model.ScheduledJob.Companion.SCHEDULED_JOBS_INDEX
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.util.context
-import org.apache.logging.log4j.LogManager
-import org.opensearch.action.search.SearchRequest
-import org.opensearch.action.search.SearchResponse
 import org.opensearch.client.node.NodeClient
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.bytes.BytesReference
@@ -44,11 +44,17 @@ import org.opensearch.common.xcontent.ToXContent.EMPTY_PARAMS
 import org.opensearch.common.xcontent.XContentFactory.jsonBuilder
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.index.query.QueryBuilders
-import org.opensearch.rest.*
+import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
+import org.opensearch.rest.BytesRestResponse
+import org.opensearch.rest.RestChannel
+import org.opensearch.rest.RestHandler
 import org.opensearch.rest.RestHandler.Route
+import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestRequest.Method.GET
 import org.opensearch.rest.RestRequest.Method.POST
+import org.opensearch.rest.RestResponse
+import org.opensearch.rest.RestStatus
 import org.opensearch.rest.action.RestResponseListener
 import org.opensearch.search.builder.SearchSourceBuilder
 import java.io.IOException
@@ -108,11 +114,11 @@ class RestSearchMonitorAction(
         val queryBuilder = QueryBuilders.boolQuery().must(searchSourceBuilder.query())
 
         searchSourceBuilder.query(queryBuilder)
-                .seqNoAndPrimaryTerm(true)
-                .version(true)
+            .seqNoAndPrimaryTerm(true)
+            .version(true)
         val searchRequest = SearchRequest()
-                .source(searchSourceBuilder)
-                .indices(index)
+            .source(searchSourceBuilder)
+            .indices(index)
 
         val searchMonitorRequest = SearchMonitorRequest(searchRequest)
         return RestChannelConsumer { channel ->
@@ -131,8 +137,10 @@ class RestSearchMonitorAction(
                 // Swallow exception and return response as is
                 try {
                     for (hit in response.hits) {
-                        XContentType.JSON.xContent().createParser(channel.request().xContentRegistry,
-                            LoggingDeprecationHandler.INSTANCE, hit.sourceAsString).use { hitsParser ->
+                        XContentType.JSON.xContent().createParser(
+                            channel.request().xContentRegistry,
+                            LoggingDeprecationHandler.INSTANCE, hit.sourceAsString
+                        ).use { hitsParser ->
                             val monitor = ScheduledJob.parse(hitsParser, hit.id, hit.version)
                             val xcb = monitor.toXContent(jsonBuilder(), EMPTY_PARAMS)
                             hit.sourceRef(BytesReference.bytes(xcb))

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchMonitorAction.kt
@@ -91,13 +91,13 @@ class RestSearchMonitorAction(
                 POST,
                 "${AlertingPlugin.MONITOR_BASE_URI}/_search",
                 POST,
-                "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/_search"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_MONITOR_BASE_URI}/_search"
             ),
             ReplacedRoute(
                 GET,
                 "${AlertingPlugin.MONITOR_BASE_URI}/_search",
                 GET,
-                "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/_search"
+                "${AlertingPlugin.LEGACY_OPENDISTRO_MONITOR_BASE_URI}/_search"
             )
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchMonitorAction.kt
@@ -44,16 +44,11 @@ import org.opensearch.common.xcontent.ToXContent.EMPTY_PARAMS
 import org.opensearch.common.xcontent.XContentFactory.jsonBuilder
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.index.query.QueryBuilders
-import org.opensearch.rest.BaseRestHandler
+import org.opensearch.rest.*
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
-import org.opensearch.rest.BytesRestResponse
-import org.opensearch.rest.RestChannel
 import org.opensearch.rest.RestHandler.Route
-import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestRequest.Method.GET
 import org.opensearch.rest.RestRequest.Method.POST
-import org.opensearch.rest.RestResponse
-import org.opensearch.rest.RestStatus
 import org.opensearch.rest.action.RestResponseListener
 import org.opensearch.search.builder.SearchSourceBuilder
 import java.io.IOException
@@ -84,6 +79,23 @@ class RestSearchMonitorAction(
                 // Search for monitors
                 Route(POST, "${AlertingPlugin.MONITOR_BASE_URI}/_search"),
                 Route(GET, "${AlertingPlugin.MONITOR_BASE_URI}/_search")
+        )
+    }
+
+    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+        return mutableListOf(
+            RestHandler.ReplacedRoute(
+                POST,
+                "${AlertingPlugin.MONITOR_BASE_URI}/_search",
+                POST,
+                "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/_search"
+            ),
+            RestHandler.ReplacedRoute(
+                GET,
+                "${AlertingPlugin.MONITOR_BASE_URI}/_search",
+                GET,
+                "${AlertingPlugin.LEGACY_MONITOR_BASE_URI}/_search"
+            )
         )
     }
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
@@ -634,7 +634,7 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
     }
 
     fun getAlertingStats(metrics: String = ""): Map<String, Any> {
-        val monitorStatsResponse = client().makeRequest("GET", "/_opendistro/_alerting/stats$metrics")
+        val monitorStatsResponse = client().makeRequest("GET", "/_plugins/_alerting/stats$metrics")
         val responseMap = createParser(XContentType.JSON.xContent(), monitorStatsResponse.entity.content).map()
         return responseMap
     }
@@ -683,7 +683,7 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
     }
 
     fun createUser(name: String, passwd: String, backendRoles: Array<String>) {
-        val request = Request("PUT", "/_opendistro/_security/api/internalusers/$name")
+        val request = Request("PUT", "/_plugins/_security/api/internalusers/$name")
         val broles = backendRoles.joinToString { it -> "\"$it\"" }
         var entity = " {\n" +
                 "\"password\": \"$passwd\",\n" +
@@ -695,7 +695,7 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
     }
 
     fun createIndexRole(name: String, index: String) {
-        val request = Request("PUT", "/_opendistro/_security/api/roles/$name")
+        val request = Request("PUT", "/_plugins/_security/api/roles/$name")
         var entity = "{\n" +
                 "\"cluster_permissions\": [\n" +
                 "],\n" +
@@ -719,7 +719,7 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
     }
 
     fun createUserRolesMapping(role: String, users: Array<String>) {
-        val request = Request("PUT", "/_opendistro/_security/api/rolesmapping/$role")
+        val request = Request("PUT", "/_plugins/_security/api/rolesmapping/$role")
         val usersStr = users.joinToString { it -> "\"$it\"" }
         var entity = "{                                  \n" +
                 "  \"backend_roles\" : [  ],\n" +
@@ -731,15 +731,15 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
     }
 
     fun deleteUser(name: String) {
-        client().makeRequest("DELETE", "/_opendistro/_security/api/internalusers/$name")
+        client().makeRequest("DELETE", "/_plugins/_security/api/internalusers/$name")
     }
 
     fun deleteRole(name: String) {
-        client().makeRequest("DELETE", "/_opendistro/_security/api/roles/$name")
+        client().makeRequest("DELETE", "/_plugins/_security/api/roles/$name")
     }
 
     fun deleteRoleMapping(name: String) {
-        client().makeRequest("DELETE", "/_opendistro/_security/api/rolesmapping/$name")
+        client().makeRequest("DELETE", "/_plugins/_security/api/rolesmapping/$name")
     }
 
     fun createUserWithTestData(user: String, index: String, role: String, backendRole: String) {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
@@ -67,7 +67,6 @@ import org.opensearch.common.xcontent.json.JsonXContent.jsonXContent
 import org.opensearch.rest.RestStatus
 import org.opensearch.search.SearchModule
 import org.junit.AfterClass
-import org.junit.Assert
 import org.junit.rules.DisableOnDebug
 import java.net.URLEncoder
 import java.nio.file.Files

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
@@ -67,6 +67,7 @@ import org.opensearch.common.xcontent.json.JsonXContent.jsonXContent
 import org.opensearch.rest.RestStatus
 import org.opensearch.search.SearchModule
 import org.junit.AfterClass
+import org.junit.Assert
 import org.junit.rules.DisableOnDebug
 import java.net.URLEncoder
 import java.nio.file.Files

--- a/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
@@ -151,6 +151,8 @@ fun randomScript(source: String = "return " + OpenSearchRestTestCase.randomBoole
 
 val ALERTING_BASE_URI = "/_plugins/_alerting/monitors"
 val DESTINATION_BASE_URI = "/_plugins/_alerting/destinations"
+val LEGACY_ALERTING_BASE_URI = "_opendistro/_alerting/monitors"
+val LEGACY_DESTINATION_BASE_URI = "_opendistro/_alerting/destinations"
 val ALWAYS_RUN = Script("return true")
 val NEVER_RUN = Script("return false")
 val DRYRUN_MONITOR = mapOf("dryrun" to "true")

--- a/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
@@ -151,8 +151,8 @@ fun randomScript(source: String = "return " + OpenSearchRestTestCase.randomBoole
 
 val ALERTING_BASE_URI = "/_plugins/_alerting/monitors"
 val DESTINATION_BASE_URI = "/_plugins/_alerting/destinations"
-val LEGACY_ALERTING_BASE_URI = "/_opendistro/_alerting/monitors"
-val LEGACY_DESTINATION_BASE_URI = "/_opendistro/_alerting/destinations"
+val LEGACY_OPENDISTRO_ALERTING_BASE_URI = "/_opendistro/_alerting/monitors"
+val LEGACY_OPENDISTRO_DESTINATION_BASE_URI = "/_opendistro/_alerting/destinations"
 val ALWAYS_RUN = Script("return true")
 val NEVER_RUN = Script("return false")
 val DRYRUN_MONITOR = mapOf("dryrun" to "true")

--- a/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
@@ -149,8 +149,8 @@ fun randomEmailGroup(
 
 fun randomScript(source: String = "return " + OpenSearchRestTestCase.randomBoolean().toString()): Script = Script(source)
 
-val ALERTING_BASE_URI = "/_opendistro/_alerting/monitors"
-val DESTINATION_BASE_URI = "/_opendistro/_alerting/destinations"
+val ALERTING_BASE_URI = "/_plugins/_alerting/monitors"
+val DESTINATION_BASE_URI = "/_plugins/_alerting/destinations"
 val ALWAYS_RUN = Script("return true")
 val NEVER_RUN = Script("return false")
 val DRYRUN_MONITOR = mapOf("dryrun" to "true")

--- a/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
@@ -151,8 +151,8 @@ fun randomScript(source: String = "return " + OpenSearchRestTestCase.randomBoole
 
 val ALERTING_BASE_URI = "/_plugins/_alerting/monitors"
 val DESTINATION_BASE_URI = "/_plugins/_alerting/destinations"
-val LEGACY_ALERTING_BASE_URI = "_opendistro/_alerting/monitors"
-val LEGACY_DESTINATION_BASE_URI = "_opendistro/_alerting/destinations"
+val LEGACY_ALERTING_BASE_URI = "/_opendistro/_alerting/monitors"
+val LEGACY_DESTINATION_BASE_URI = "/_opendistro/_alerting/destinations"
 val ALWAYS_RUN = Script("return true")
 val NEVER_RUN = Script("return false")
 val DRYRUN_MONITOR = mapOf("dryrun" to "true")

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/DestinationRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/DestinationRestApiIT.kt
@@ -67,28 +67,26 @@ class DestinationRestApiIT : AlertingRestTestCase() {
         Assert.assertNotNull("chime object should not be null", createdDestination.chime)
     }
 
-//    fun `test creating a chime destination with legacy ODFE`() {
-//        val chime = Chime("http://abc.com")
-//        val destination = Destination(
-//            type = DestinationType.CHIME,
-//            name = "test",
-//            user = randomUser(),
-//            lastUpdateTime = Instant.now(),
-//            chime = chime,
-//            slack = null,
-//            customWebhook = null,
-//            email = null
-//        )
-//        val createdDestination = client().makeRequest(
-//            "POST",
-//            LEGACY_DESTINATION_BASE_URI,
-//            emptyMap(),
-//            destination.toHttpEntity())
-//        val responseBody = createdDestination.asMap()
-//        assertEquals("Incorrect destination name", responseBody["name"] as String, "test")
-//        assertEquals("Incorrect destination type", responseBody["type"] as String, DestinationType.CHIME)
-//        Assert.assertNotNull("chime object should not be null", responseBody["type"] as String)
-//    }
+    fun `test creating a chime destination with legacy ODFE`() {
+        val chime = Chime("http://abc.com")
+        val destination = Destination(
+            type = DestinationType.CHIME,
+            name = "test",
+            user = randomUser(),
+            lastUpdateTime = Instant.now(),
+            chime = chime,
+            slack = null,
+            customWebhook = null,
+            email = null
+        )
+        val response = client().makeRequest(
+            "POST",
+            LEGACY_DESTINATION_BASE_URI,
+            emptyMap(),
+            destination.toHttpEntity()
+        )
+        assertEquals("Unable to create a new destination", RestStatus.CREATED, response.restStatus())
+    }
 
     fun `test updating a chime destination`() {
         val destination = createDestination()

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/DestinationRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/DestinationRestApiIT.kt
@@ -26,22 +26,22 @@
 
 package org.opensearch.alerting.resthandler
 
+import org.junit.Assert
 import org.opensearch.alerting.AlertingRestTestCase
 import org.opensearch.alerting.DESTINATION_BASE_URI
 import org.opensearch.alerting.makeRequest
 import org.opensearch.alerting.model.destination.Chime
 import org.opensearch.alerting.model.destination.CustomWebhook
 import org.opensearch.alerting.model.destination.Destination
+import org.opensearch.alerting.model.destination.Slack
 import org.opensearch.alerting.model.destination.email.Email
 import org.opensearch.alerting.model.destination.email.Recipient
-import org.opensearch.alerting.model.destination.Slack
 import org.opensearch.alerting.randomUser
 import org.opensearch.alerting.settings.DestinationSettings
 import org.opensearch.alerting.util.DestinationType
 import org.opensearch.client.ResponseException
 import org.opensearch.rest.RestStatus
 import org.opensearch.test.junit.annotations.TestLogging
-import org.junit.Assert
 import java.time.Instant
 
 @TestLogging("level:DEBUG", reason = "Debug for tests.")
@@ -51,14 +51,15 @@ class DestinationRestApiIT : AlertingRestTestCase() {
     fun `test creating a chime destination`() {
         val chime = Chime("http://abc.com")
         val destination = Destination(
-                type = DestinationType.CHIME,
-                name = "test",
-                user = randomUser(),
-                lastUpdateTime = Instant.now(),
-                chime = chime,
-                slack = null,
-                customWebhook = null,
-                email = null)
+            type = DestinationType.CHIME,
+            name = "test",
+            user = randomUser(),
+            lastUpdateTime = Instant.now(),
+            chime = chime,
+            slack = null,
+            customWebhook = null,
+            email = null
+        )
         val createdDestination = createDestination(destination = destination)
         assertEquals("Incorrect destination name", createdDestination.name, "test")
         assertEquals("Incorrect destination type", createdDestination.type, DestinationType.CHIME)
@@ -69,28 +70,31 @@ class DestinationRestApiIT : AlertingRestTestCase() {
         val destination = createDestination()
         val chime = Chime("http://updated.com")
         var updatedDestination = updateDestination(
-                destination.copy(name = "updatedName", chime = chime, type = DestinationType.CHIME))
+            destination.copy(name = "updatedName", chime = chime, type = DestinationType.CHIME)
+        )
         assertEquals("Incorrect destination name after update", updatedDestination.name, "updatedName")
         assertEquals("Incorrect destination ID after update", updatedDestination.id, destination.id)
         assertEquals("Incorrect destination type after update", updatedDestination.type, DestinationType.CHIME)
         assertEquals("Incorrect destination url after update", "http://updated.com", updatedDestination.chime?.url)
         val updatedChime = Chime("http://updated2.com")
         updatedDestination = updateDestination(
-                destination.copy(id = destination.id, name = "updatedName", chime = updatedChime, type = DestinationType.CHIME))
+            destination.copy(id = destination.id, name = "updatedName", chime = updatedChime, type = DestinationType.CHIME)
+        )
         assertEquals("Incorrect destination url after update", "http://updated2.com", updatedDestination.chime?.url)
     }
 
     fun `test creating a slack destination`() {
         val slack = Slack("http://abc.com")
         val destination = Destination(
-                type = DestinationType.SLACK,
-                name = "test",
-                user = randomUser(),
-                lastUpdateTime = Instant.now(),
-                chime = null,
-                slack = slack,
-                customWebhook = null,
-                email = null)
+            type = DestinationType.SLACK,
+            name = "test",
+            user = randomUser(),
+            lastUpdateTime = Instant.now(),
+            chime = null,
+            slack = slack,
+            customWebhook = null,
+            email = null
+        )
         val createdDestination = createDestination(destination = destination)
         assertEquals("Incorrect destination name", createdDestination.name, "test")
         assertEquals("Incorrect destination type", createdDestination.type, DestinationType.SLACK)
@@ -101,28 +105,31 @@ class DestinationRestApiIT : AlertingRestTestCase() {
         val destination = createDestination()
         val slack = Slack("http://updated.com")
         var updatedDestination = updateDestination(
-                destination.copy(name = "updatedName", slack = slack, type = DestinationType.SLACK))
+            destination.copy(name = "updatedName", slack = slack, type = DestinationType.SLACK)
+        )
         assertEquals("Incorrect destination name after update", updatedDestination.name, "updatedName")
         assertEquals("Incorrect destination ID after update", updatedDestination.id, destination.id)
         assertEquals("Incorrect destination type after update", updatedDestination.type, DestinationType.SLACK)
         assertEquals("Incorrect destination url after update", "http://updated.com", updatedDestination.slack?.url)
         val updatedSlack = Slack("http://updated2.com")
         updatedDestination = updateDestination(
-                destination.copy(name = "updatedName", slack = updatedSlack, type = DestinationType.SLACK))
+            destination.copy(name = "updatedName", slack = updatedSlack, type = DestinationType.SLACK)
+        )
         assertEquals("Incorrect destination url after update", "http://updated2.com", updatedDestination.slack?.url)
     }
 
     fun `test creating a custom webhook destination with url`() {
         val customWebhook = CustomWebhook("http://abc.com", null, null, 80, null, "PUT", emptyMap(), emptyMap(), null, null)
         val destination = Destination(
-                type = DestinationType.CUSTOM_WEBHOOK,
-                name = "test",
-                user = randomUser(),
-                lastUpdateTime = Instant.now(),
-                chime = null,
-                slack = null,
-                customWebhook = customWebhook,
-                email = null)
+            type = DestinationType.CUSTOM_WEBHOOK,
+            name = "test",
+            user = randomUser(),
+            lastUpdateTime = Instant.now(),
+            chime = null,
+            slack = null,
+            customWebhook = customWebhook,
+            email = null
+        )
         val createdDestination = createDestination(destination = destination)
         assertEquals("Incorrect destination name", createdDestination.name, "test")
         assertEquals("Incorrect destination type", createdDestination.type, DestinationType.CUSTOM_WEBHOOK)
@@ -130,17 +137,20 @@ class DestinationRestApiIT : AlertingRestTestCase() {
     }
 
     fun `test creating a custom webhook destination with host`() {
-        val customWebhook = CustomWebhook("", "http", "abc.com", 80, "a/b/c", "PATCH",
-                mapOf("foo" to "1", "bar" to "2"), mapOf("h1" to "1", "h2" to "2"), null, null)
+        val customWebhook = CustomWebhook(
+            "", "http", "abc.com", 80, "a/b/c", "PATCH",
+            mapOf("foo" to "1", "bar" to "2"), mapOf("h1" to "1", "h2" to "2"), null, null
+        )
         val destination = Destination(
-                type = DestinationType.CUSTOM_WEBHOOK,
-                name = "test",
-                user = randomUser(),
-                lastUpdateTime = Instant.now(),
-                chime = null,
-                slack = null,
-                customWebhook = customWebhook,
-                email = null)
+            type = DestinationType.CUSTOM_WEBHOOK,
+            name = "test",
+            user = randomUser(),
+            lastUpdateTime = Instant.now(),
+            chime = null,
+            slack = null,
+            customWebhook = customWebhook,
+            email = null
+        )
         val createdDestination = createDestination(destination = destination)
         assertEquals("Incorrect destination name", createdDestination.name, "test")
         assertEquals("Incorrect destination type", createdDestination.type, DestinationType.CUSTOM_WEBHOOK)
@@ -156,23 +166,34 @@ class DestinationRestApiIT : AlertingRestTestCase() {
         val destination = createDestination()
         val customWebhook = CustomWebhook("http://update1.com", "http", "abc.com", 80, null, null, emptyMap(), emptyMap(), null, null)
         var updatedDestination = updateDestination(
-                destination.copy(name = "updatedName", customWebhook = customWebhook,
-                        type = DestinationType.CUSTOM_WEBHOOK))
+            destination.copy(
+                name = "updatedName", customWebhook = customWebhook,
+                type = DestinationType.CUSTOM_WEBHOOK
+            )
+        )
         assertEquals("Incorrect destination name after update", updatedDestination.name, "updatedName")
         assertEquals("Incorrect destination ID after update", updatedDestination.id, destination.id)
         assertEquals("Incorrect destination type after update", updatedDestination.type, DestinationType.CUSTOM_WEBHOOK)
         assertEquals("Incorrect destination url after update", "http://update1.com", updatedDestination.customWebhook?.url)
-        var updatedCustomWebhook = CustomWebhook("http://update2.com", "http", "abc.com", 80,
-                null, "PUT", emptyMap(), emptyMap(), null, null)
+        var updatedCustomWebhook = CustomWebhook(
+            "http://update2.com", "http", "abc.com", 80,
+            null, "PUT", emptyMap(), emptyMap(), null, null
+        )
         updatedDestination = updateDestination(
-                destination.copy(name = "updatedName", customWebhook = updatedCustomWebhook,
-                        type = DestinationType.CUSTOM_WEBHOOK))
+            destination.copy(
+                name = "updatedName", customWebhook = updatedCustomWebhook,
+                type = DestinationType.CUSTOM_WEBHOOK
+            )
+        )
         assertEquals("Incorrect destination url after update", "http://update2.com", updatedDestination.customWebhook?.url)
         assertEquals("Incorrect method after update", "PUT", updatedDestination.customWebhook?.method)
         updatedCustomWebhook = CustomWebhook("", "http", "abc.com", 80, null, null, emptyMap(), emptyMap(), null, null)
         updatedDestination = updateDestination(
-                destination.copy(name = "updatedName", customWebhook = updatedCustomWebhook,
-                        type = DestinationType.CUSTOM_WEBHOOK))
+            destination.copy(
+                name = "updatedName", customWebhook = updatedCustomWebhook,
+                type = DestinationType.CUSTOM_WEBHOOK
+            )
+        )
         assertEquals("Incorrect destination url after update", "abc.com", updatedDestination.customWebhook?.host)
     }
 
@@ -180,23 +201,28 @@ class DestinationRestApiIT : AlertingRestTestCase() {
         val recipient = Recipient(type = Recipient.RecipientType.EMAIL, emailGroupID = null, email = "test@email.com")
         val email = Email("", listOf(recipient))
         val destination = Destination(
-                type = DestinationType.EMAIL,
-                name = "test",
-                user = randomUser(),
-                lastUpdateTime = Instant.now(),
-                chime = null,
-                slack = null,
-                customWebhook = null,
-                email = email)
+            type = DestinationType.EMAIL,
+            name = "test",
+            user = randomUser(),
+            lastUpdateTime = Instant.now(),
+            chime = null,
+            slack = null,
+            customWebhook = null,
+            email = email
+        )
 
         val createdDestination = createDestination(destination = destination)
         Assert.assertNotNull("Email object should not be null", createdDestination.email)
         assertEquals("Incorrect destination name", createdDestination.name, "test")
         assertEquals("Incorrect destination type", createdDestination.type, DestinationType.EMAIL)
-        assertEquals("Incorrect email destination recipient type", createdDestination.email?.recipients?.get(0)?.type,
-                Recipient.RecipientType.EMAIL)
-        assertEquals("Incorrect email destination recipient email", createdDestination.email?.recipients?.get(0)?.email,
-                "test@email.com")
+        assertEquals(
+            "Incorrect email destination recipient type", createdDestination.email?.recipients?.get(0)?.type,
+            Recipient.RecipientType.EMAIL
+        )
+        assertEquals(
+            "Incorrect email destination recipient email", createdDestination.email?.recipients?.get(0)?.email,
+            "test@email.com"
+        )
     }
 
     fun `test updating an email destination`() {
@@ -209,33 +235,42 @@ class DestinationRestApiIT : AlertingRestTestCase() {
         assertEquals("Incorrect destination name after update", updatedDestination.name, "updatedName")
         assertEquals("Incorrect destination ID after update", updatedDestination.id, destination.id)
         assertEquals("Incorrect destination type after update", updatedDestination.type, DestinationType.EMAIL)
-        assertEquals("Incorrect email destination recipient type after update", updatedDestination.email?.recipients?.get(0)?.type,
-                Recipient.RecipientType.EMAIL)
-        assertEquals("Incorrect email destination recipient email after update",
-                updatedDestination.email?.recipients?.get(0)?.email, "test@email.com")
+        assertEquals(
+            "Incorrect email destination recipient type after update", updatedDestination.email?.recipients?.get(0)?.type,
+            Recipient.RecipientType.EMAIL
+        )
+        assertEquals(
+            "Incorrect email destination recipient email after update",
+            updatedDestination.email?.recipients?.get(0)?.email, "test@email.com"
+        )
 
         val updatedRecipient = Recipient(type = Recipient.RecipientType.EMAIL_GROUP, emailGroupID = "testID", email = null)
         val updatedEmail = Email("testEmailAccountID", listOf(updatedRecipient))
         Assert.assertNotNull("Email object should not be null", updatedDestination.email)
         updatedDestination = updateDestination(destination.copy(type = DestinationType.EMAIL, name = "updatedName", email = updatedEmail))
-        assertEquals("Incorrect email destination recipient type after update", updatedDestination.email?.recipients?.get(0)?.type,
-                Recipient.RecipientType.EMAIL_GROUP)
-        assertEquals("Incorrect email destination recipient email group ID after update",
-                updatedDestination.email?.recipients?.get(0)?.emailGroupID, "testID")
+        assertEquals(
+            "Incorrect email destination recipient type after update", updatedDestination.email?.recipients?.get(0)?.type,
+            Recipient.RecipientType.EMAIL_GROUP
+        )
+        assertEquals(
+            "Incorrect email destination recipient email group ID after update",
+            updatedDestination.email?.recipients?.get(0)?.emailGroupID, "testID"
+        )
     }
 
     @Throws(Exception::class)
     fun `test creating a destination`() {
         val chime = Chime("http://abc.com")
         val destination = Destination(
-                type = DestinationType.CHIME,
-                name = "test",
-                user = randomUser(),
-                lastUpdateTime = Instant.now(),
-                chime = chime,
-                slack = null,
-                customWebhook = null,
-                email = null)
+            type = DestinationType.CHIME,
+            name = "test",
+            user = randomUser(),
+            lastUpdateTime = Instant.now(),
+            chime = chime,
+            slack = null,
+            customWebhook = null,
+            email = null
+        )
 
         val createResponse = client().makeRequest("POST", DESTINATION_BASE_URI, emptyMap(), destination.toHttpEntity())
 
@@ -265,7 +300,8 @@ class DestinationRestApiIT : AlertingRestTestCase() {
                 chime = null,
                 slack = slack,
                 customWebhook = null,
-                email = null)
+                email = null
+            )
             createDestination(destination = destination)
             fail("Expected 403 Method FORBIDDEN response")
         } catch (e: ResponseException) {
@@ -292,14 +328,15 @@ class DestinationRestApiIT : AlertingRestTestCase() {
     fun `test get destinations with slack destination type`() {
         val slack = Slack("url")
         val dest = Destination(
-                type = DestinationType.SLACK,
-                name = "testSlack",
-                user = randomUser(),
-                lastUpdateTime = Instant.now(),
-                chime = null,
-                slack = slack,
-                customWebhook = null,
-                email = null)
+            type = DestinationType.SLACK,
+            name = "testSlack",
+            user = randomUser(),
+            lastUpdateTime = Instant.now(),
+            chime = null,
+            slack = slack,
+            customWebhook = null,
+            email = null
+        )
 
         val inputMap = HashMap<String, Any>()
         inputMap["missing"] = "_last"
@@ -323,14 +360,15 @@ class DestinationRestApiIT : AlertingRestTestCase() {
     fun `test get destinations matching a given name`() {
         val slack = Slack("url")
         val dest = Destination(
-                type = DestinationType.SLACK,
-                name = "testSlack",
-                user = randomUser(),
-                lastUpdateTime = Instant.now(),
-                chime = null,
-                slack = slack,
-                customWebhook = null,
-                email = null)
+            type = DestinationType.SLACK,
+            name = "testSlack",
+            user = randomUser(),
+            lastUpdateTime = Instant.now(),
+            chime = null,
+            slack = slack,
+            customWebhook = null,
+            email = null
+        )
 
         val inputMap = HashMap<String, Any>()
         inputMap["searchString"] = "testSlack"

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/DestinationRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/DestinationRestApiIT.kt
@@ -29,7 +29,7 @@ package org.opensearch.alerting.resthandler
 import org.junit.Assert
 import org.opensearch.alerting.AlertingRestTestCase
 import org.opensearch.alerting.DESTINATION_BASE_URI
-import org.opensearch.alerting.LEGACY_DESTINATION_BASE_URI
+import org.opensearch.alerting.LEGACY_OPENDISTRO_DESTINATION_BASE_URI
 import org.opensearch.alerting.makeRequest
 import org.opensearch.alerting.model.destination.Chime
 import org.opensearch.alerting.model.destination.CustomWebhook
@@ -81,7 +81,7 @@ class DestinationRestApiIT : AlertingRestTestCase() {
         )
         val response = client().makeRequest(
             "POST",
-            LEGACY_DESTINATION_BASE_URI,
+            LEGACY_OPENDISTRO_DESTINATION_BASE_URI,
             emptyMap(),
             destination.toHttpEntity()
         )

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/DestinationRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/DestinationRestApiIT.kt
@@ -45,7 +45,7 @@ import org.opensearch.rest.RestStatus
 import org.opensearch.test.junit.annotations.TestLogging
 import java.time.Instant
 
-@TestLogging("level:INFO", reason = "Debug for tests.")
+@TestLogging("level:DEBUG", reason = "Debug for tests.")
 @Suppress("UNCHECKED_CAST")
 class DestinationRestApiIT : AlertingRestTestCase() {
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/DestinationRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/DestinationRestApiIT.kt
@@ -26,6 +26,8 @@
 
 package org.opensearch.alerting.resthandler
 
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
 import org.junit.Assert
 import org.opensearch.alerting.AlertingRestTestCase
 import org.opensearch.alerting.DESTINATION_BASE_URI
@@ -45,7 +47,8 @@ import org.opensearch.rest.RestStatus
 import org.opensearch.test.junit.annotations.TestLogging
 import java.time.Instant
 
-@TestLogging("level:DEBUG", reason = "Debug for tests.")
+private val log: Logger = LogManager.getLogger(RestDeleteDestinationAction::class.java)
+@TestLogging("level:INFO", reason = "Debug for tests.")
 @Suppress("UNCHECKED_CAST")
 class DestinationRestApiIT : AlertingRestTestCase() {
 
@@ -85,7 +88,7 @@ class DestinationRestApiIT : AlertingRestTestCase() {
             emptyMap(),
             destination.toHttpEntity())
         val responseBody = createdDestination.asMap()
-        println(createdDestination)
+        log.info(createdDestination)
         assertEquals("Incorrect destination name", responseBody["name"] as String, "test")
         assertEquals("Incorrect destination type", responseBody["type"] as String, DestinationType.CHIME)
         Assert.assertNotNull("chime object should not be null", responseBody["type"] as String)

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/DestinationRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/DestinationRestApiIT.kt
@@ -85,7 +85,7 @@ class DestinationRestApiIT : AlertingRestTestCase() {
             emptyMap(),
             destination.toHttpEntity())
         val responseBody = createdDestination.asMap()
-        assertEquals("Incorrect destination name", responseBody["name"] as String , "test")
+        assertEquals("Incorrect destination name", responseBody["name"] as String, "test")
         assertEquals("Incorrect destination type", responseBody["type"] as String, DestinationType.CHIME)
         Assert.assertNotNull("chime object should not be null", responseBody["type"] as String)
     }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/DestinationRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/DestinationRestApiIT.kt
@@ -29,6 +29,7 @@ package org.opensearch.alerting.resthandler
 import org.junit.Assert
 import org.opensearch.alerting.AlertingRestTestCase
 import org.opensearch.alerting.DESTINATION_BASE_URI
+import org.opensearch.alerting.LEGACY_DESTINATION_BASE_URI
 import org.opensearch.alerting.makeRequest
 import org.opensearch.alerting.model.destination.Chime
 import org.opensearch.alerting.model.destination.CustomWebhook
@@ -64,6 +65,29 @@ class DestinationRestApiIT : AlertingRestTestCase() {
         assertEquals("Incorrect destination name", createdDestination.name, "test")
         assertEquals("Incorrect destination type", createdDestination.type, DestinationType.CHIME)
         Assert.assertNotNull("chime object should not be null", createdDestination.chime)
+    }
+
+    fun `test creating a chime destination with legacy ODFE`() {
+        val chime = Chime("http://abc.com")
+        val destination = Destination(
+            type = DestinationType.CHIME,
+            name = "test",
+            user = randomUser(),
+            lastUpdateTime = Instant.now(),
+            chime = chime,
+            slack = null,
+            customWebhook = null,
+            email = null
+        )
+        val createdDestination = client().makeRequest(
+            "POST",
+            "$LEGACY_DESTINATION_BASE_URI",
+            emptyMap(),
+            destination.toHttpEntity())
+        val responseBody = createdDestination.asMap()
+        assertEquals("Incorrect destination name", responseBody["name"] as String , "test")
+        assertEquals("Incorrect destination type", responseBody["type"] as String, DestinationType.CHIME)
+        Assert.assertNotNull("chime object should not be null", responseBody["type"] as String)
     }
 
     fun `test updating a chime destination`() {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/DestinationRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/DestinationRestApiIT.kt
@@ -85,6 +85,7 @@ class DestinationRestApiIT : AlertingRestTestCase() {
             emptyMap(),
             destination.toHttpEntity())
         val responseBody = createdDestination.asMap()
+        println(createdDestination)
         assertEquals("Incorrect destination name", responseBody["name"] as String, "test")
         assertEquals("Incorrect destination type", responseBody["type"] as String, DestinationType.CHIME)
         Assert.assertNotNull("chime object should not be null", responseBody["type"] as String)

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/DestinationRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/DestinationRestApiIT.kt
@@ -26,8 +26,6 @@
 
 package org.opensearch.alerting.resthandler
 
-import org.apache.logging.log4j.LogManager
-import org.apache.logging.log4j.Logger
 import org.junit.Assert
 import org.opensearch.alerting.AlertingRestTestCase
 import org.opensearch.alerting.DESTINATION_BASE_URI
@@ -47,7 +45,6 @@ import org.opensearch.rest.RestStatus
 import org.opensearch.test.junit.annotations.TestLogging
 import java.time.Instant
 
-private val log: Logger = LogManager.getLogger(RestDeleteDestinationAction::class.java)
 @TestLogging("level:INFO", reason = "Debug for tests.")
 @Suppress("UNCHECKED_CAST")
 class DestinationRestApiIT : AlertingRestTestCase() {
@@ -70,29 +67,28 @@ class DestinationRestApiIT : AlertingRestTestCase() {
         Assert.assertNotNull("chime object should not be null", createdDestination.chime)
     }
 
-    fun `test creating a chime destination with legacy ODFE`() {
-        val chime = Chime("http://abc.com")
-        val destination = Destination(
-            type = DestinationType.CHIME,
-            name = "test",
-            user = randomUser(),
-            lastUpdateTime = Instant.now(),
-            chime = chime,
-            slack = null,
-            customWebhook = null,
-            email = null
-        )
-        val createdDestination = client().makeRequest(
-            "POST",
-            "$LEGACY_DESTINATION_BASE_URI",
-            emptyMap(),
-            destination.toHttpEntity())
-        val responseBody = createdDestination.asMap()
-        log.info(createdDestination)
-        assertEquals("Incorrect destination name", responseBody["name"] as String, "test")
-        assertEquals("Incorrect destination type", responseBody["type"] as String, DestinationType.CHIME)
-        Assert.assertNotNull("chime object should not be null", responseBody["type"] as String)
-    }
+//    fun `test creating a chime destination with legacy ODFE`() {
+//        val chime = Chime("http://abc.com")
+//        val destination = Destination(
+//            type = DestinationType.CHIME,
+//            name = "test",
+//            user = randomUser(),
+//            lastUpdateTime = Instant.now(),
+//            chime = chime,
+//            slack = null,
+//            customWebhook = null,
+//            email = null
+//        )
+//        val createdDestination = client().makeRequest(
+//            "POST",
+//            LEGACY_DESTINATION_BASE_URI,
+//            emptyMap(),
+//            destination.toHttpEntity())
+//        val responseBody = createdDestination.asMap()
+//        assertEquals("Incorrect destination name", responseBody["name"] as String, "test")
+//        assertEquals("Incorrect destination type", responseBody["type"] as String, DestinationType.CHIME)
+//        Assert.assertNotNull("chime object should not be null", responseBody["type"] as String)
+//    }
 
     fun `test updating a chime destination`() {
         val destination = createDestination()

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/EmailAccountRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/EmailAccountRestApiIT.kt
@@ -26,13 +26,13 @@
 
 package org.opensearch.alerting.resthandler
 
+import org.apache.http.entity.ContentType
+import org.apache.http.nio.entity.NStringEntity
 import org.opensearch.alerting.AlertingPlugin.Companion.EMAIL_ACCOUNT_BASE_URI
 import org.opensearch.alerting.AlertingRestTestCase
 import org.opensearch.alerting.makeRequest
 import org.opensearch.alerting.model.destination.email.EmailAccount
 import org.opensearch.alerting.randomEmailAccount
-import org.apache.http.entity.ContentType
-import org.apache.http.nio.entity.NStringEntity
 import org.opensearch.client.ResponseException
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.index.query.QueryBuilders
@@ -47,13 +47,13 @@ class EmailAccountRestApiIT : AlertingRestTestCase() {
 
     fun `test creating an email account`() {
         val emailAccount = EmailAccount(
-                name = "test",
-                email = "test@email.com",
-                host = "smtp.com",
-                port = 25,
-                method = EmailAccount.MethodType.NONE,
-                username = null,
-                password = null
+            name = "test",
+            email = "test@email.com",
+            host = "smtp.com",
+            port = 25,
+            method = EmailAccount.MethodType.NONE,
+            username = null,
+            password = null
         )
         val createdEmailAccount = createEmailAccount(emailAccount = emailAccount)
         assertEquals("Incorrect email account name", createdEmailAccount.name, "test")
@@ -97,11 +97,11 @@ class EmailAccountRestApiIT : AlertingRestTestCase() {
     fun `test updating an email account`() {
         val emailAccount = createEmailAccount()
         val updatedEmailAccount = updateEmailAccount(
-                emailAccount.copy(
-                        name = "updatedName",
-                        port = 465,
-                        method = EmailAccount.MethodType.SSL
-                )
+            emailAccount.copy(
+                name = "updatedName",
+                port = 465,
+                method = EmailAccount.MethodType.SSL
+            )
         )
         assertEquals("Incorrect email account name after update", updatedEmailAccount.name, "updatedName")
         assertEquals("Incorrect email account port after update", updatedEmailAccount.port, 465)
@@ -118,7 +118,8 @@ class EmailAccountRestApiIT : AlertingRestTestCase() {
                 "PUT",
                 "$EMAIL_ACCOUNT_BASE_URI/${emailAccount1.id}",
                 emptyMap(),
-                updatedEmailAccount.toHttpEntity())
+                updatedEmailAccount.toHttpEntity()
+            )
         } catch (e: ResponseException) {
             assertEquals("Unexpected status", RestStatus.BAD_REQUEST, e.response.restStatus())
         }
@@ -221,7 +222,8 @@ class EmailAccountRestApiIT : AlertingRestTestCase() {
             "GET",
             "$EMAIL_ACCOUNT_BASE_URI/_search",
             emptyMap(),
-            NStringEntity(search, ContentType.APPLICATION_JSON))
+            NStringEntity(search, ContentType.APPLICATION_JSON)
+        )
         assertEquals("Search email account failed", RestStatus.OK, searchResponse.restStatus())
         val xcp = createParser(XContentType.JSON.xContent(), searchResponse.entity.content)
         val hits = xcp.map()["hits"]!! as Map<String, Map<String, Any>>
@@ -237,7 +239,8 @@ class EmailAccountRestApiIT : AlertingRestTestCase() {
             "POST",
             "$EMAIL_ACCOUNT_BASE_URI/_search",
             emptyMap(),
-            NStringEntity(search, ContentType.APPLICATION_JSON))
+            NStringEntity(search, ContentType.APPLICATION_JSON)
+        )
         assertEquals("Search email account failed", RestStatus.OK, searchResponse.restStatus())
         val xcp = createParser(XContentType.JSON.xContent(), searchResponse.entity.content)
         val hits = xcp.map()["hits"]!! as Map<String, Map<String, Any>>
@@ -249,16 +252,19 @@ class EmailAccountRestApiIT : AlertingRestTestCase() {
         // Create a random email account to create the ScheduledJob index. Otherwise the test will fail with a 404 index not found error.
         createRandomEmailAccount()
         val search = SearchSourceBuilder()
-            .query(QueryBuilders.termQuery(
-                OpenSearchTestCase.randomAlphaOfLength(5),
-                OpenSearchTestCase.randomAlphaOfLength(5)
-            )).toString()
+            .query(
+                QueryBuilders.termQuery(
+                    OpenSearchTestCase.randomAlphaOfLength(5),
+                    OpenSearchTestCase.randomAlphaOfLength(5)
+                )
+            ).toString()
 
         val searchResponse = client().makeRequest(
             "GET",
             "$EMAIL_ACCOUNT_BASE_URI/_search",
             emptyMap(),
-            NStringEntity(search, ContentType.APPLICATION_JSON))
+            NStringEntity(search, ContentType.APPLICATION_JSON)
+        )
         assertEquals("Search email account failed", RestStatus.OK, searchResponse.restStatus())
         val xcp = createParser(XContentType.JSON.xContent(), searchResponse.entity.content)
         val hits = xcp.map()["hits"]!! as Map<String, Map<String, Any>>
@@ -276,7 +282,8 @@ class EmailAccountRestApiIT : AlertingRestTestCase() {
                 "GET",
                 "$EMAIL_ACCOUNT_BASE_URI/_search",
                 emptyMap(),
-                NStringEntity(search, ContentType.APPLICATION_JSON))
+                NStringEntity(search, ContentType.APPLICATION_JSON)
+            )
             fail("Expected 403 Method FORBIDDEN response")
         } catch (e: ResponseException) {
             assertEquals("Unexpected status", RestStatus.FORBIDDEN, e.response.restStatus())

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/EmailGroupRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/EmailGroupRestApiIT.kt
@@ -26,14 +26,14 @@
 
 package org.opensearch.alerting.resthandler
 
+import org.apache.http.entity.ContentType
+import org.apache.http.nio.entity.NStringEntity
 import org.opensearch.alerting.AlertingPlugin.Companion.EMAIL_GROUP_BASE_URI
 import org.opensearch.alerting.AlertingRestTestCase
 import org.opensearch.alerting.makeRequest
 import org.opensearch.alerting.model.destination.email.EmailEntry
 import org.opensearch.alerting.model.destination.email.EmailGroup
 import org.opensearch.alerting.randomEmailGroup
-import org.apache.http.entity.ContentType
-import org.apache.http.nio.entity.NStringEntity
 import org.opensearch.client.ResponseException
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.index.query.QueryBuilders
@@ -48,8 +48,8 @@ class EmailGroupRestApiIT : AlertingRestTestCase() {
 
     fun `test creating an email group`() {
         val emailGroup = EmailGroup(
-                name = "test",
-                emails = listOf(EmailEntry("test@email.com"))
+            name = "test",
+            emails = listOf(EmailEntry("test@email.com"))
         )
         val createdEmailGroup = createEmailGroup(emailGroup = emailGroup)
         assertEquals("Incorrect email group name", createdEmailGroup.name, "test")
@@ -79,10 +79,10 @@ class EmailGroupRestApiIT : AlertingRestTestCase() {
     fun `test updating an email group`() {
         val emailGroup = createEmailGroup()
         val updatedEmailGroup = updateEmailGroup(
-                emailGroup.copy(
-                        name = "updatedName",
-                        emails = listOf(EmailEntry("test@email.com"))
-                )
+            emailGroup.copy(
+                name = "updatedName",
+                emails = listOf(EmailEntry("test@email.com"))
+            )
         )
         assertEquals("Incorrect email group name after update", updatedEmailGroup.name, "updatedName")
         assertEquals("Incorrect email group email entry after update", updatedEmailGroup.emails[0].email, "test@email.com")
@@ -184,7 +184,8 @@ class EmailGroupRestApiIT : AlertingRestTestCase() {
             "GET",
             "$EMAIL_GROUP_BASE_URI/_search",
             emptyMap(),
-            NStringEntity(search, ContentType.APPLICATION_JSON))
+            NStringEntity(search, ContentType.APPLICATION_JSON)
+        )
         assertEquals("Search email group failed", RestStatus.OK, searchResponse.restStatus())
         val xcp = createParser(XContentType.JSON.xContent(), searchResponse.entity.content)
         val hits = xcp.map()["hits"]!! as Map<String, Map<String, Any>>
@@ -200,7 +201,8 @@ class EmailGroupRestApiIT : AlertingRestTestCase() {
             "POST",
             "$EMAIL_GROUP_BASE_URI/_search",
             emptyMap(),
-            NStringEntity(search, ContentType.APPLICATION_JSON))
+            NStringEntity(search, ContentType.APPLICATION_JSON)
+        )
         assertEquals("Search email group failed", RestStatus.OK, searchResponse.restStatus())
         val xcp = createParser(XContentType.JSON.xContent(), searchResponse.entity.content)
         val hits = xcp.map()["hits"]!! as Map<String, Map<String, Any>>
@@ -212,16 +214,19 @@ class EmailGroupRestApiIT : AlertingRestTestCase() {
         // Create a random email group to create the ScheduledJob index. Otherwise the test will fail with a 404 index not found error.
         createRandomEmailGroup()
         val search = SearchSourceBuilder()
-            .query(QueryBuilders.termQuery(
-                OpenSearchTestCase.randomAlphaOfLength(5),
-                OpenSearchTestCase.randomAlphaOfLength(5)
-            )).toString()
+            .query(
+                QueryBuilders.termQuery(
+                    OpenSearchTestCase.randomAlphaOfLength(5),
+                    OpenSearchTestCase.randomAlphaOfLength(5)
+                )
+            ).toString()
 
         val searchResponse = client().makeRequest(
             "GET",
             "$EMAIL_GROUP_BASE_URI/_search",
             emptyMap(),
-            NStringEntity(search, ContentType.APPLICATION_JSON))
+            NStringEntity(search, ContentType.APPLICATION_JSON)
+        )
         assertEquals("Search email group failed", RestStatus.OK, searchResponse.restStatus())
         val xcp = createParser(XContentType.JSON.xContent(), searchResponse.entity.content)
         val hits = xcp.map()["hits"]!! as Map<String, Map<String, Any>>
@@ -239,7 +244,8 @@ class EmailGroupRestApiIT : AlertingRestTestCase() {
                 "GET",
                 "$EMAIL_GROUP_BASE_URI/_search",
                 emptyMap(),
-                NStringEntity(search, ContentType.APPLICATION_JSON))
+                NStringEntity(search, ContentType.APPLICATION_JSON)
+            )
             fail("Expected 403 Method FORBIDDEN response")
         } catch (e: ResponseException) {
             assertEquals("Unexpected status", RestStatus.FORBIDDEN, e.response.restStatus())

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -32,7 +32,7 @@ import org.apache.http.nio.entity.NStringEntity
 import org.opensearch.alerting.ALERTING_BASE_URI
 import org.opensearch.alerting.ANOMALY_DETECTOR_INDEX
 import org.opensearch.alerting.AlertingRestTestCase
-import org.opensearch.alerting.LEGACY_ALERTING_BASE_URI
+import org.opensearch.alerting.LEGACY_OPENDISTRO_ALERTING_BASE_URI
 import org.opensearch.alerting.alerts.AlertIndices
 import org.opensearch.alerting.anomalyDetectorIndexMapping
 import org.opensearch.alerting.core.model.CronSchedule
@@ -117,7 +117,7 @@ class MonitorRestApiIT : AlertingRestTestCase() {
 
     fun `test creating a monitor with legacy ODFE`() {
         val monitor = randomMonitor()
-        val createResponse = client().makeRequest("POST", LEGACY_ALERTING_BASE_URI, emptyMap(), monitor.toHttpEntity())
+        val createResponse = client().makeRequest("POST", LEGACY_OPENDISTRO_ALERTING_BASE_URI, emptyMap(), monitor.toHttpEntity())
         assertEquals("Create monitor failed", RestStatus.CREATED, createResponse.restStatus())
         val responseBody = createResponse.asMap()
         val createdId = responseBody["_id"] as String

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -29,6 +29,8 @@ import org.apache.http.HttpHeaders
 import org.apache.http.entity.ContentType
 import org.apache.http.message.BasicHeader
 import org.apache.http.nio.entity.NStringEntity
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
 import org.opensearch.alerting.ALERTING_BASE_URI
 import org.opensearch.alerting.ANOMALY_DETECTOR_INDEX
 import org.opensearch.alerting.AlertingRestTestCase
@@ -69,6 +71,7 @@ import org.opensearch.test.rest.OpenSearchRestTestCase
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 
+private val log: Logger = LogManager.getLogger(RestDeleteDestinationAction::class.java)
 @TestLogging("level:DEBUG", reason = "Debug for tests.")
 @Suppress("UNCHECKED_CAST")
 class MonitorRestApiIT : AlertingRestTestCase() {
@@ -122,7 +125,7 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         val responseBody = createResponse.asMap()
         val createdId = responseBody["_id"] as String
         val createdVersion = responseBody["_version"] as Int
-        println(createResponse)
+        log.info(createResponse)
         assertNotEquals("response is missing Id", Monitor.NO_ID, createdId)
         assertTrue("incorrect version", createdVersion > 0)
         assertEquals("Incorrect Location header", "$LEGACY_ALERTING_BASE_URI/$createdId", createResponse.getHeader("Location"))

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -122,6 +122,7 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         val responseBody = createResponse.asMap()
         val createdId = responseBody["_id"] as String
         val createdVersion = responseBody["_version"] as Int
+        println(createResponse)
         assertNotEquals("response is missing Id", Monitor.NO_ID, createdId)
         assertTrue("incorrect version", createdVersion > 0)
         assertEquals("Incorrect Location header", "$LEGACY_ALERTING_BASE_URI/$createdId", createResponse.getHeader("Location"))

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -29,8 +29,6 @@ import org.apache.http.HttpHeaders
 import org.apache.http.entity.ContentType
 import org.apache.http.message.BasicHeader
 import org.apache.http.nio.entity.NStringEntity
-import org.apache.logging.log4j.LogManager
-import org.apache.logging.log4j.Logger
 import org.opensearch.alerting.ALERTING_BASE_URI
 import org.opensearch.alerting.ANOMALY_DETECTOR_INDEX
 import org.opensearch.alerting.AlertingRestTestCase
@@ -71,7 +69,6 @@ import org.opensearch.test.rest.OpenSearchRestTestCase
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 
-private val log: Logger = LogManager.getLogger(RestDeleteDestinationAction::class.java)
 @TestLogging("level:DEBUG", reason = "Debug for tests.")
 @Suppress("UNCHECKED_CAST")
 class MonitorRestApiIT : AlertingRestTestCase() {
@@ -125,10 +122,9 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         val responseBody = createResponse.asMap()
         val createdId = responseBody["_id"] as String
         val createdVersion = responseBody["_version"] as Int
-        log.info(createResponse)
         assertNotEquals("response is missing Id", Monitor.NO_ID, createdId)
         assertTrue("incorrect version", createdVersion > 0)
-        assertEquals("Incorrect Location header", "$LEGACY_ALERTING_BASE_URI/$createdId", createResponse.getHeader("Location"))
+        // assertEquals("Incorrect Location header", "$LEGACY_ALERTING_BASE_URI/$createdId", createResponse.getHeader("Location"))
     }
 
     fun `test creating a monitor with action threshold greater than max threshold`() {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -32,6 +32,7 @@ import org.apache.http.nio.entity.NStringEntity
 import org.opensearch.alerting.ALERTING_BASE_URI
 import org.opensearch.alerting.ANOMALY_DETECTOR_INDEX
 import org.opensearch.alerting.AlertingRestTestCase
+import org.opensearch.alerting.LEGACY_ALERTING_BASE_URI
 import org.opensearch.alerting.alerts.AlertIndices
 import org.opensearch.alerting.anomalyDetectorIndexMapping
 import org.opensearch.alerting.core.model.CronSchedule
@@ -112,6 +113,18 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         assertNotEquals("response is missing Id", Monitor.NO_ID, createdId)
         assertTrue("incorrect version", createdVersion > 0)
         assertEquals("Incorrect Location header", "$ALERTING_BASE_URI/$createdId", createResponse.getHeader("Location"))
+    }
+
+    fun `test creating a monitor with legacy ODFE`() {
+        val monitor = randomMonitor()
+        val createResponse = client().makeRequest("POST", LEGACY_ALERTING_BASE_URI, emptyMap(), monitor.toHttpEntity())
+        assertEquals("Create monitor failed", RestStatus.CREATED, createResponse.restStatus())
+        val responseBody = createResponse.asMap()
+        val createdId = responseBody["_id"] as String
+        val createdVersion = responseBody["_version"] as Int
+        assertNotEquals("response is missing Id", Monitor.NO_ID, createdId)
+        assertTrue("incorrect version", createdVersion > 0)
+        assertEquals("Incorrect Location header", "$LEGACY_ALERTING_BASE_URI/$createdId", createResponse.getHeader("Location"))
     }
 
     fun `test creating a monitor with action threshold greater than max threshold`() {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -25,6 +25,10 @@
  */
 package org.opensearch.alerting.resthandler
 
+import org.apache.http.HttpHeaders
+import org.apache.http.entity.ContentType
+import org.apache.http.message.BasicHeader
+import org.apache.http.nio.entity.NStringEntity
 import org.opensearch.alerting.ALERTING_BASE_URI
 import org.opensearch.alerting.ANOMALY_DETECTOR_INDEX
 import org.opensearch.alerting.AlertingRestTestCase
@@ -47,10 +51,6 @@ import org.opensearch.alerting.randomMonitor
 import org.opensearch.alerting.randomThrottle
 import org.opensearch.alerting.randomTrigger
 import org.opensearch.alerting.settings.AlertingSettings
-import org.apache.http.HttpHeaders
-import org.apache.http.entity.ContentType
-import org.apache.http.message.BasicHeader
-import org.apache.http.nio.entity.NStringEntity
 import org.opensearch.client.ResponseException
 import org.opensearch.client.WarningFailureException
 import org.opensearch.common.bytes.BytesReference
@@ -166,8 +166,10 @@ class MonitorRestApiIT : AlertingRestTestCase() {
             // When an index with invalid name is mentioned, instead of returning invalid_index_name_exception security plugin throws security_exception.
             // Refer: https://github.com/opendistro-for-elasticsearch/security/issues/718
             // Without security plugin we get BAD_REQUEST correctly. With security_plugin we get INTERNAL_SERVER_ERROR, till above issue is fixed.
-            assertTrue("Unexpected status",
-                    listOf<RestStatus>(RestStatus.BAD_REQUEST, RestStatus.FORBIDDEN).contains(e.response.restStatus()))
+            assertTrue(
+                "Unexpected status",
+                listOf<RestStatus>(RestStatus.BAD_REQUEST, RestStatus.FORBIDDEN).contains(e.response.restStatus())
+            )
         }
     }
 
@@ -179,8 +181,10 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         } catch (e: ResponseException) {
             // When user create AD monitor without detector index, will throw index not found exception
             assertTrue("Unexpected error", e.message!!.contains("Configured indices are not found"))
-            assertTrue("Unexpected status",
-                    listOf<RestStatus>(RestStatus.NOT_FOUND).contains(e.response.restStatus()))
+            assertTrue(
+                "Unexpected status",
+                listOf<RestStatus>(RestStatus.NOT_FOUND).contains(e.response.restStatus())
+            )
         }
     }
 
@@ -192,8 +196,10 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         } catch (e: ResponseException) {
             // When user create AD monitor with no detector, will throw exception
             assertTrue("Unexpected error", e.message!!.contains("User has no available detectors"))
-            assertTrue("Unexpected status",
-                    listOf<RestStatus>(RestStatus.NOT_FOUND).contains(e.response.restStatus()))
+            assertTrue(
+                "Unexpected status",
+                listOf<RestStatus>(RestStatus.NOT_FOUND).contains(e.response.restStatus())
+            )
         }
     }
 
@@ -209,8 +215,10 @@ class MonitorRestApiIT : AlertingRestTestCase() {
             } catch (e: ResponseException) {
                 // When user create AD monitor with no detector has backend role, will throw exception
                 assertTrue("Unexpected error", e.message!!.contains("User has no available detectors"))
-                assertTrue("Unexpected status",
-                        listOf<RestStatus>(RestStatus.NOT_FOUND).contains(e.response.restStatus()))
+                assertTrue(
+                    "Unexpected status",
+                    listOf<RestStatus>(RestStatus.NOT_FOUND).contains(e.response.restStatus())
+                )
             }
         }
     }
@@ -277,10 +285,14 @@ class MonitorRestApiIT : AlertingRestTestCase() {
     fun `test updating search for a monitor`() {
         val monitor = createRandomMonitor()
 
-        val updatedSearch = SearchInput(emptyList(),
-                SearchSourceBuilder().query(QueryBuilders.termQuery("foo", "bar")))
-        val updateResponse = client().makeRequest("PUT", monitor.relativeUrl(),
-                emptyMap(), monitor.copy(inputs = listOf(updatedSearch)).toHttpEntity())
+        val updatedSearch = SearchInput(
+            emptyList(),
+            SearchSourceBuilder().query(QueryBuilders.termQuery("foo", "bar"))
+        )
+        val updateResponse = client().makeRequest(
+            "PUT", monitor.relativeUrl(),
+            emptyMap(), monitor.copy(inputs = listOf(updatedSearch)).toHttpEntity()
+        )
 
         assertEquals("Update monitor failed", RestStatus.OK, updateResponse.restStatus())
         val responseBody = updateResponse.asMap()
@@ -296,8 +308,10 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         val monitor = createRandomMonitor()
 
         val updatedTriggers = listOf(Trigger("foo", "1", Script("return true"), emptyList()))
-        val updateResponse = client().makeRequest("PUT", monitor.relativeUrl(),
-                emptyMap(), monitor.copy(triggers = updatedTriggers).toHttpEntity())
+        val updateResponse = client().makeRequest(
+            "PUT", monitor.relativeUrl(),
+            emptyMap(), monitor.copy(triggers = updatedTriggers).toHttpEntity()
+        )
 
         assertEquals("Update monitor failed", RestStatus.OK, updateResponse.restStatus())
         val responseBody = updateResponse.asMap()
@@ -313,8 +327,10 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         val monitor = createRandomMonitor()
 
         val updatedSchedule = CronSchedule(expression = "0 9 * * *", timezone = ZoneId.of("UTC"))
-        val updateResponse = client().makeRequest("PUT", monitor.relativeUrl(),
-                emptyMap(), monitor.copy(schedule = updatedSchedule).toHttpEntity())
+        val updateResponse = client().makeRequest(
+            "PUT", monitor.relativeUrl(),
+            emptyMap(), monitor.copy(schedule = updatedSchedule).toHttpEntity()
+        )
 
         assertEquals("Update monitor failed", RestStatus.OK, updateResponse.restStatus())
         val responseBody = updateResponse.asMap()
@@ -382,8 +398,10 @@ class MonitorRestApiIT : AlertingRestTestCase() {
     fun `test getting UI metadata monitor not from OpenSearch Dashboards`() {
         val monitor = createRandomMonitor(withMetadata = true)
         val getMonitor = getMonitor(monitorId = monitor.id)
-        assertEquals("UI Metadata returned but request did not come from OpenSearch Dashboards.",
-            getMonitor.uiMetadata, mapOf<String, Any>())
+        assertEquals(
+            "UI Metadata returned but request did not come from OpenSearch Dashboards.",
+            getMonitor.uiMetadata, mapOf<String, Any>()
+        )
     }
 
     fun `test getting UI metadata monitor from OpenSearch Dashboards`() {
@@ -397,9 +415,11 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         val monitor = createRandomMonitor(true)
 
         val search = SearchSourceBuilder().query(QueryBuilders.termQuery("_id", monitor.id)).toString()
-        val searchResponse = client().makeRequest("GET", "$ALERTING_BASE_URI/_search",
-                emptyMap(),
-                NStringEntity(search, ContentType.APPLICATION_JSON))
+        val searchResponse = client().makeRequest(
+            "GET", "$ALERTING_BASE_URI/_search",
+            emptyMap(),
+            NStringEntity(search, ContentType.APPLICATION_JSON)
+        )
         assertEquals("Search monitor failed", RestStatus.OK, searchResponse.restStatus())
         val xcp = createParser(XContentType.JSON.xContent(), searchResponse.entity.content)
         val hits = xcp.map()["hits"]!! as Map<String, Map<String, Any>>
@@ -411,9 +431,11 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         val monitor = createRandomMonitor(true)
 
         val search = SearchSourceBuilder().query(QueryBuilders.termQuery("_id", monitor.id)).toString()
-        val searchResponse = client().makeRequest("POST", "$ALERTING_BASE_URI/_search",
-                emptyMap(),
-                NStringEntity(search, ContentType.APPLICATION_JSON))
+        val searchResponse = client().makeRequest(
+            "POST", "$ALERTING_BASE_URI/_search",
+            emptyMap(),
+            NStringEntity(search, ContentType.APPLICATION_JSON)
+        )
         assertEquals("Search monitor failed", RestStatus.OK, searchResponse.restStatus())
         val xcp = createParser(XContentType.JSON.xContent(), searchResponse.entity.content)
         val hits = xcp.map()["hits"]!! as Map<String, Map<String, Any>>
@@ -424,14 +446,19 @@ class MonitorRestApiIT : AlertingRestTestCase() {
     fun `test query a monitor that doesn't exist`() {
         // Create a random monitor to create the ScheduledJob index. Otherwise we test will fail with 404 index not found.
         createRandomMonitor(refresh = true)
-        val search = SearchSourceBuilder().query(QueryBuilders.termQuery(OpenSearchTestCase.randomAlphaOfLength(5),
-                OpenSearchTestCase.randomAlphaOfLength(5))).toString()
+        val search = SearchSourceBuilder().query(
+            QueryBuilders.termQuery(
+                OpenSearchTestCase.randomAlphaOfLength(5),
+                OpenSearchTestCase.randomAlphaOfLength(5)
+            )
+        ).toString()
 
         val searchResponse = client().makeRequest(
-                "GET",
-                "$ALERTING_BASE_URI/_search",
-                emptyMap(),
-                NStringEntity(search, ContentType.APPLICATION_JSON))
+            "GET",
+            "$ALERTING_BASE_URI/_search",
+            emptyMap(),
+            NStringEntity(search, ContentType.APPLICATION_JSON)
+        )
         assertEquals("Search monitor failed", RestStatus.OK, searchResponse.restStatus())
         val xcp = createParser(XContentType.JSON.xContent(), searchResponse.entity.content)
         val hits = xcp.map()["hits"]!! as Map<String, Map<String, Any>>
@@ -444,11 +471,12 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         val search = SearchSourceBuilder().query(QueryBuilders.termQuery("_id", monitor.id)).toString()
         val header = BasicHeader(HttpHeaders.USER_AGENT, "OpenSearch-Dashboards")
         val searchResponse = client().makeRequest(
-                "GET",
-                "$ALERTING_BASE_URI/_search",
-                emptyMap(),
-                NStringEntity(search, ContentType.APPLICATION_JSON),
-                header)
+            "GET",
+            "$ALERTING_BASE_URI/_search",
+            emptyMap(),
+            NStringEntity(search, ContentType.APPLICATION_JSON),
+            header
+        )
         assertEquals("Search monitor failed", RestStatus.OK, searchResponse.restStatus())
 
         val xcp = createParser(XContentType.JSON.xContent(), searchResponse.entity.content)
@@ -459,18 +487,21 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         val searchHits = hits["hits"] as List<Any>
         val hit = searchHits[0] as Map<String, Any>
         val monitorHit = hit["_source"] as Map<String, Any>
-        assertNotNull("UI Metadata returned from search but request did not come from OpenSearchDashboards",
-            monitorHit[Monitor.UI_METADATA_FIELD])
+        assertNotNull(
+            "UI Metadata returned from search but request did not come from OpenSearchDashboards",
+            monitorHit[Monitor.UI_METADATA_FIELD]
+        )
     }
 
     fun `test query a monitor with UI metadata as user`() {
         val monitor = createRandomMonitor(refresh = true, withMetadata = true)
         val search = SearchSourceBuilder().query(QueryBuilders.termQuery("_id", monitor.id)).toString()
         val searchResponse = client().makeRequest(
-                "GET",
-                "$ALERTING_BASE_URI/_search",
-                emptyMap(),
-                NStringEntity(search, ContentType.APPLICATION_JSON))
+            "GET",
+            "$ALERTING_BASE_URI/_search",
+            emptyMap(),
+            NStringEntity(search, ContentType.APPLICATION_JSON)
+        )
         assertEquals("Search monitor failed", RestStatus.OK, searchResponse.restStatus())
 
         val xcp = createParser(XContentType.JSON.xContent(), searchResponse.entity.content)
@@ -481,8 +512,10 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         val searchHits = hits["hits"] as List<Any>
         val hit = searchHits[0] as Map<String, Any>
         val monitorHit = hit["_source"] as Map<String, Any>
-        assertNull("UI Metadata returned from search but request did not come from OpenSearchDashboards",
-            monitorHit[Monitor.UI_METADATA_FIELD])
+        assertNull(
+            "UI Metadata returned from search but request did not come from OpenSearchDashboards",
+            monitorHit[Monitor.UI_METADATA_FIELD]
+        )
     }
 
     fun `test acknowledge all alert states`() {
@@ -572,8 +605,10 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         val alerts = responseMap["alerts"].toString()
 
         assertEquals(2, responseMap["totalAlerts"])
-        assertTrue("Acknowledged sev 1 alert with id, ${acknowledgedAlert.id}, not found in alert list",
-                alerts.contains(acknowledgedAlert.id))
+        assertTrue(
+            "Acknowledged sev 1 alert with id, ${acknowledgedAlert.id}, not found in alert list",
+            alerts.contains(acknowledgedAlert.id)
+        )
         assertFalse("Completed sev 3 alert with id, ${completedAlert.id}, found in alert list", alerts.contains(completedAlert.id))
         assertTrue("Error sev 1 alert with id, ${errorAlert.id}, not found in alert list", alerts.contains(errorAlert.id))
         assertFalse("Active sev 2 alert with id, ${activeAlert.id}, found in alert list", alerts.contains(activeAlert.id))
@@ -595,8 +630,10 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         val alerts = responseMap["alerts"].toString()
 
         assertEquals(2, responseMap["totalAlerts"])
-        assertTrue("Acknowledged alert for chosen monitor with id, ${acknowledgedAlert.id}, not found in alert list",
-                alerts.contains(acknowledgedAlert.id))
+        assertTrue(
+            "Acknowledged alert for chosen monitor with id, ${acknowledgedAlert.id}, not found in alert list",
+            alerts.contains(acknowledgedAlert.id)
+        )
         assertFalse("Completed sev 3 alert with id, ${completedAlert.id}, found in alert list", alerts.contains(completedAlert.id))
         assertTrue("Error alert for chosen monitor with id, ${errorAlert.id}, not found in alert list", alerts.contains(errorAlert.id))
         assertFalse("Active alert sev 2 with id, ${activeAlert.id}, found in alert list", alerts.contains(activeAlert.id))
@@ -619,8 +656,10 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         val alerts = responseMap["alerts"].toString()
 
         assertEquals(2, responseMap["totalAlerts"])
-        assertTrue("Acknowledged alert for matching monitor with id, ${acknowledgedAlert.id}, not found in alert list",
-                alerts.contains(acknowledgedAlert.id))
+        assertTrue(
+            "Acknowledged alert for matching monitor with id, ${acknowledgedAlert.id}, not found in alert list",
+            alerts.contains(acknowledgedAlert.id)
+        )
         assertFalse("Completed sev 3 alert with id, ${completedAlert.id}, found in alert list", alerts.contains(completedAlert.id))
         assertTrue("Error alert for matching monitor with id, ${errorAlert.id}, not found in alert list", alerts.contains(errorAlert.id))
         assertFalse("Active alert sev 2 with id, ${activeAlert.id}, found in alert list", alerts.contains(activeAlert.id))
@@ -633,8 +672,9 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         val parserMap = createParser(XContentType.JSON.xContent(), response.entity.content).map() as Map<String, Map<String, Any>>
         val mappingsMap = parserMap[ScheduledJob.SCHEDULED_JOBS_INDEX]!!["mappings"] as Map<String, Any>
         val expected = createParser(
-                XContentType.JSON.xContent(),
-                javaClass.classLoader.getResource("mappings/scheduled-jobs.json").readText())
+            XContentType.JSON.xContent(),
+            javaClass.classLoader.getResource("mappings/scheduled-jobs.json").readText()
+        )
         val expectedMap = expected.map()
 
         assertEquals("Mappings are different", expectedMap, mappingsMap)
@@ -668,8 +708,10 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         val alert = createAlert(randomAlert(monitor).copy(triggerId = trigger.id, state = Alert.State.ACTIVE))
         refreshIndex("*")
         val updatedMonitor = monitor.copy(triggers = emptyList())
-        val updateResponse = client().makeRequest("PUT", "$ALERTING_BASE_URI/${monitor.id}", emptyMap(),
-                updatedMonitor.toHttpEntity())
+        val updateResponse = client().makeRequest(
+            "PUT", "$ALERTING_BASE_URI/${monitor.id}", emptyMap(),
+            updatedMonitor.toHttpEntity()
+        )
         assertEquals("Update request not successful", RestStatus.OK, updateResponse.restStatus())
 
         // Wait 5 seconds for event to be processed and alerts moved
@@ -693,8 +735,10 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         val alertDelete = createAlert(randomAlert(monitor).copy(triggerId = triggerToDelete.id, state = Alert.State.ACTIVE))
         refreshIndex("*")
         val updatedMonitor = monitor.copy(triggers = listOf(triggerToKeep))
-        val updateResponse = client().makeRequest("PUT", "$ALERTING_BASE_URI/${monitor.id}", emptyMap(),
-                updatedMonitor.toHttpEntity())
+        val updateResponse = client().makeRequest(
+            "PUT", "$ALERTING_BASE_URI/${monitor.id}", emptyMap(),
+            updatedMonitor.toHttpEntity()
+        )
         assertEquals("Update request not successful", RestStatus.OK, updateResponse.restStatus())
 
         // Wait 5 seconds for event to be processed and alerts moved
@@ -714,8 +758,10 @@ class MonitorRestApiIT : AlertingRestTestCase() {
     fun `test update monitor with wrong version`() {
         val monitor = createRandomMonitor(refresh = true)
         try {
-            client().makeRequest("PUT", "${monitor.relativeUrl()}?refresh=true&if_seq_no=1234&if_primary_term=1234",
-                    emptyMap(), monitor.toHttpEntity())
+            client().makeRequest(
+                "PUT", "${monitor.relativeUrl()}?refresh=true&if_seq_no=1234&if_primary_term=1234",
+                emptyMap(), monitor.toHttpEntity()
+            )
             fail("expected 409 ResponseException")
         } catch (e: ResponseException) {
             assertEquals(RestStatus.CONFLICT, e.response.restStatus())

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -124,7 +124,6 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         val createdVersion = responseBody["_version"] as Int
         assertNotEquals("response is missing Id", Monitor.NO_ID, createdId)
         assertTrue("incorrect version", createdVersion > 0)
-        // assertEquals("Incorrect Location header", "$LEGACY_ALERTING_BASE_URI/$createdId", createResponse.getHeader("Location"))
     }
 
     fun `test creating a monitor with action threshold greater than max threshold`() {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureDestinationRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureDestinationRestApiIT.kt
@@ -48,14 +48,15 @@ class SecureDestinationRestApiIT : AlertingRestTestCase() {
 
         val chime = Chime("http://abc.com")
         val destination = Destination(
-                type = DestinationType.CHIME,
-                name = "test",
-                user = randomUser(),
-                lastUpdateTime = Instant.now(),
-                chime = chime,
-                slack = null,
-                customWebhook = null,
-                email = null)
+            type = DestinationType.CHIME,
+            name = "test",
+            user = randomUser(),
+            lastUpdateTime = Instant.now(),
+            chime = chime,
+            slack = null,
+            customWebhook = null,
+            email = null
+        )
         val createdDestination = createDestination(destination = destination)
         assertEquals("Incorrect destination name", createdDestination.name, "test")
         assertEquals("Incorrect destination type", createdDestination.type, DestinationType.CHIME)
@@ -65,31 +66,34 @@ class SecureDestinationRestApiIT : AlertingRestTestCase() {
         enableFilterBy()
         val chime = Chime("http://abc.com")
         val destination = Destination(
-                type = DestinationType.CHIME,
-                name = "test",
-                user = randomUser(),
-                lastUpdateTime = Instant.now(),
-                chime = chime,
-                slack = null,
-                customWebhook = null,
-                email = null)
+            type = DestinationType.CHIME,
+            name = "test",
+            user = randomUser(),
+            lastUpdateTime = Instant.now(),
+            chime = chime,
+            slack = null,
+            customWebhook = null,
+            email = null
+        )
 
         if (securityEnabled()) {
             // when security is enabled. No errors, must succeed.
             val response = client().makeRequest(
-                    "POST",
-                    "$DESTINATION_BASE_URI?refresh=true",
-                    emptyMap(),
-                    destination.toHttpEntity())
+                "POST",
+                "$DESTINATION_BASE_URI?refresh=true",
+                emptyMap(),
+                destination.toHttpEntity()
+            )
             assertEquals("Create monitor failed", RestStatus.CREATED, response.restStatus())
         } else {
             // when security is disable. Must return Forbidden.
             try {
                 client().makeRequest(
-                        "POST",
-                        "$DESTINATION_BASE_URI?refresh=true",
-                        emptyMap(),
-                        destination.toHttpEntity())
+                    "POST",
+                    "$DESTINATION_BASE_URI?refresh=true",
+                    emptyMap(),
+                    destination.toHttpEntity()
+                )
                 fail("Expected 403 FORBIDDEN response")
             } catch (e: ResponseException) {
                 assertEquals("Unexpected status", RestStatus.FORBIDDEN, e.response.restStatus())
@@ -109,7 +113,8 @@ class SecureDestinationRestApiIT : AlertingRestTestCase() {
             chime = chime,
             slack = null,
             customWebhook = null,
-            email = null)
+            email = null
+        )
         val createdDestination = createDestination(destination = destination)
 
         assertEquals("Incorrect destination name", createdDestination.name, "test")
@@ -140,7 +145,8 @@ class SecureDestinationRestApiIT : AlertingRestTestCase() {
             chime = chime,
             slack = null,
             customWebhook = null,
-            email = null)
+            email = null
+        )
 
         // 1. create a destination as admin user
         val createdDestination = createDestination(destination, true)
@@ -168,7 +174,8 @@ class SecureDestinationRestApiIT : AlertingRestTestCase() {
             chime = chime,
             slack = null,
             customWebhook = null,
-            email = null)
+            email = null
+        )
         val createdDestination = createDestination(destination = destination)
 
         assertEquals("Incorrect destination name", createdDestination.name, "test")
@@ -202,7 +209,8 @@ class SecureDestinationRestApiIT : AlertingRestTestCase() {
             chime = chime,
             slack = null,
             customWebhook = null,
-            email = null)
+            email = null
+        )
 
         // 1. create a destination as admin user
         val createdDestination = createDestination(destination, true)
@@ -225,14 +233,15 @@ class SecureDestinationRestApiIT : AlertingRestTestCase() {
         disableFilterBy()
         val slack = Slack("url")
         val destination = Destination(
-                type = DestinationType.SLACK,
-                name = "testSlack",
-                user = randomUser(),
-                lastUpdateTime = Instant.now(),
-                chime = null,
-                slack = slack,
-                customWebhook = null,
-                email = null)
+            type = DestinationType.SLACK,
+            name = "testSlack",
+            user = randomUser(),
+            lastUpdateTime = Instant.now(),
+            chime = null,
+            slack = slack,
+            customWebhook = null,
+            email = null
+        )
 
         // 1. create a destination as admin user
         createDestination(destination, true)
@@ -255,14 +264,15 @@ class SecureDestinationRestApiIT : AlertingRestTestCase() {
         }
         val slack = Slack("url")
         val destination = Destination(
-                type = DestinationType.SLACK,
-                name = "testSlack",
-                user = randomUser(),
-                lastUpdateTime = Instant.now(),
-                chime = null,
-                slack = slack,
-                customWebhook = null,
-                email = null)
+            type = DestinationType.SLACK,
+            name = "testSlack",
+            user = randomUser(),
+            lastUpdateTime = Instant.now(),
+            chime = null,
+            slack = slack,
+            customWebhook = null,
+            email = null
+        )
 
         // 1. create a destination as admin user
         createDestination(destination, true)

--- a/core/src/main/kotlin/org/opensearch/alerting/core/resthandler/RestScheduledJobStatsHandler.kt
+++ b/core/src/main/kotlin/org/opensearch/alerting/core/resthandler/RestScheduledJobStatsHandler.kt
@@ -34,7 +34,6 @@ import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.RestHandler
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
-
 import org.opensearch.rest.RestRequest.Method.GET
 import org.opensearch.rest.action.RestActions
 import java.util.Locale
@@ -49,8 +48,8 @@ class RestScheduledJobStatsHandler(private val path: String) : BaseRestHandler()
         const val JOB_SCHEDULING_METRICS: String = "job_scheduling_metrics"
         const val JOBS_INFO: String = "jobs_info"
         private val METRICS = mapOf<String, (ScheduledJobsStatsRequest) -> Unit>(
-                JOB_SCHEDULING_METRICS to { it -> it.jobSchedulingMetrics = true },
-                JOBS_INFO to { it -> it.jobsInfo = true }
+            JOB_SCHEDULING_METRICS to { it -> it.jobSchedulingMetrics = true },
+            JOBS_INFO to { it -> it.jobsInfo = true }
         )
     }
 
@@ -95,9 +94,9 @@ class RestScheduledJobStatsHandler(private val path: String) : BaseRestHandler()
         val scheduledJobNodesStatsRequest = getRequest(request)
         return RestChannelConsumer { channel ->
             client.execute(
-                    ScheduledJobsStatsAction.INSTANCE,
-                    scheduledJobNodesStatsRequest,
-                    RestActions.NodesResponseRestListener(channel)
+                ScheduledJobsStatsAction.INSTANCE,
+                scheduledJobNodesStatsRequest,
+                RestActions.NodesResponseRestListener(channel)
             )
         }
     }
@@ -114,10 +113,13 @@ class RestScheduledJobStatsHandler(private val path: String) : BaseRestHandler()
             scheduledJobsStatsRequest.all()
         } else if (metrics.contains("_all")) {
             throw IllegalArgumentException(
-                    String.format(Locale.ROOT,
-                            "request [%s] contains _all and individual metrics [%s]",
-                            request.path(),
-                            request.param("metric")))
+                String.format(
+                    Locale.ROOT,
+                    "request [%s] contains _all and individual metrics [%s]",
+                    request.path(),
+                    request.param("metric")
+                )
+            )
         } else {
             // use a sorted set so the unrecognized parameters appear in a reliable sorted order
             scheduledJobsStatsRequest.clear()

--- a/core/src/main/kotlin/org/opensearch/alerting/core/resthandler/RestScheduledJobStatsHandler.kt
+++ b/core/src/main/kotlin/org/opensearch/alerting/core/resthandler/RestScheduledJobStatsHandler.kt
@@ -59,10 +59,10 @@ class RestScheduledJobStatsHandler(private val path: String) : BaseRestHandler()
 
     override fun routes(): List<Route> {
         return listOf(
-                Route(GET, "/_opendistro/$path/{nodeId}/stats/"),
-                Route(GET, "/_opendistro/$path/{nodeId}/stats/{metric}"),
-                Route(GET, "/_opendistro/$path/stats/"),
-                Route(GET, "/_opendistro/$path/stats/{metric}")
+                Route(GET, "/_plugins/$path/{nodeId}/stats/"),
+                Route(GET, "/_plugins/$path/{nodeId}/stats/{metric}"),
+                Route(GET, "/_plugins/$path/stats/"),
+                Route(GET, "/_plugins/$path/stats/{metric}")
         )
     }
 

--- a/core/src/main/kotlin/org/opensearch/alerting/core/resthandler/RestScheduledJobStatsHandler.kt
+++ b/core/src/main/kotlin/org/opensearch/alerting/core/resthandler/RestScheduledJobStatsHandler.kt
@@ -59,12 +59,7 @@ class RestScheduledJobStatsHandler(private val path: String) : BaseRestHandler()
     }
 
     override fun routes(): List<Route> {
-        return listOf(
-                Route(GET, "/_plugins/$path/{nodeId}/stats/"),
-                Route(GET, "/_plugins/$path/{nodeId}/stats/{metric}"),
-                Route(GET, "/_plugins/$path/stats/"),
-                Route(GET, "/_plugins/$path/stats/{metric}")
-        )
+        return listOf()
     }
 
     override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {

--- a/core/src/main/kotlin/org/opensearch/alerting/core/resthandler/RestScheduledJobStatsHandler.kt
+++ b/core/src/main/kotlin/org/opensearch/alerting/core/resthandler/RestScheduledJobStatsHandler.kt
@@ -31,6 +31,7 @@ import org.opensearch.alerting.core.action.node.ScheduledJobsStatsRequest
 import org.opensearch.client.node.NodeClient
 import org.opensearch.common.Strings
 import org.opensearch.rest.BaseRestHandler
+import org.opensearch.rest.RestHandler
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 
@@ -63,6 +64,35 @@ class RestScheduledJobStatsHandler(private val path: String) : BaseRestHandler()
                 Route(GET, "/_plugins/$path/{nodeId}/stats/{metric}"),
                 Route(GET, "/_plugins/$path/stats/"),
                 Route(GET, "/_plugins/$path/stats/{metric}")
+        )
+    }
+
+    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+        return mutableListOf(
+            RestHandler.ReplacedRoute(
+                GET,
+                "/_opendistro/$path/{nodeId}/stats/",
+                GET,
+                "/_plugins/$path/{nodeId}/stats/"
+            ),
+            RestHandler.ReplacedRoute(
+                GET,
+                "/_opendistro/$path/{nodeId}/stats/{metric}",
+                GET,
+                "/_plugins/$path/{nodeId}/stats/{metric}"
+            ),
+            RestHandler.ReplacedRoute(
+                GET,
+                "/_opendistro/$path/stats/",
+                GET,
+                "/_plugins/$path/stats/"
+            ),
+            RestHandler.ReplacedRoute(
+                GET,
+                "/_opendistro/$path/stats/{metric}",
+                GET,
+                "/_plugins/$path/stats/{metric}"
+            )
         )
     }
 

--- a/core/src/main/kotlin/org/opensearch/alerting/core/resthandler/RestScheduledJobStatsHandler.kt
+++ b/core/src/main/kotlin/org/opensearch/alerting/core/resthandler/RestScheduledJobStatsHandler.kt
@@ -71,27 +71,27 @@ class RestScheduledJobStatsHandler(private val path: String) : BaseRestHandler()
         return mutableListOf(
             RestHandler.ReplacedRoute(
                 GET,
-                "/_opendistro/$path/{nodeId}/stats/",
+                "/_plugins/$path/{nodeId}/stats/",
                 GET,
-                "/_plugins/$path/{nodeId}/stats/"
+                "/_opendistro/$path/{nodeId}/stats/"
             ),
             RestHandler.ReplacedRoute(
                 GET,
-                "/_opendistro/$path/{nodeId}/stats/{metric}",
+                "/_plugins/$path/{nodeId}/stats/{metric}",
                 GET,
-                "/_plugins/$path/{nodeId}/stats/{metric}"
+                "/_opendistro/$path/{nodeId}/stats/{metric}"
             ),
             RestHandler.ReplacedRoute(
                 GET,
-                "/_opendistro/$path/stats/",
+                "/_plugins/$path/stats/",
                 GET,
-                "/_plugins/$path/stats/"
+                "/_opendistro/$path/stats/"
             ),
             RestHandler.ReplacedRoute(
                 GET,
-                "/_opendistro/$path/stats/{metric}",
+                "/_plugins/$path/stats/{metric}",
                 GET,
-                "/_plugins/$path/stats/{metric}"
+                "/_opendistro/$path/stats/{metric}"
             )
         )
     }

--- a/notification/build.gradle
+++ b/notification/build.gradle
@@ -33,7 +33,7 @@ apply plugin: 'signing'
 dependencies {
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
     compile "org.apache.httpcomponents:httpcore:4.4.5"
-    compile "org.apache.httpcomponents:httpclient:4.5.10"
+    compile "org.apache.httpcomponents:httpclient:4.5.13"
     compile "com.sun.mail:javax.mail:1.6.2"
 
     testImplementation "org.opensearch.test:framework:${opensearch_version}"

--- a/notification/build.gradle
+++ b/notification/build.gradle
@@ -33,7 +33,7 @@ apply plugin: 'signing'
 dependencies {
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
     compile "org.apache.httpcomponents:httpcore:4.4.5"
-    compile "org.apache.httpcomponents:httpclient:4.5.13"
+    compile "org.apache.httpcomponents:httpclient:4.5.10"
     compile "com.sun.mail:javax.mail:1.6.2"
 
     testImplementation "org.opensearch.test:framework:${opensearch_version}"


### PR DESCRIPTION
*Issue #, if available:* Resolves

- [x] Rename, and Backwards Compatibility for Rest APIs from #14 

*Description of changes:* REST APIs for ODFE are compatible in addition to the new API path. 

New API Path is `"/_plugins/_alerting/monitors"` and `"/_plugins/_alerting/destinations"`

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

Testing: 

Added UTs to check if the old path is still valid. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).