### PR TITLE
Adding the ITs for the support of Date Math Index Resolution and a fix for moving the alert to the error state in case of not being able to publish the emails

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
@@ -57,7 +57,7 @@ fun isValidEmail(email: String): Boolean {
 fun Destination.isAllowed(allowList: List<String>): Boolean = allowList.contains(this.type.value)
 
 fun BaseMessage.isHostInDenylist(networks: List<String>): Boolean {
-    if (this.url != null) {
+    if (this.url != null || this.uri.host != null) {
         val ipStr = IPAddressString(this.uri.host)
         for (network in networks) {
             val netStr = IPAddressString(network)

--- a/alerting/src/test/kotlin/org/opensearch/alerting/util/AlertingUtilsTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/util/AlertingUtilsTests.kt
@@ -68,7 +68,7 @@ class AlertingUtilsTests : OpenSearchTestCase() {
 
     private fun createMessageWithHost(host: String): BaseMessage {
         return CustomWebhookMessage.Builder("abc")
-            .withUrl(host)
+            .withHost(host)
             .withPath("incomingwebhooks/383c0e2b-d028-44f4-8d38-696754bc4574")
             .withMessage("{\"Content\":\"Message test\"}")
             .withMethod("POST")

--- a/notification/src/main/java/org/opensearch/alerting/destination/client/DestinationEmailClient.java
+++ b/notification/src/main/java/org/opensearch/alerting/destination/client/DestinationEmailClient.java
@@ -97,7 +97,7 @@ public class DestinationEmailClient {
 
                 SendMessage(mailmsg);
             } catch (MessagingException e) {
-                return e.getMessage();
+                throw new MessagingException(e.getMessage());
             }
         }
         return "Sent";

--- a/notification/src/test/java/org/opensearch/alerting/destination/EmailDestinationTest.java
+++ b/notification/src/test/java/org/opensearch/alerting/destination/EmailDestinationTest.java
@@ -117,7 +117,7 @@ public class EmailDestinationTest {
         assertEquals(expectedEmailResponse.getStatusCode(), actualEmailResponse.getStatusCode());
     }
 
-    @Test
+    @Test(expected = IllegalStateException.class)
     public void testFailingMailMessage() throws Exception {
 
         DestinationResponse expectedEmailResponse = new DestinationResponse.Builder()


### PR DESCRIPTION
*Issue #, if available:* #74 https://github.com/opensearch-project/alerting/issues/94

*Description of changes:* A null check was required to prevent the destinations which don't have a URL or a HOST as a part of the Destination Params. This resulted in validation failures whenever Destinations such as SNS are added. Added the null checks and also updated the UTs

An urgent update (hot fix) was done as a part of [this](https://github.com/opensearch-project/alerting/commit/496c9546889cdad5f30c483cf04d18b870531460) commit to unblock.

This also updates the integration test to create the index which is encoded in date math format. (#74)

This also contains the fix for storing the alert in the error condition whenever the action is unable to send the email to the destination.  

Changes are tested locally by hitting the APIs and checking the response of the unreachably configured SMPT server. 

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).