### PR TITLE
Fix snapshot build and increment to 1.1.0.

### DIFF
--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -29,20 +29,20 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: '1.0'
+          ref: '1.x'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal
       # This step adds dependency, common-utils
       - name: Checkout common-utils
         uses: actions/checkout@v2
         with:
           repository: 'opensearch-project/common-utils'
           path: common-utils
-          ref: '1.0'
+          ref: 'main'
       - name: Build common-utils
         working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
         uses: actions/checkout@v2
@@ -52,7 +52,7 @@ jobs:
         with:
           java-version: 14
       - name: Run integration tests with multi node config
-        run: ./gradlew integTest -PnumNodes=3 -Dopensearch.version=1.0.0 -Dbuild.snapshot=false
+        run: ./gradlew integTest -PnumNodes=3 -Dopensearch.version=1.1.0-SNAPSHOT
       - name: Pull and Run Docker
         run: |
           plugin=`ls alerting/build/distributions/*.zip`

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -35,10 +35,10 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: '1.0'
+          ref: '1.x'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal
 
       # dependencies: common-utils
       - name: Checkout common-utils
@@ -46,13 +46,13 @@ jobs:
         with:
           repository: 'opensearch-project/common-utils'
           path: common-utils
-          ref: '1.0'
+          ref: 'main'
       - name: Build common-utils
         working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
 
       - name: Build and run with Gradle
-        run: ./gradlew build -Dopensearch.version=1.0.0
+        run: ./gradlew build -Dopensearch.version=1.1.0-SNAPSHOT
 
 #      - name: Create Artifact Path
 #        run: |
@@ -71,4 +71,4 @@ jobs:
 #          path: alerting-artifacts
       # Publish to local maven
       - name: Publish to Maven Local
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ build/
 .DS_Store
 *.log
 out/
+.project
+.settings
+.vscode

--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -35,15 +35,10 @@ apply plugin: 'jacoco'
 def usingRemoteCluster = System.properties.containsKey('tests.rest.cluster') || System.properties.containsKey('tests.cluster')
 def usingMultiNode = project.properties.containsKey('numNodes')
 
-
 ext {
     projectSubstitutions = [:]
     licenseFile = rootProject.file('LICENSE.txt')
     noticeFile = rootProject.file('NOTICE.txt')
-}
-
-if (isSnapshot) {
-    version += "-SNAPSHOT"
 }
 
 opensearchplugin {

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,10 @@ buildscript {
     apply from: 'build-tools/repositories.gradle'
 
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.0.0")
-        common_utils_version = '1.0.0.0'
+        opensearch_version = System.getProperty("opensearch.version", "1.1.0-SNAPSHOT")
+        // 1.0.0 -> 1.0.0.0, and 1.0.0-SNAPSHOT -> 1.0.0.0-SNAPSHOT
+        opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
+        common_utils_version = System.getProperty("common_utils.version", opensearch_build)
         kotlin_version = '1.3.72'
     }
 
@@ -45,7 +47,6 @@ buildscript {
     }
 }
 
-
 plugins {
     id 'nebula.ospackage' version "8.3.0" apply false
     id "com.dorongold.task-tree" version "1.5"
@@ -54,11 +55,6 @@ plugins {
 apply plugin: 'base'
 apply plugin: 'jacoco'
 apply from: 'build-tools/merged-coverage.gradle'
-
-ext {
-    opendistroVersion = "${version}"
-    isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-}
 
 configurations {
     ktlint
@@ -88,12 +84,16 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
 
 check.dependsOn ktlint
 
+ext {
+    isSnapshot = "true" == System.getProperty("build.snapshot", "true")
+}
 
 allprojects {
     group = "org.opensearch"
-    // Increment the final digit when there's a new plugin versions for the same opendistro version
-    // Reset the final digit to 0 when upgrading to a new opendistro version
-    version = "${opendistroVersion}.0"
+    version = "${opensearch_version}" - "-SNAPSHOT" + ".0"
+    if (isSnapshot) {
+        version += "-SNAPSHOT"
+    }
 
     apply from: "$rootDir/build-tools/repositories.gradle"
 


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

*Issue #, if available:*

Fixes https://github.com/opensearch-project/alerting/issues/141 and defaults to building a `-SNAPSHOT` version.

Depends on https://github.com/opensearch-project/common-utils/pull/58/files

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).