### PR TITLE
Upgrade google-java-format to 1.10.0 to pick guava v30

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlin_version}"
     compile "com.cronutils:cron-utils:9.1.3"
     compile "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
-    compile 'com.google.googlejavaformat:google-java-format:1.3'
+    compile 'com.google.googlejavaformat:google-java-format:1.10.0'
     compile "org.opensearch:common-utils:${common_utils_version}"
 
     testImplementation "org.opensearch.test:framework:${opensearch_version}"


### PR DESCRIPTION
*Issue #, if available:*
Upgrade google-java-format to 1.10.0 to pick guava v30
*Description of changes:*
Upgrade google-java-format to 1.10.0 to pick guava v30

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).