### PR TITLE
Update Bucket-Level Alerting RFC

### DIFF
--- a/docs/bucket-level-alerting-rfc.md
+++ b/docs/bucket-level-alerting-rfc.md
@@ -1,6 +1,6 @@
-# Document-Level Alerting RFC
+# Bucket-Level Alerting RFC
 
-The purpose of this request for comments (RFC) is to introduce our plans to enhance the Alerting plugin with document-level alerting functionality and collect feedback and discuss our plans with the community. This RFC is meant to cover the high-level functionality and does not go into implementation details and architecture.
+The purpose of this request for comments (RFC) is to introduce our plans to enhance the Alerting plugin with bucket-level alerting functionality and collect feedback and discuss our plans with the community. This RFC is meant to cover the high-level functionality and does not go into implementation details and architecture.
 
 ## Problem Statement
 
@@ -28,4 +28,4 @@ Similar to controlling the possible flood of alerts, the resulting actions/notif
 
 ## Providing Feedback
 
-If you have comments or feedback on our plans for Document-Level Alerting, please comment on the [GitHub issue](https://github.com/opendistro-for-elasticsearch/alerting/issues/326) in this project to discuss.
+If you have comments or feedback on our plans for Bucket-Level Alerting, please comment on the [GitHub issue](https://github.com/opensearch-project/alerting/issues/86) in this project to discuss.


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <qreshi@amazon.com>

*Issue #, if available:*

*Description of changes:*
Updating Bucket-Level Alerting RFC to reflect the feature name for posterity as well as updating the issue link to the OpenSearch Alerting equivalent.

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).