### PR TITLE
Adding check for security enabled

### DIFF
--- a/alerting/src/test/kotlin/org/opensearch/alerting/MonitorRunnerIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/MonitorRunnerIT.kt
@@ -772,30 +772,33 @@ class MonitorRunnerIT : AlertingRestTestCase() {
 
     fun `test execute monitor with custom webhook destination and denied host`() {
 
-        listOf("http://10.1.1.1", "127.0.0.1").forEach {
-            val customWebhook = CustomWebhook(it, null, null, 80, null, "PUT", emptyMap(), emptyMap(), null, null)
-            val destination = createDestination(
-                Destination(
-                    type = DestinationType.CUSTOM_WEBHOOK,
-                    name = "testDesination",
-                    user = randomUser(),
-                    lastUpdateTime = Instant.now(),
-                    chime = null,
-                    slack = null,
-                    customWebhook = customWebhook,
-                    email = null
+        // TODO: change to REST API call to test security enabled case
+        if (!securityEnabled()) {
+            listOf("http://10.1.1.1", "127.0.0.1").forEach {
+                val customWebhook = CustomWebhook(it, null, null, 80, null, "PUT", emptyMap(), emptyMap(), null, null)
+                val destination = createDestination(
+                    Destination(
+                        type = DestinationType.CUSTOM_WEBHOOK,
+                        name = "testDesination",
+                        user = randomUser(),
+                        lastUpdateTime = Instant.now(),
+                        chime = null,
+                        slack = null,
+                        customWebhook = customWebhook,
+                        email = null
+                    )
                 )
-            )
-            val action = randomAction(destinationId = destination.id)
-            val trigger = randomTrigger(condition = ALWAYS_RUN, actions = listOf(action))
-            val monitor = createMonitor(randomMonitor(triggers = listOf(trigger)))
-            executeMonitor(adminClient(), monitor.id)
+                val action = randomAction(destinationId = destination.id)
+                val trigger = randomTrigger(condition = ALWAYS_RUN, actions = listOf(action))
+                val monitor = createMonitor(randomMonitor(triggers = listOf(trigger)))
+                executeMonitor(adminClient(), monitor.id)
 
-            val alerts = searchAlerts(monitor)
-            assertEquals("Alert not saved", 1, alerts.size)
-            verifyAlert(alerts.single(), monitor, ERROR)
+                val alerts = searchAlerts(monitor)
+                assertEquals("Alert not saved", 1, alerts.size)
+                verifyAlert(alerts.single(), monitor, ERROR)
 
-            Assert.assertTrue(alerts.single().errorMessage?.contains("The destination address is invalid") as Boolean)
+                Assert.assertTrue(alerts.single().errorMessage?.contains("The destination address is invalid") as Boolean)
+            }
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:* Current REST API calls are incompatible with security enabled clusters. Added a check for the current ITs to pass with the security disabled cluster. 

Other IT tests in our Framework use the SecureClientBuilder. [Here](https://github.com/opendistro-for-elasticsearch/alerting/blob/ea60c949dfd8f95088b92e40b40857650c4d0ce4/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/SecureMonitorRestApiIT.kt#L41) 

We need to implement the same client in our current ITs

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).