### PR TITLE
Adding Workflow to test the Security Integration tests with the Security Plugin Installed on Opensearch Docker Image

### DIFF
--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -52,4 +52,49 @@ jobs:
         with:
           java-version: 14
       - name: Run integration tests with multi node config
-        run: ./gradlew integTest -PnumNodes=3 -Dopensearch.version=1.0.0-rc1
+        run: ./gradlew integTest -PnumNodes=3 -Dopensearch.version=1.0.0-rc1 -Dbuild.snapshot=false
+      - name: Pull and Run Docker
+        run: |
+          plugin=`ls alerting/build/distributions/*.zip`
+          list_of_files=`ls`
+          list_of_all_files=`ls alerting/build/distributions/`
+          version=`echo $plugin|awk -F- '{print $3}'| cut -d. -f 1-3`
+          plugin_version=`echo $plugin|awk -F- '{print $3}'| cut -d. -f 1-4`
+          candidate_version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-1`
+          echo $version $plugin_version $candidate_version
+          echo $ls $list_of_all_files
+
+          if docker pull opensearchstaging/opensearch:$version-$candidate_version
+          then
+            echo "FROM opensearchstaging/opensearch:$version-$candidate_version" >> Dockerfile
+            echo "RUN if [ -d /usr/share/opensearch/plugins/opensearch-alerting ]; then /usr/share/opensearch/bin/opensearch-plugin remove opensearch-alerting; fi" >> Dockerfile
+            echo "ADD alerting/build/distributions/opensearch-alerting-$plugin_version-$candidate_version.zip /tmp/" >> Dockerfile
+            echo "RUN /usr/share/opensearch/bin/opensearch-plugin install --batch file:/tmp/opensearch-alerting-$plugin_version-$candidate_version.zip" >> Dockerfile
+
+            docker build -t opensearch-alerting:test .
+            echo "imagePresent=true" >> $GITHUB_ENV
+          else
+            echo "imagePresent=false" >> $GITHUB_ENV
+          fi
+
+      - name: Run Docker Image
+        if: env.imagePresent == 'true'
+        run: |
+          cd ..
+          docker run -p 9200:9200 -d -p 9600:9600 -e "discovery.type=single-node" opensearch-alerting:test
+          sleep 120
+
+      - name: Run Alerting Test for security enabled test cases
+        if: env.imagePresent == 'true'
+        run: |
+          cluster_running=`curl -XGET https://localhost:9200/_cat/plugins -u admin:admin --insecure`
+          echo $cluster_running
+          security=`curl -XGET https://localhost:9200/_cat/plugins -u admin:admin --insecure |grep opensearch-security|wc -l`
+          echo $security
+          if [ $security -gt 0 ]
+          then
+            echo "Security plugin is available"
+            ./gradlew :alerting:integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=docker-cluster -Dsecurity=true -Dhttps=true -Duser=admin -Dpassword=admin
+          else
+            echo "Security plugin is NOT available skipping this run as tests without security have already been run"
+          fi


### PR DESCRIPTION
Signed-off-by: Aditya Jindal <aditjind@amazon.com>

*Issue #, if available:*

*Description of changes:* Added the workflow to run the integration tests with security plugin installed on an Open-search cluster created via Docker Image for the staging artifacts. 

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).