### PR TITLE
Added release notes for OpenSearch 1.0.0.0.

### DIFF
--- a/release-notes/opensearch-alerting.release-notes-1.0.0.0.md
+++ b/release-notes/opensearch-alerting.release-notes-1.0.0.0.md
@@ -1,0 +1,22 @@
+## Version 1.0.0.0 2021-06-30
+
+Compatible with OpenSearch 1.0.0
+
+### Infrastructure
+* Upgrading the Ktlint Version and applying the formatting to the project ([#20](https://github.com/opensearch-project/alerting/pull/20))
+* Upgrade google-java-format to 1.10.0 to pick guava v30 ([#115](https://github.com/opensearch-project/alerting/pull/115))
+### Enhancements
+* Adding check for security enabled ([#24](https://github.com/opensearch-project/alerting/pull/24))
+* Adding Workflow to test the Security Integration tests with the Security Plugin Installed on Opensearch Docker Image ([#25](https://github.com/opensearch-project/alerting/pull/25))
+* Adding Ktlint formatting check to the Gradle build task ([#26](https://github.com/opensearch-project/alerting/pull/26))
+* Updating UTs for the Destination Settings ([#102](https://github.com/opensearch-project/alerting/pull/102))
+* Adding additional null checks for URL not present ([#112](https://github.com/opensearch-project/alerting/pull/112))
+* Enable license headers check ([118](https://github.com/opensearch-project/alerting/pull/118))
+### Documentation
+* Update issue template with multiple labels ([#13](https://github.com/opensearch-project/alerting/pull/13))
+* Update and add documentation files ([#117](https://github.com/opensearch-project/alerting/pull/117))
+### Maintenance
+* Adding Rest APIs Backward Compatibility with ODFE ([#16](https://github.com/opensearch-project/alerting/pull/16))
+* Moving the ODFE Settings to Legacy Settings and adding the new settings compatible with Opensearch ([#18](https://github.com/opensearch-project/alerting/pull/18))
+### Refactoring
+* Rename namespaces from com.amazon.opendistroforelasticsearch to org.opensearch ([#15](https://github.com/opensearch-project/alerting/pull/15))


### PR DESCRIPTION
Signed-off-by: Thomas Hurney [hurneyt@amazon.com](mailto:hurneyt@amazon.com)

*Issue #, if available:*
N/A

*Description of changes:*
Added release notes for OpenSearch-Alerting 1.0.0.0. These release notes include notes from OpenSearch-Alerting 1.0.0.0-rc1.

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).