### PR TITLE
Refactor Monitor and Trigger to split into Query-Level and Bucket-Lev…

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -57,7 +57,9 @@ import org.opensearch.alerting.core.resthandler.RestScheduledJobStatsHandler
 import org.opensearch.alerting.core.schedule.JobScheduler
 import org.opensearch.alerting.core.settings.LegacyOpenDistroScheduledJobSettings
 import org.opensearch.alerting.core.settings.ScheduledJobSettings
+import org.opensearch.alerting.model.BucketLevelTrigger
 import org.opensearch.alerting.model.Monitor
+import org.opensearch.alerting.model.QueryLevelTrigger
 import org.opensearch.alerting.resthandler.RestAcknowledgeAlertAction
 import org.opensearch.alerting.resthandler.RestDeleteDestinationAction
 import org.opensearch.alerting.resthandler.RestDeleteEmailAccountAction
@@ -135,8 +137,8 @@ import java.util.function.Supplier
 /**
  * Entry point of the OpenDistro for Elasticsearch alerting plugin
  * This class initializes the [RestGetMonitorAction], [RestDeleteMonitorAction], [RestIndexMonitorAction] rest handlers.
- * It also adds [Monitor.XCONTENT_REGISTRY], [SearchInput.XCONTENT_REGISTRY] to the
- * [NamedXContentRegistry] so that we are able to deserialize the custom named objects.
+ * It also adds [Monitor.XCONTENT_REGISTRY], [SearchInput.XCONTENT_REGISTRY], [QueryLevelTrigger.XCONTENT_REGISTRY],
+ * [BucketLevelTrigger.XCONTENT_REGISTRY] to the [NamedXContentRegistry] so that we are able to deserialize the custom named objects.
  */
 internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, ReloadablePlugin, SearchPlugin, Plugin() {
 
@@ -224,7 +226,12 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
     }
 
     override fun getNamedXContent(): List<NamedXContentRegistry.Entry> {
-        return listOf(Monitor.XCONTENT_REGISTRY, SearchInput.XCONTENT_REGISTRY)
+        return listOf(
+            Monitor.XCONTENT_REGISTRY,
+            SearchInput.XCONTENT_REGISTRY,
+            QueryLevelTrigger.XCONTENT_REGISTRY,
+            BucketLevelTrigger.XCONTENT_REGISTRY
+        )
     }
 
     override fun createComponents(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/action/ExecuteMonitorResponse.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/action/ExecuteMonitorResponse.kt
@@ -37,9 +37,9 @@ import java.io.IOException
 
 class ExecuteMonitorResponse : ActionResponse, ToXContentObject {
 
-    val monitorRunResult: MonitorRunResult
+    val monitorRunResult: MonitorRunResult<*>
 
-    constructor(monitorRunResult: MonitorRunResult) : super() {
+    constructor(monitorRunResult: MonitorRunResult<*>) : super() {
         this.monitorRunResult = monitorRunResult
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/Alert.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/Alert.kt
@@ -31,6 +31,7 @@ import org.opensearch.alerting.elasticapi.instant
 import org.opensearch.alerting.elasticapi.optionalTimeField
 import org.opensearch.alerting.elasticapi.optionalUserField
 import org.opensearch.alerting.util.IndexUtils.Companion.NO_SCHEMA_VERSION
+import org.opensearch.commons.authuser.User
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.StreamOutput
 import org.opensearch.common.io.stream.Writeable
@@ -39,7 +40,6 @@ import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
-import org.opensearch.commons.authuser.User
 import java.io.IOException
 import java.time.Instant
 
@@ -61,7 +61,8 @@ data class Alert(
     val errorMessage: String? = null,
     val errorHistory: List<AlertError>,
     val severity: String,
-    val actionExecutionResults: List<ActionExecutionResult>
+    val actionExecutionResults: List<ActionExecutionResult>,
+    val aggregationResultBucket: AggregationResultBucket? = null
 ) : Writeable, ToXContent {
 
     init {
@@ -72,7 +73,7 @@ data class Alert(
 
     constructor(
         monitor: Monitor,
-        trigger: Trigger,
+        trigger: QueryLevelTrigger,
         startTime: Instant,
         lastNotificationTime: Instant?,
         state: State = State.ACTIVE,
@@ -80,12 +81,44 @@ data class Alert(
         errorHistory: List<AlertError> = mutableListOf(),
         actionExecutionResults: List<ActionExecutionResult> = mutableListOf(),
         schemaVersion: Int = NO_SCHEMA_VERSION
-    ) : this(
-        monitorId = monitor.id, monitorName = monitor.name, monitorVersion = monitor.version, monitorUser = monitor.user,
+    ) : this(monitorId = monitor.id, monitorName = monitor.name, monitorVersion = monitor.version, monitorUser = monitor.user,
         triggerId = trigger.id, triggerName = trigger.name, state = state, startTime = startTime,
         lastNotificationTime = lastNotificationTime, errorMessage = errorMessage, errorHistory = errorHistory,
-        severity = trigger.severity, actionExecutionResults = actionExecutionResults, schemaVersion = schemaVersion
-    )
+        severity = trigger.severity, actionExecutionResults = actionExecutionResults, schemaVersion = schemaVersion,
+        aggregationResultBucket = null)
+
+    constructor(
+        monitor: Monitor,
+        trigger: BucketLevelTrigger,
+        startTime: Instant,
+        lastNotificationTime: Instant?,
+        state: State = State.ACTIVE,
+        errorMessage: String? = null,
+        errorHistory: List<AlertError> = mutableListOf(),
+        actionExecutionResults: List<ActionExecutionResult> = mutableListOf(),
+        schemaVersion: Int = NO_SCHEMA_VERSION
+    ) : this(monitorId = monitor.id, monitorName = monitor.name, monitorVersion = monitor.version, monitorUser = monitor.user,
+        triggerId = trigger.id, triggerName = trigger.name, state = state, startTime = startTime,
+        lastNotificationTime = lastNotificationTime, errorMessage = errorMessage, errorHistory = errorHistory,
+        severity = trigger.severity, actionExecutionResults = actionExecutionResults, schemaVersion = schemaVersion,
+        aggregationResultBucket = null)
+
+    constructor(
+        monitor: Monitor,
+        trigger: BucketLevelTrigger,
+        startTime: Instant,
+        lastNotificationTime: Instant?,
+        state: State = State.ACTIVE,
+        errorMessage: String? = null,
+        errorHistory: List<AlertError> = mutableListOf(),
+        actionExecutionResults: List<ActionExecutionResult> = mutableListOf(),
+        schemaVersion: Int = NO_SCHEMA_VERSION,
+        aggregationResultBucket: AggregationResultBucket
+    ) : this(monitorId = monitor.id, monitorName = monitor.name, monitorVersion = monitor.version, monitorUser = monitor.user,
+        triggerId = trigger.id, triggerName = trigger.name, state = state, startTime = startTime,
+        lastNotificationTime = lastNotificationTime, errorMessage = errorMessage, errorHistory = errorHistory,
+        severity = trigger.severity, actionExecutionResults = actionExecutionResults, schemaVersion = schemaVersion,
+        aggregationResultBucket = aggregationResultBucket)
 
     enum class State {
         ACTIVE, ACKNOWLEDGED, COMPLETED, ERROR, DELETED
@@ -112,7 +145,8 @@ data class Alert(
         errorMessage = sin.readOptionalString(),
         errorHistory = sin.readList(::AlertError),
         severity = sin.readString(),
-        actionExecutionResults = sin.readList(::ActionExecutionResult)
+        actionExecutionResults = sin.readList(::ActionExecutionResult),
+        aggregationResultBucket = if (sin.readBoolean()) AggregationResultBucket(sin) else null
     )
 
     fun isAcknowledged(): Boolean = (state == State.ACKNOWLEDGED)
@@ -138,6 +172,12 @@ data class Alert(
         out.writeCollection(errorHistory)
         out.writeString(severity)
         out.writeCollection(actionExecutionResults)
+        if (aggregationResultBucket != null) {
+            out.writeBoolean(true)
+            aggregationResultBucket.writeTo(out)
+        } else {
+            out.writeBoolean(false)
+        }
     }
 
     companion object {
@@ -160,7 +200,8 @@ data class Alert(
         const val ALERT_HISTORY_FIELD = "alert_history"
         const val SEVERITY_FIELD = "severity"
         const val ACTION_EXECUTION_RESULTS_FIELD = "action_execution_results"
-
+        const val BUCKET_KEYS = AggregationResultBucket.BUCKET_KEYS
+        const val PARENTS_BUCKET_PATH = AggregationResultBucket.PARENTS_BUCKET_PATH
         const val NO_ID = ""
         const val NO_VERSION = Versions.NOT_FOUND
 
@@ -183,8 +224,8 @@ data class Alert(
             var acknowledgedTime: Instant? = null
             var errorMessage: String? = null
             val errorHistory: MutableList<AlertError> = mutableListOf()
-            var actionExecutionResults: MutableList<ActionExecutionResult> = mutableListOf()
-
+            val actionExecutionResults: MutableList<ActionExecutionResult> = mutableListOf()
+            var aggAlertBucket: AggregationResultBucket? = null
             ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
             while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
                 val fieldName = xcp.currentName()
@@ -217,18 +258,27 @@ data class Alert(
                             actionExecutionResults.add(ActionExecutionResult.parse(xcp))
                         }
                     }
+                    AggregationResultBucket.CONFIG_NAME -> {
+                        // If an Alert with aggAlertBucket contents is indexed into the alerts index first, then
+                        // that field will be added to the mappings.
+                        // In this case, that field will default to null when it isn't present for Alerts created by Query-Level Monitors
+                        // (even though the toXContent doesn't output the field) so null is being accounted for here.
+                        aggAlertBucket = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                            null
+                        } else {
+                            AggregationResultBucket.parse(xcp)
+                        }
+                    }
                 }
             }
 
-            return Alert(
-                id = id, version = version, schemaVersion = schemaVersion, monitorId = requireNotNull(monitorId),
+            return Alert(id = id, version = version, schemaVersion = schemaVersion, monitorId = requireNotNull(monitorId),
                 monitorName = requireNotNull(monitorName), monitorVersion = monitorVersion, monitorUser = monitorUser,
                 triggerId = requireNotNull(triggerId), triggerName = requireNotNull(triggerName),
                 state = requireNotNull(state), startTime = requireNotNull(startTime), endTime = endTime,
                 lastNotificationTime = lastNotificationTime, acknowledgedTime = acknowledgedTime,
                 errorMessage = errorMessage, errorHistory = errorHistory, severity = severity,
-                actionExecutionResults = actionExecutionResults
-            )
+                actionExecutionResults = actionExecutionResults, aggregationResultBucket = aggAlertBucket)
         }
 
         @JvmStatic
@@ -239,7 +289,7 @@ data class Alert(
     }
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject()
+        builder.startObject()
             .field(ALERT_ID_FIELD, id)
             .field(ALERT_VERSION_FIELD, version)
             .field(MONITOR_ID_FIELD, monitorId)
@@ -258,7 +308,9 @@ data class Alert(
             .optionalTimeField(LAST_NOTIFICATION_TIME_FIELD, lastNotificationTime)
             .optionalTimeField(END_TIME_FIELD, endTime)
             .optionalTimeField(ACKNOWLEDGED_TIME_FIELD, acknowledgedTime)
-            .endObject()
+        aggregationResultBucket?.innerXContent(builder)
+        builder.endObject()
+        return builder
     }
 
     fun asTemplateArg(): Map<String, Any?> {
@@ -271,7 +323,10 @@ data class Alert(
             LAST_NOTIFICATION_TIME_FIELD to lastNotificationTime?.toEpochMilli(),
             SEVERITY_FIELD to severity,
             START_TIME_FIELD to startTime.toEpochMilli(),
-            STATE_FIELD to state.toString()
+            STATE_FIELD to state.toString(),
+            // Converting bucket keys to comma separated String to avoid manipulation in Action mustache templates
+            BUCKET_KEYS to aggregationResultBucket?.bucketKeys?.joinToString(","),
+            PARENTS_BUCKET_PATH to aggregationResultBucket?.parentBucketPath
         )
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/BucketLevelTrigger.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/BucketLevelTrigger.kt
@@ -1,0 +1,152 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.alerting.model
+
+import org.opensearch.alerting.aggregation.bucketselectorext.BucketSelectorExtAggregationBuilder
+import org.opensearch.alerting.model.Trigger.Companion.ACTIONS_FIELD
+import org.opensearch.alerting.model.Trigger.Companion.ID_FIELD
+import org.opensearch.alerting.model.Trigger.Companion.NAME_FIELD
+import org.opensearch.alerting.model.Trigger.Companion.SEVERITY_FIELD
+import org.opensearch.alerting.model.action.Action
+import org.opensearch.common.CheckedFunction
+import org.opensearch.common.ParseField
+import org.opensearch.common.UUIDs
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.common.xcontent.NamedXContentRegistry
+import org.opensearch.common.xcontent.ToXContent
+import org.opensearch.common.xcontent.XContentBuilder
+import org.opensearch.common.xcontent.XContentParser
+import org.opensearch.common.xcontent.XContentParser.Token
+import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
+import java.io.IOException
+
+/**
+ * A multi-alert Trigger available with Bucket-Level Monitors that filters aggregation buckets via a pipeline
+ * aggregator.
+ */
+data class BucketLevelTrigger(
+    override val id: String = UUIDs.base64UUID(),
+    override val name: String,
+    override val severity: String,
+    val bucketSelector: BucketSelectorExtAggregationBuilder,
+    override val actions: List<Action>
+) : Trigger {
+
+    @Throws(IOException::class)
+    constructor(sin: StreamInput): this(
+        sin.readString(), // id
+        sin.readString(), // name
+        sin.readString(), // severity
+        BucketSelectorExtAggregationBuilder(sin), // condition
+        sin.readList(::Action) // actions
+    )
+
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        builder.startObject()
+            .startObject(BUCKET_LEVEL_TRIGGER_FIELD)
+            .field(ID_FIELD, id)
+            .field(NAME_FIELD, name)
+            .field(SEVERITY_FIELD, severity)
+            .startObject(CONDITION_FIELD)
+        bucketSelector.internalXContent(builder, params)
+        builder.endObject()
+            .field(ACTIONS_FIELD, actions.toTypedArray())
+            .endObject()
+            .endObject()
+        return builder
+    }
+
+    override fun name(): String {
+        return BUCKET_LEVEL_TRIGGER_FIELD
+    }
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        out.writeString(id)
+        out.writeString(name)
+        out.writeString(severity)
+        bucketSelector.writeTo(out)
+        out.writeCollection(actions)
+    }
+
+    fun asTemplateArg(): Map<String, Any> {
+        return mapOf(
+            ID_FIELD to id,
+            NAME_FIELD to name,
+            SEVERITY_FIELD to severity,
+            ACTIONS_FIELD to actions.map { it.asTemplateArg() },
+            PARENT_BUCKET_PATH to getParentBucketPath()
+        )
+    }
+
+    fun getParentBucketPath(): String {
+        return bucketSelector.parentBucketPath
+    }
+
+    companion object {
+        const val BUCKET_LEVEL_TRIGGER_FIELD = "bucket_level_trigger"
+        const val CONDITION_FIELD = "condition"
+        const val PARENT_BUCKET_PATH = "parentBucketPath"
+
+        val XCONTENT_REGISTRY = NamedXContentRegistry.Entry(Trigger::class.java, ParseField(BUCKET_LEVEL_TRIGGER_FIELD),
+            CheckedFunction { parseInner(it) })
+
+        @JvmStatic
+        @Throws(IOException::class)
+        fun parseInner(xcp: XContentParser): BucketLevelTrigger {
+            var id = UUIDs.base64UUID() // assign a default triggerId if one is not specified
+            lateinit var name: String
+            lateinit var severity: String
+            val actions: MutableList<Action> = mutableListOf()
+            ensureExpectedToken(Token.START_OBJECT, xcp.currentToken(), xcp)
+            lateinit var bucketSelector: BucketSelectorExtAggregationBuilder
+
+            while (xcp.nextToken() != Token.END_OBJECT) {
+                val fieldName = xcp.currentName()
+
+                xcp.nextToken()
+                when (fieldName) {
+                    ID_FIELD -> id = xcp.text()
+                    NAME_FIELD -> name = xcp.text()
+                    SEVERITY_FIELD -> severity = xcp.text()
+                    CONDITION_FIELD -> {
+                        // Using the trigger id as the name in the bucket selector since it is validated for uniqueness within Monitors
+                        // and the id is not given by users when making API requests so it should be set before this is called.
+                        // On the other hand, trigger name could potentially be given in any order in the JSON request and may not precede
+                        // the condition field.
+                        bucketSelector = BucketSelectorExtAggregationBuilder.parse(id, xcp)
+                    }
+                    ACTIONS_FIELD -> {
+                        ensureExpectedToken(Token.START_ARRAY, xcp.currentToken(), xcp)
+                        while (xcp.nextToken() != Token.END_ARRAY) {
+                            actions.add(Action.parse(xcp))
+                        }
+                    }
+                }
+            }
+
+            return BucketLevelTrigger(
+                id = requireNotNull(id) { "Trigger id is null." },
+                name = requireNotNull(name) { "Trigger name is null" },
+                severity = requireNotNull(severity) { "Trigger severity is null" },
+                bucketSelector = bucketSelector,
+                actions = requireNotNull(actions) { "Trigger actions are null" })
+        }
+
+        @JvmStatic
+        @Throws(IOException::class)
+        fun readFrom(sin: StreamInput): BucketLevelTrigger {
+            return BucketLevelTrigger(sin)
+        }
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/BucketLevelTriggerRunResult.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/BucketLevelTriggerRunResult.kt
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.alerting.model
+
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.common.xcontent.ToXContent
+import org.opensearch.common.xcontent.XContentBuilder
+import java.io.IOException
+
+data class BucketLevelTriggerRunResult(
+    override var triggerName: String,
+    override var error: Exception? = null,
+    var aggregationResultBuckets: Map<String, AggregationResultBucket>,
+    var actionResultsMap: MutableMap<String, MutableMap<String, ActionRunResult>> = mutableMapOf()
+) : TriggerRunResult(triggerName, error) {
+
+    @Throws(IOException::class)
+    @Suppress("UNCHECKED_CAST")
+    constructor(sin: StreamInput): this(
+        sin.readString(),
+        sin.readException() as Exception?, // error
+        sin.readMap(StreamInput::readString, ::AggregationResultBucket),
+        sin.readMap() as MutableMap<String, MutableMap<String, ActionRunResult>>
+    )
+
+    override fun internalXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        return builder
+            .field(AGG_RESULT_BUCKETS, aggregationResultBuckets)
+            .field(ACTIONS_RESULTS, actionResultsMap as Map<String, Any>)
+    }
+
+    @Throws(IOException::class)
+    @Suppress("UNCHECKED_CAST")
+    override fun writeTo(out: StreamOutput) {
+        super.writeTo(out)
+        out.writeMap(aggregationResultBuckets, StreamOutput::writeString) {
+            valueOut: StreamOutput, aggResultBucket: AggregationResultBucket -> aggResultBucket.writeTo(valueOut)
+        }
+        out.writeMap(actionResultsMap as Map<String, Any>)
+    }
+
+    companion object {
+        const val AGG_RESULT_BUCKETS = "agg_result_buckets"
+        const val ACTIONS_RESULTS = "action_results"
+
+        @JvmStatic
+        @Throws(IOException::class)
+        fun readFrom(sin: StreamInput): TriggerRunResult {
+            return BucketLevelTriggerRunResult(sin)
+        }
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/QueryLevelTrigger.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/QueryLevelTrigger.kt
@@ -1,0 +1,185 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.alerting.model
+
+import org.opensearch.alerting.model.Trigger.Companion.ACTIONS_FIELD
+import org.opensearch.alerting.model.Trigger.Companion.ID_FIELD
+import org.opensearch.alerting.model.Trigger.Companion.NAME_FIELD
+import org.opensearch.alerting.model.Trigger.Companion.SEVERITY_FIELD
+import org.opensearch.alerting.model.action.Action
+import org.opensearch.common.CheckedFunction
+import org.opensearch.common.ParseField
+import org.opensearch.common.UUIDs
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.common.xcontent.NamedXContentRegistry
+import org.opensearch.common.xcontent.ToXContent
+import org.opensearch.common.xcontent.XContentBuilder
+import org.opensearch.common.xcontent.XContentParser
+import org.opensearch.common.xcontent.XContentParser.Token
+import org.opensearch.common.xcontent.XContentParserUtils
+import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
+import org.opensearch.script.Script
+import java.io.IOException
+
+/**
+ * A single-alert Trigger that uses Painless scripts which execute on the response of the Monitor input query to define
+ * alerting conditions.
+ */
+data class QueryLevelTrigger(
+    override val id: String = UUIDs.base64UUID(),
+    override val name: String,
+    override val severity: String,
+    override val actions: List<Action>,
+    val condition: Script
+) : Trigger {
+
+    @Throws(IOException::class)
+    constructor(sin: StreamInput): this(
+        sin.readString(), // id
+        sin.readString(), // name
+        sin.readString(), // severity
+        sin.readList(::Action), // actions
+        Script(sin) // condition
+    )
+
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        builder.startObject()
+            .startObject(QUERY_LEVEL_TRIGGER_FIELD)
+            .field(ID_FIELD, id)
+            .field(NAME_FIELD, name)
+            .field(SEVERITY_FIELD, severity)
+            .startObject(CONDITION_FIELD)
+            .field(SCRIPT_FIELD, condition)
+            .endObject()
+            .field(ACTIONS_FIELD, actions.toTypedArray())
+            .endObject()
+            .endObject()
+        return builder
+    }
+
+    override fun name(): String {
+        return QUERY_LEVEL_TRIGGER_FIELD
+    }
+
+    /** Returns a representation of the trigger suitable for passing into painless and mustache scripts. */
+    fun asTemplateArg(): Map<String, Any> {
+        return mapOf(ID_FIELD to id, NAME_FIELD to name, SEVERITY_FIELD to severity,
+            ACTIONS_FIELD to actions.map { it.asTemplateArg() })
+    }
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        out.writeString(id)
+        out.writeString(name)
+        out.writeString(severity)
+        out.writeCollection(actions)
+        condition.writeTo(out)
+    }
+
+    companion object {
+        const val QUERY_LEVEL_TRIGGER_FIELD = "query_level_trigger"
+        const val CONDITION_FIELD = "condition"
+        const val SCRIPT_FIELD = "script"
+
+        val XCONTENT_REGISTRY = NamedXContentRegistry.Entry(Trigger::class.java, ParseField(QUERY_LEVEL_TRIGGER_FIELD),
+            CheckedFunction { parseInner(it) })
+
+        /**
+         * This parse method needs to account for both the old and new Trigger format.
+         * In the old format, only one Trigger existed (which is now QueryLevelTrigger) and it was
+         * not a named object.
+         *
+         * The parse() method in the Trigger interface needs to consume the outer START_OBJECT to be able
+         * to infer whether it is dealing with the old or new Trigger format. This means that the currentToken at
+         * the time this parseInner method is called could differ based on which format is being dealt with.
+         *
+         * Old Format
+         * ----------
+         * {
+         *   "id": ...,
+         *    ^
+         *    Current token starts here
+         *   "name" ...,
+         *   ...
+         * }
+         *
+         * New Format
+         * ----------
+         * {
+         *   "query_level_trigger": {
+         *     "id": ...,           ^ Current token starts here
+         *     "name": ...,
+         *     ...
+         *   }
+         * }
+         *
+         * It isn't typically conventional but this parse method will account for both START_OBJECT
+         * and FIELD_NAME as the starting token to cover both cases.
+         */
+        @JvmStatic @Throws(IOException::class)
+        fun parseInner(xcp: XContentParser): QueryLevelTrigger {
+            var id = UUIDs.base64UUID() // assign a default triggerId if one is not specified
+            lateinit var name: String
+            lateinit var severity: String
+            lateinit var condition: Script
+            val actions: MutableList<Action> = mutableListOf()
+
+            if (xcp.currentToken() != Token.START_OBJECT && xcp.currentToken() != Token.FIELD_NAME) {
+                XContentParserUtils.throwUnknownToken(xcp.currentToken(), xcp.tokenLocation)
+            }
+
+            // If the parser began on START_OBJECT, move to the next token so that the while loop enters on
+            // the fieldName (or END_OBJECT if it's empty).
+            if (xcp.currentToken() == Token.START_OBJECT) xcp.nextToken()
+
+            while (xcp.currentToken() != Token.END_OBJECT) {
+                val fieldName = xcp.currentName()
+
+                xcp.nextToken()
+                when (fieldName) {
+                    ID_FIELD -> id = xcp.text()
+                    NAME_FIELD -> name = xcp.text()
+                    SEVERITY_FIELD -> severity = xcp.text()
+                    CONDITION_FIELD -> {
+                        xcp.nextToken()
+                        condition = Script.parse(xcp)
+                        require(condition.lang == Script.DEFAULT_SCRIPT_LANG) {
+                            "Invalid script language. Allowed languages are [${Script.DEFAULT_SCRIPT_LANG}]"
+                        }
+                        xcp.nextToken()
+                    }
+                    ACTIONS_FIELD -> {
+                        ensureExpectedToken(Token.START_ARRAY, xcp.currentToken(), xcp)
+                        while (xcp.nextToken() != Token.END_ARRAY) {
+                            actions.add(Action.parse(xcp))
+                        }
+                    }
+                }
+                xcp.nextToken()
+            }
+
+            return QueryLevelTrigger(
+                name = requireNotNull(name) { "Trigger name is null" },
+                severity = requireNotNull(severity) { "Trigger severity is null" },
+                condition = requireNotNull(condition) { "Trigger is null" },
+                actions = requireNotNull(actions) { "Trigger actions are null" },
+                id = requireNotNull(id) { "Trigger id is null." })
+        }
+
+        @JvmStatic
+        @Throws(IOException::class)
+        fun readFrom(sin: StreamInput): QueryLevelTrigger {
+            return QueryLevelTrigger(sin)
+        }
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/QueryLevelTriggerRunResult.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/QueryLevelTriggerRunResult.kt
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.alerting.model
+
+import org.opensearch.alerting.alerts.AlertError
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.common.xcontent.ToXContent
+import org.opensearch.common.xcontent.XContentBuilder
+import org.opensearch.script.ScriptException
+import java.io.IOException
+import java.time.Instant
+
+data class QueryLevelTriggerRunResult(
+    override var triggerName: String,
+    var triggered: Boolean,
+    override var error: Exception?,
+    var actionResults: MutableMap<String, ActionRunResult> = mutableMapOf()
+) : TriggerRunResult(triggerName, error) {
+
+    @Throws(IOException::class)
+    @Suppress("UNCHECKED_CAST")
+    constructor(sin: StreamInput) : this(
+        triggerName = sin.readString(),
+        error = sin.readException(),
+        triggered = sin.readBoolean(),
+        actionResults = sin.readMap() as MutableMap<String, ActionRunResult>
+    )
+
+    override fun alertError(): AlertError? {
+        if (error != null) {
+            return AlertError(Instant.now(), "Failed evaluating trigger:\n${error!!.userErrorMessage()}")
+        }
+        for (actionResult in actionResults.values) {
+            if (actionResult.error != null) {
+                return AlertError(Instant.now(), "Failed running action:\n${actionResult.error.userErrorMessage()}")
+            }
+        }
+        return null
+    }
+
+    override fun internalXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        if (error is ScriptException) error = Exception((error as ScriptException).toJsonString(), error)
+        return builder
+            .field("triggered", triggered)
+            .field("action_results", actionResults as Map<String, ActionRunResult>)
+    }
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        super.writeTo(out)
+        out.writeBoolean(triggered)
+        out.writeMap(actionResults as Map<String, ActionRunResult>)
+    }
+
+    companion object {
+        @JvmStatic
+        @Throws(IOException::class)
+        fun readFrom(sin: StreamInput): TriggerRunResult {
+            return QueryLevelTriggerRunResult(sin)
+        }
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/Trigger.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/Trigger.kt
@@ -26,120 +26,77 @@
 
 package org.opensearch.alerting.model
 
+import org.opensearch.alerting.core.model.ScheduledJob.Companion.SCHEDULED_JOBS_INDEX
 import org.opensearch.alerting.model.action.Action
-import org.opensearch.common.UUIDs
 import org.opensearch.common.io.stream.StreamInput
-import org.opensearch.common.io.stream.StreamOutput
 import org.opensearch.common.io.stream.Writeable
-import org.opensearch.common.xcontent.ToXContent
-import org.opensearch.common.xcontent.XContentBuilder
+import org.opensearch.common.xcontent.ToXContentObject
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParser.Token
 import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
-import org.opensearch.script.Script
 import java.io.IOException
 
-data class Trigger(
-    val name: String,
-    val severity: String,
-    val condition: Script,
-    val actions: List<Action>,
-    val id: String = UUIDs.base64UUID()
-) : Writeable, ToXContent {
+interface Trigger : Writeable, ToXContentObject {
 
-    @Throws(IOException::class)
-    constructor(sin: StreamInput) : this(
-        sin.readString(), // name
-        sin.readString(), // severity
-        Script(sin), // condition
-        sin.readList(::Action), // actions
-        sin.readString() // id
-    )
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        builder.startObject()
-            .field(ID_FIELD, id)
-            .field(NAME_FIELD, name)
-            .field(SEVERITY_FIELD, severity)
-            .startObject(CONDITION_FIELD)
-            .field(SCRIPT_FIELD, condition)
-            .endObject()
-            .field(ACTIONS_FIELD, actions.toTypedArray())
-            .endObject()
-        return builder
-    }
+    enum class Type(val value: String) {
+        QUERY_LEVEL_TRIGGER(QueryLevelTrigger.QUERY_LEVEL_TRIGGER_FIELD),
+        BUCKET_LEVEL_TRIGGER(BucketLevelTrigger.BUCKET_LEVEL_TRIGGER_FIELD);
 
-    /** Returns a representation of the trigger suitable for passing into painless and mustache scripts. */
-    fun asTemplateArg(): Map<String, Any> {
-        return mapOf(
-            ID_FIELD to id, NAME_FIELD to name, SEVERITY_FIELD to severity,
-            ACTIONS_FIELD to actions.map { it.asTemplateArg() }
-        )
-    }
-
-    @Throws(IOException::class)
-    override fun writeTo(out: StreamOutput) {
-        out.writeString(name)
-        out.writeString(severity)
-        condition.writeTo(out)
-        out.writeCollection(actions)
-        out.writeString(id)
+        override fun toString(): String {
+            return value
+        }
     }
 
     companion object {
         const val ID_FIELD = "id"
         const val NAME_FIELD = "name"
         const val SEVERITY_FIELD = "severity"
-        const val CONDITION_FIELD = "condition"
         const val ACTIONS_FIELD = "actions"
-        const val SCRIPT_FIELD = "script"
 
-        @JvmStatic @Throws(IOException::class)
+        @Throws(IOException::class)
         fun parse(xcp: XContentParser): Trigger {
-            var id = UUIDs.base64UUID() // assign a default triggerId if one is not specified
-            lateinit var name: String
-            lateinit var severity: String
-            lateinit var condition: Script
-            val actions: MutableList<Action> = mutableListOf()
+            val trigger: Trigger
+
             ensureExpectedToken(Token.START_OBJECT, xcp.currentToken(), xcp)
-
-            while (xcp.nextToken() != Token.END_OBJECT) {
-                val fieldName = xcp.currentName()
-
-                xcp.nextToken()
-                when (fieldName) {
-                    ID_FIELD -> id = xcp.text()
-                    NAME_FIELD -> name = xcp.text()
-                    SEVERITY_FIELD -> severity = xcp.text()
-                    CONDITION_FIELD -> {
-                        xcp.nextToken()
-                        condition = Script.parse(xcp)
-                        require(condition.lang == Script.DEFAULT_SCRIPT_LANG) {
-                            "Invalid script language. Allowed languages are [${Script.DEFAULT_SCRIPT_LANG}]"
-                        }
-                        xcp.nextToken()
-                    }
-                    ACTIONS_FIELD -> {
-                        ensureExpectedToken(Token.START_ARRAY, xcp.currentToken(), xcp)
-                        while (xcp.nextToken() != Token.END_ARRAY) {
-                            actions.add(Action.parse(xcp))
-                        }
-                    }
-                }
+            ensureExpectedToken(Token.FIELD_NAME, xcp.nextToken(), xcp)
+            val triggerTypeNames = Type.values().map { it.toString() }
+            if (triggerTypeNames.contains(xcp.currentName())) {
+                ensureExpectedToken(Token.START_OBJECT, xcp.nextToken(), xcp)
+                trigger = xcp.namedObject(Trigger::class.java, xcp.currentName(), null)
+                ensureExpectedToken(Token.END_OBJECT, xcp.nextToken(), xcp)
+            } else {
+                // Infer the old Trigger (now called QueryLevelTrigger) when it is not defined as a named
+                // object to remain backwards compatible when parsing the old format
+                trigger = QueryLevelTrigger.parseInner(xcp)
+                ensureExpectedToken(Token.END_OBJECT, xcp.currentToken(), xcp)
             }
-
-            return Trigger(
-                name = requireNotNull(name) { "Trigger name is null" },
-                severity = requireNotNull(severity) { "Trigger severity is null" },
-                condition = requireNotNull(condition) { "Trigger is null" },
-                actions = requireNotNull(actions) { "Trigger actions are null" },
-                id = requireNotNull(id) { "Trigger id is null." }
-            )
+            return trigger
         }
 
         @JvmStatic
         @Throws(IOException::class)
         fun readFrom(sin: StreamInput): Trigger {
-            return Trigger(sin)
+            return when (val type = sin.readEnum(Trigger.Type::class.java)) {
+                Type.QUERY_LEVEL_TRIGGER -> QueryLevelTrigger(sin)
+                Type.BUCKET_LEVEL_TRIGGER -> BucketLevelTrigger(sin)
+                // This shouldn't be reachable but ensuring exhaustiveness as Kotlin warns
+                // enum can be null in Java
+                else -> throw IllegalStateException("Unexpected input [$type] when reading Trigger")
+            }
         }
     }
+
+    /** The id of the Trigger in the [SCHEDULED_JOBS_INDEX] */
+    val id: String
+
+    /** The name of the Trigger */
+    val name: String
+
+    /** The severity of the Trigger, used to classify the subsequent Alert */
+    val severity: String
+
+    /** The actions executed if the Trigger condition evaluates to true */
+    val actions: List<Action>
+
+    fun name(): String
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/TriggerRunResult.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/TriggerRunResult.kt
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.alerting.model
+
+import org.opensearch.alerting.alerts.AlertError
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.common.io.stream.Writeable
+import org.opensearch.common.xcontent.ToXContent
+import org.opensearch.common.xcontent.XContentBuilder
+import java.io.IOException
+import java.time.Instant
+
+abstract class TriggerRunResult(
+    open var triggerName: String,
+    open var error: Exception? = null
+) : Writeable, ToXContent {
+
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        builder.startObject()
+            .field("name", triggerName)
+
+        internalXContent(builder, params)
+        val msg = error?.message
+
+        builder.field("error", msg)
+            .endObject()
+        return builder
+    }
+
+    abstract fun internalXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder
+
+    /** Returns error information to store in the Alert. Currently it's just the stack trace but it can be more */
+    open fun alertError(): AlertError? {
+        if (error != null) {
+            return AlertError(Instant.now(), "Failed evaluating trigger:\n${error!!.userErrorMessage()}")
+        }
+        return null
+    }
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        out.writeString(triggerName)
+        out.writeException(error)
+    }
+
+    companion object {
+        @Suppress("UNCHECKED_CAST")
+        fun suppressWarning(map: MutableMap<String?, Any?>?): MutableMap<String, ActionRunResult> {
+            return map as MutableMap<String, ActionRunResult>
+        }
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/script/BucketLevelTriggerExecutionContext.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/script/BucketLevelTriggerExecutionContext.kt
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.alerting.script
+
+import org.opensearch.alerting.model.BucketLevelTrigger
+import org.opensearch.alerting.model.BucketLevelTriggerRunResult
+import org.opensearch.alerting.model.Alert
+import org.opensearch.alerting.model.Monitor
+import org.opensearch.alerting.model.MonitorRunResult
+import java.time.Instant
+
+data class BucketLevelTriggerExecutionContext(
+    override val monitor: Monitor,
+    val trigger: BucketLevelTrigger,
+    override val results: List<Map<String, Any>>,
+    override val periodStart: Instant,
+    override val periodEnd: Instant,
+    val dedupedAlerts: List<Alert> = listOf(),
+    val newAlerts: List<Alert> = listOf(),
+    val completedAlerts: List<Alert> = listOf(),
+    override val error: Exception? = null
+) : TriggerExecutionContext(monitor, results, periodStart, periodEnd, error) {
+
+    constructor(
+        monitor: Monitor,
+        trigger: BucketLevelTrigger,
+        monitorRunResult: MonitorRunResult<BucketLevelTriggerRunResult>,
+        dedupedAlerts: List<Alert> = listOf(),
+        newAlerts: List<Alert> = listOf(),
+        completedAlerts: List<Alert> = listOf()
+    ) : this(monitor, trigger, monitorRunResult.inputResults.results, monitorRunResult.periodStart, monitorRunResult.periodEnd,
+        dedupedAlerts, newAlerts, completedAlerts, monitorRunResult.scriptContextError(trigger))
+
+    /**
+     * Mustache templates need special permissions to reflectively introspect field names. To avoid doing this we
+     * translate the context to a Map of Strings to primitive types, which can be accessed without reflection.
+     */
+    override fun asTemplateArg(): Map<String, Any?> {
+        val tempArg = super.asTemplateArg().toMutableMap()
+        tempArg["trigger"] = trigger.asTemplateArg()
+        tempArg["dedupedAlerts"] = dedupedAlerts.map { it.asTemplateArg() }
+        tempArg["newAlerts"] = newAlerts.map { it.asTemplateArg() }
+        tempArg["completedAlerts"] = completedAlerts.map { it.asTemplateArg() }
+        return tempArg
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/script/QueryLevelTriggerExecutionContext.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/script/QueryLevelTriggerExecutionContext.kt
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.alerting.script
+
+import org.opensearch.alerting.model.Alert
+import org.opensearch.alerting.model.Monitor
+import org.opensearch.alerting.model.MonitorRunResult
+import org.opensearch.alerting.model.QueryLevelTrigger
+import org.opensearch.alerting.model.QueryLevelTriggerRunResult
+import java.time.Instant
+
+data class QueryLevelTriggerExecutionContext(
+    override val monitor: Monitor,
+    val trigger: QueryLevelTrigger,
+    override val results: List<Map<String, Any>>,
+    override val periodStart: Instant,
+    override val periodEnd: Instant,
+    val alert: Alert? = null,
+    override val error: Exception? = null
+) : TriggerExecutionContext(monitor, results, periodStart, periodEnd, error) {
+
+    constructor(
+        monitor: Monitor,
+        trigger: QueryLevelTrigger,
+        monitorRunResult: MonitorRunResult<QueryLevelTriggerRunResult>,
+        alert: Alert? = null
+    ) : this(monitor, trigger, monitorRunResult.inputResults.results, monitorRunResult.periodStart, monitorRunResult.periodEnd,
+        alert, monitorRunResult.scriptContextError(trigger))
+
+    /**
+     * Mustache templates need special permissions to reflectively introspect field names. To avoid doing this we
+     * translate the context to a Map of Strings to primitive types, which can be accessed without reflection.
+     */
+    override fun asTemplateArg(): Map<String, Any?> {
+        val tempArg = super.asTemplateArg().toMutableMap()
+        tempArg["trigger"] = trigger.asTemplateArg()
+        tempArg["alert"] = alert?.asTemplateArg()
+        return tempArg
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/script/TriggerExecutionContext.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/script/TriggerExecutionContext.kt
@@ -26,40 +26,33 @@
 
 package org.opensearch.alerting.script
 
-import org.opensearch.alerting.model.Alert
 import org.opensearch.alerting.model.Monitor
 import org.opensearch.alerting.model.MonitorRunResult
 import org.opensearch.alerting.model.Trigger
 import java.time.Instant
 
-data class TriggerExecutionContext(
-    val monitor: Monitor,
-    val trigger: Trigger,
-    val results: List<Map<String, Any>>,
-    val periodStart: Instant,
-    val periodEnd: Instant,
-    val alert: Alert? = null,
-    val error: Exception? = null
+abstract class TriggerExecutionContext(
+    open val monitor: Monitor,
+    open val results: List<Map<String, Any>>,
+    open val periodStart: Instant,
+    open val periodEnd: Instant,
+    open val error: Exception? = null
 ) {
 
-    constructor(monitor: Monitor, trigger: Trigger, monitorRunResult: MonitorRunResult, alert: Alert? = null) :
-        this(
-            monitor, trigger, monitorRunResult.inputResults.results, monitorRunResult.periodStart,
-            monitorRunResult.periodEnd, alert, monitorRunResult.scriptContextError(trigger)
-        )
+    constructor(monitor: Monitor, trigger: Trigger, monitorRunResult: MonitorRunResult<*>):
+        this(monitor, monitorRunResult.inputResults.results, monitorRunResult.periodStart,
+            monitorRunResult.periodEnd, monitorRunResult.scriptContextError(trigger))
 
     /**
      * Mustache templates need special permissions to reflectively introspect field names. To avoid doing this we
      * translate the context to a Map of Strings to primitive types, which can be accessed without reflection.
      */
-    fun asTemplateArg(): Map<String, Any?> {
+    open fun asTemplateArg(): Map<String, Any?> {
         return mapOf(
             "monitor" to monitor.asTemplateArg(),
-            "trigger" to trigger.asTemplateArg(),
             "results" to results,
             "periodStart" to periodStart,
             "periodEnd" to periodEnd,
-            "alert" to alert?.asTemplateArg(),
             "error" to error
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/script/TriggerScript.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/script/TriggerScript.kt
@@ -58,7 +58,7 @@ abstract class TriggerScript(_scriptParams: Map<String, Any>) {
      *
      * @param ctx - the trigger execution context
      */
-    abstract fun execute(ctx: TriggerExecutionContext): Boolean
+    abstract fun execute(ctx: QueryLevelTriggerExecutionContext): Boolean
 
     interface Factory {
         fun newInstance(scriptParams: Map<String, Any>): TriggerScript

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
@@ -31,6 +31,7 @@ import org.opensearch.OpenSearchStatusException
 import org.opensearch.action.ActionListener
 import org.opensearch.alerting.destination.message.BaseMessage
 import org.opensearch.alerting.model.AggregationResultBucket
+import org.opensearch.alerting.model.Monitor
 import org.opensearch.alerting.model.action.Action
 import org.opensearch.alerting.model.action.ActionExecutionScope
 import org.opensearch.alerting.model.destination.Destination
@@ -142,6 +143,8 @@ fun <T : Any> checkUserFilterByPermissions(
     }
     return true
 }
+
+fun Monitor.isBucketLevelMonitor(): Boolean = this.monitorType == Monitor.MonitorType.BUCKET_LEVEL_MONITOR
 
 /**
  * Since buckets can have multi-value keys, this converts the bucket key values to a string that can be used

--- a/alerting/src/main/resources/org/opensearch/alerting/alerts/alert_mapping.json
+++ b/alerting/src/main/resources/org/opensearch/alerting/alerts/alert_mapping.json
@@ -4,7 +4,7 @@
     "required": true
   },
   "_meta" : {
-    "schema_version": 2
+    "schema_version": 3
   },
   "properties": {
     "schema_version": {
@@ -123,6 +123,17 @@
         },
         "throttled_count": {
           "type": "integer"
+        }
+      }
+    },
+    "agg_alert_content": {
+      "dynamic": true,
+      "properties": {
+        "parent_bucket_path": {
+          "type": "text"
+        },
+        "bucket_key": {
+          "type": "text"
         }
       }
     }

--- a/alerting/src/main/resources/org/opensearch/alerting/org.opensearch.alerting.txt
+++ b/alerting/src/main/resources/org/opensearch/alerting/org.opensearch.alerting.txt
@@ -4,7 +4,7 @@
 
 class org.opensearch.alerting.script.TriggerScript {
     Map getParams()
-    boolean execute(TriggerExecutionContext)
+    boolean execute(QueryLevelTriggerExecutionContext)
     String[] PARAMETERS
 }
 
@@ -14,7 +14,15 @@ class org.opensearch.alerting.script.TriggerScript$Factory {
 
 class org.opensearch.alerting.script.TriggerExecutionContext {
     Monitor getMonitor()
-    Trigger getTrigger()
+    List getResults()
+    java.time.Instant getPeriodStart()
+    java.time.Instant getPeriodEnd()
+    Exception getError()
+}
+
+class org.opensearch.alerting.script.QueryLevelTriggerExecutionContext {
+    Monitor getMonitor()
+    QueryLevelTrigger getTrigger()
     List getResults()
     java.time.Instant getPeriodStart()
     java.time.Instant getPeriodEnd()
@@ -29,15 +37,11 @@ class org.opensearch.alerting.model.Monitor {
     boolean getEnabled()
 }
 
-class org.opensearch.alerting.model.Trigger {
+class org.opensearch.alerting.model.QueryLevelTrigger {
     String getId()
     String getName()
     String getSeverity()
     List getActions()
-}
-
-class org.opensearch.alerting.model.action.Action {
-    String getName()
 }
 
 class org.opensearch.alerting.model.Alert {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/MonitorRunnerIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/MonitorRunnerIT.kt
@@ -66,7 +66,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
 
     fun `test execute monitor with dryrun`() {
         val action = randomAction(template = randomTemplateScript("Hello {{ctx.monitor.name}}"), destinationId = createDestination().id)
-        val monitor = randomMonitor(triggers = listOf(randomTrigger(condition = ALWAYS_RUN, actions = listOf(action))))
+        val monitor = randomQueryLevelMonitor(triggers = listOf(randomQueryLevelTrigger(condition = ALWAYS_RUN, actions = listOf(action))))
 
         val response = executeMonitor(monitor, params = DRYRUN_MONITOR)
 
@@ -101,8 +101,8 @@ class MonitorRunnerIT : AlertingRestTestCase() {
             return ctx.results[0].hits.hits.size() == 1
         """.trimIndent()
 
-        val trigger = randomTrigger(condition = Script(triggerScript))
-        val monitor = randomMonitor(inputs = listOf(input), triggers = listOf(trigger))
+        val trigger = randomQueryLevelTrigger(condition = Script(triggerScript))
+        val monitor = randomQueryLevelMonitor(inputs = listOf(input), triggers = listOf(trigger))
         val response = executeMonitor(monitor, params = DRYRUN_MONITOR)
 
         val output = entityAsMap(response)
@@ -116,7 +116,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
     }
 
     fun `test execute monitor not triggered`() {
-        val monitor = randomMonitor(triggers = listOf(randomTrigger(condition = NEVER_RUN)))
+        val monitor = randomQueryLevelMonitor(triggers = listOf(randomQueryLevelTrigger(condition = NEVER_RUN)))
 
         val response = executeMonitor(monitor)
 
@@ -132,7 +132,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
 
     fun `test active alert is updated on each run`() {
         val monitor = createMonitor(
-            randomMonitor(triggers = listOf(randomTrigger(condition = ALWAYS_RUN, destinationId = createDestination().id)))
+            randomQueryLevelMonitor(triggers = listOf(randomQueryLevelTrigger(condition = ALWAYS_RUN, destinationId = createDestination().id)))
         )
 
         executeMonitor(monitor.id)
@@ -158,9 +158,9 @@ class MonitorRunnerIT : AlertingRestTestCase() {
         createIndex("foo", Settings.EMPTY)
         val input = SearchInput(indices = listOf("foo"), query = SearchSourceBuilder().query(QueryBuilders.matchAllQuery()))
         val monitor = createMonitor(
-            randomMonitor(
+            randomQueryLevelMonitor(
                 inputs = listOf(input),
-                triggers = listOf(randomTrigger(condition = NEVER_RUN))
+                triggers = listOf(randomQueryLevelTrigger(condition = NEVER_RUN))
             )
         )
 
@@ -183,9 +183,9 @@ class MonitorRunnerIT : AlertingRestTestCase() {
         createIndex("foo", Settings.EMPTY)
         val input = SearchInput(indices = listOf("foo"), query = SearchSourceBuilder().query(QueryBuilders.matchAllQuery()))
         val monitor = createMonitor(
-            randomMonitor(
+            randomQueryLevelMonitor(
                 inputs = listOf(input),
-                triggers = listOf(randomTrigger(condition = NEVER_RUN))
+                triggers = listOf(randomQueryLevelTrigger(condition = NEVER_RUN))
             )
         )
 
@@ -204,9 +204,9 @@ class MonitorRunnerIT : AlertingRestTestCase() {
         createIndex("foo", Settings.EMPTY)
         val input = SearchInput(indices = listOf("foo"), query = SearchSourceBuilder().query(QueryBuilders.matchAllQuery()))
         val monitor = createMonitor(
-            randomMonitor(
+            randomQueryLevelMonitor(
                 inputs = listOf(input),
-                triggers = listOf(randomTrigger(condition = ALWAYS_RUN, destinationId = destinationId))
+                triggers = listOf(randomQueryLevelTrigger(condition = ALWAYS_RUN, destinationId = destinationId))
             )
         )
 
@@ -231,7 +231,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
 
     fun `test acknowledged alert is not updated unnecessarily`() {
         val monitor = createMonitor(
-            randomMonitor(triggers = listOf(randomTrigger(condition = ALWAYS_RUN, destinationId = createDestination().id)))
+            randomQueryLevelMonitor(triggers = listOf(randomQueryLevelTrigger(condition = ALWAYS_RUN, destinationId = createDestination().id)))
         )
         executeMonitor(monitor.id)
         acknowledgeAlerts(monitor, searchAlerts(monitor).single())
@@ -253,8 +253,8 @@ class MonitorRunnerIT : AlertingRestTestCase() {
     }
 
     fun `test alert completion`() {
-        val trigger = randomTrigger(condition = Script("ctx.alert == null"), destinationId = createDestination().id)
-        val monitor = createMonitor(randomMonitor(triggers = listOf(trigger)))
+        val trigger = randomQueryLevelTrigger(condition = Script("ctx.alert == null"), destinationId = createDestination().id)
+        val monitor = createMonitor(randomQueryLevelMonitor(triggers = listOf(trigger)))
 
         executeMonitor(monitor.id)
         val activeAlert = searchAlerts(monitor).single()
@@ -268,8 +268,8 @@ class MonitorRunnerIT : AlertingRestTestCase() {
 
     fun `test execute monitor script error`() {
         // This painless script should cause a syntax error
-        val trigger = randomTrigger(condition = Script("foo bar baz"))
-        val monitor = randomMonitor(triggers = listOf(trigger))
+        val trigger = randomQueryLevelTrigger(condition = Script("foo bar baz"))
+        val monitor = randomQueryLevelMonitor(triggers = listOf(trigger))
 
         val response = executeMonitor(monitor)
 
@@ -286,7 +286,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
     fun `test execute action template error`() {
         // Intentional syntax error in mustache template
         val action = randomAction(template = randomTemplateScript("Hello {{ctx.monitor.name"))
-        val monitor = randomMonitor(triggers = listOf(randomTrigger(condition = ALWAYS_RUN, actions = listOf(action))))
+        val monitor = randomQueryLevelMonitor(triggers = listOf(randomQueryLevelTrigger(condition = ALWAYS_RUN, actions = listOf(action))))
 
         val response = executeMonitor(monitor)
 
@@ -320,8 +320,8 @@ class MonitorRunnerIT : AlertingRestTestCase() {
             return ctx.results[0].hits.hits.size() > 0
         """.trimIndent()
         val destinationId = createDestination().id
-        val trigger = randomTrigger(condition = Script(triggerScript), destinationId = destinationId)
-        val monitor = createMonitor(randomMonitor(inputs = listOf(input), triggers = listOf(trigger)))
+        val trigger = randomQueryLevelTrigger(condition = Script(triggerScript), destinationId = destinationId)
+        val monitor = createMonitor(randomQueryLevelMonitor(inputs = listOf(input), triggers = listOf(trigger)))
 
         val response = executeMonitor(monitor.id)
 
@@ -355,8 +355,8 @@ class MonitorRunnerIT : AlertingRestTestCase() {
             // make sure there is exactly one hit
             return ctx.results[0].hits.hits.size() == 1
         """.trimIndent()
-        val trigger = randomTrigger(condition = Script(triggerScript))
-        val monitor = randomMonitor(inputs = listOf(input), triggers = listOf(trigger))
+        val trigger = randomQueryLevelTrigger(condition = Script(triggerScript))
+        val monitor = randomQueryLevelMonitor(inputs = listOf(input), triggers = listOf(trigger))
 
         val response = executeMonitor(monitor)
 
@@ -397,8 +397,8 @@ class MonitorRunnerIT : AlertingRestTestCase() {
             // make sure there is exactly one hit
             return ctx.results[0].hits.hits.size() == 1
         """.trimIndent()
-        val trigger = randomTrigger(condition = Script(triggerScript))
-        val monitor = randomMonitor(inputs = listOf(input), triggers = listOf(trigger))
+        val trigger = randomQueryLevelTrigger(condition = Script(triggerScript))
+        val monitor = randomQueryLevelMonitor(inputs = listOf(input), triggers = listOf(trigger))
 
         val response = executeMonitor(monitor, params = DRYRUN_MONITOR)
 
@@ -420,7 +420,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
             destinationId = createDestination().id
         )
         val actions = listOf(goodAction, syntaxErrorAction)
-        val monitor = createMonitor(randomMonitor(triggers = listOf(randomTrigger(condition = ALWAYS_RUN, actions = actions))))
+        val monitor = createMonitor(randomQueryLevelMonitor(triggers = listOf(randomQueryLevelTrigger(condition = ALWAYS_RUN, actions = actions))))
 
         val output = entityAsMap(executeMonitor(monitor.id))
 
@@ -447,8 +447,8 @@ class MonitorRunnerIT : AlertingRestTestCase() {
         putAlertMappings() // Required as we do not have a create alert API.
         // This template script has a parsing error to purposefully create an errorMessage during runMonitor
         val action = randomAction(template = randomTemplateScript("Hello {{ctx.monitor.name"))
-        val trigger = randomTrigger(condition = ALWAYS_RUN, actions = listOf(action))
-        val monitor = createMonitor(randomMonitor(triggers = listOf(trigger)))
+        val trigger = randomQueryLevelTrigger(condition = ALWAYS_RUN, actions = listOf(action))
+        val monitor = createMonitor(randomQueryLevelMonitor(triggers = listOf(trigger)))
         val listOfFiveErrorMessages = (1..5).map { i -> AlertError(timestamp = Instant.now(), message = "error message $i") }
         val activeAlert = createAlert(
             randomAlert(monitor).copy(
@@ -473,7 +473,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
 
     fun `test latest error is not lost when alert is completed`() {
         // Creates an active alert the first time it's run and completes it the second time the monitor is run.
-        val trigger = randomTrigger(
+        val trigger = randomQueryLevelTrigger(
             condition = Script(
                 """
             if (ctx.alert == null) {
@@ -484,7 +484,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
                 """.trimIndent()
             )
         )
-        val monitor = createMonitor(randomMonitor(triggers = listOf(trigger)))
+        val monitor = createMonitor(randomQueryLevelMonitor(triggers = listOf(trigger)))
 
         executeMonitor(monitor.id)
         val errorAlert = searchAlerts(monitor).single()
@@ -501,14 +501,14 @@ class MonitorRunnerIT : AlertingRestTestCase() {
 
     fun `test throw script exception`() {
         // Creates an active alert the first time it's run and completes it the second time the monitor is run.
-        val trigger = randomTrigger(
+        val trigger = randomQueryLevelTrigger(
             condition = Script(
                 """
             param[0]; return true
                 """.trimIndent()
             )
         )
-        val monitor = createMonitor(randomMonitor(triggers = listOf(trigger)))
+        val monitor = createMonitor(randomQueryLevelMonitor(triggers = listOf(trigger)))
 
         executeMonitor(monitor.id)
         val errorAlert = searchAlerts(monitor).single()
@@ -524,8 +524,8 @@ class MonitorRunnerIT : AlertingRestTestCase() {
         putAlertMappings() // Required as we do not have a create alert API.
         // This template script has a parsing error to purposefully create an errorMessage during runMonitor
         val action = randomAction(template = randomTemplateScript("Hello {{ctx.monitor.name"))
-        val trigger = randomTrigger(condition = ALWAYS_RUN, actions = listOf(action))
-        val monitor = createMonitor(randomMonitor(triggers = listOf(trigger)))
+        val trigger = randomQueryLevelTrigger(condition = ALWAYS_RUN, actions = listOf(action))
+        val monitor = createMonitor(randomQueryLevelMonitor(triggers = listOf(trigger)))
         val listOfTenErrorMessages = (1..10).map { i -> AlertError(timestamp = Instant.now(), message = "error message $i") }
         val activeAlert = createAlert(
             randomAlert(monitor).copy(
@@ -551,8 +551,8 @@ class MonitorRunnerIT : AlertingRestTestCase() {
     fun `test execute monitor creates alert for trigger with no actions`() {
         putAlertMappings() // Required as we do not have a create alert API.
 
-        val trigger = randomTrigger(condition = ALWAYS_RUN, actions = emptyList(), destinationId = createDestination().id)
-        val monitor = createMonitor(randomMonitor(triggers = listOf(trigger)))
+        val trigger = randomQueryLevelTrigger(condition = ALWAYS_RUN, actions = emptyList(), destinationId = createDestination().id)
+        val monitor = createMonitor(randomQueryLevelMonitor(triggers = listOf(trigger)))
 
         executeMonitor(monitor.id)
 
@@ -563,9 +563,9 @@ class MonitorRunnerIT : AlertingRestTestCase() {
 
     fun `test execute monitor non-dryrun`() {
         val monitor = createMonitor(
-            randomMonitor(
+            randomQueryLevelMonitor(
                 triggers = listOf(
-                    randomTrigger(
+                    randomQueryLevelTrigger(
                         condition = ALWAYS_RUN,
                         actions = listOf(randomAction(destinationId = createDestination().id))
                     )
@@ -583,9 +583,9 @@ class MonitorRunnerIT : AlertingRestTestCase() {
 
     fun `test execute monitor with already active alert`() {
         val monitor = createMonitor(
-            randomMonitor(
+            randomQueryLevelMonitor(
                 triggers = listOf(
-                    randomTrigger(
+                    randomQueryLevelTrigger(
                         condition = ALWAYS_RUN,
                         actions = listOf(randomAction(destinationId = createDestination().id))
                     )
@@ -612,7 +612,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
         putAlertMappings()
 
         val newMonitor = createMonitor(
-            randomMonitor(triggers = listOf(randomTrigger(condition = NEVER_RUN, actions = listOf(randomAction()))))
+            randomQueryLevelMonitor(triggers = listOf(randomQueryLevelTrigger(condition = NEVER_RUN, actions = listOf(randomAction()))))
         )
         val deleteNewMonitorResponse = client().makeRequest("DELETE", "$ALERTING_BASE_URI/${newMonitor.id}")
 
@@ -620,7 +620,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
     }
 
     fun `test update monitor stays on schedule`() {
-        val monitor = createMonitor(randomMonitor(enabled = true))
+        val monitor = createMonitor(randomQueryLevelMonitor(enabled = true))
 
         updateMonitor(monitor.copy(enabledTime = Instant.now()))
 
@@ -629,19 +629,19 @@ class MonitorRunnerIT : AlertingRestTestCase() {
     }
 
     fun `test enabled time by disabling and re-enabling monitor`() {
-        val monitor = createMonitor(randomMonitor(enabled = true))
+        val monitor = createMonitor(randomQueryLevelMonitor(enabled = true))
         assertNotNull("Enabled time is null on a enabled monitor.", getMonitor(monitor.id).enabledTime)
 
-        val disabledMonitor = updateMonitor(randomMonitor(enabled = false).copy(id = monitor.id))
+        val disabledMonitor = updateMonitor(randomQueryLevelMonitor(enabled = false).copy(id = monitor.id))
         assertNull("Enabled time is not null on a disabled monitor.", disabledMonitor.enabledTime)
 
-        val enabledMonitor = updateMonitor(randomMonitor(enabled = true).copy(id = monitor.id))
+        val enabledMonitor = updateMonitor(randomQueryLevelMonitor(enabled = true).copy(id = monitor.id))
         assertNotNull("Enabled time is null on a enabled monitor.", enabledMonitor.enabledTime)
     }
 
     fun `test enabled time by providing enabled time`() {
         val enabledTime = Instant.ofEpochSecond(1538164858L) // This is 2018-09-27 20:00:58 GMT
-        val monitor = createMonitor(randomMonitor(enabled = true, enabledTime = enabledTime))
+        val monitor = createMonitor(randomQueryLevelMonitor(enabled = true, enabledTime = enabledTime))
 
         val retrievedMonitor = getMonitor(monitorId = monitor.id)
         assertTrue("Monitor is not enabled", retrievedMonitor.enabled)
@@ -661,8 +661,8 @@ class MonitorRunnerIT : AlertingRestTestCase() {
         )
         val actions = listOf(actionThrottleEnabled, actionThrottleNotEnabled)
         val monitor = createMonitor(
-            randomMonitor(
-                triggers = listOf(randomTrigger(condition = ALWAYS_RUN, actions = actions)),
+            randomQueryLevelMonitor(
+                triggers = listOf(randomQueryLevelTrigger(condition = ALWAYS_RUN, actions = actions)),
                 schedule = IntervalSchedule(interval = 1, unit = ChronoUnit.MINUTES)
             )
         )
@@ -716,9 +716,9 @@ class MonitorRunnerIT : AlertingRestTestCase() {
             throttleEnabled = true, throttle = Throttle(value = 5, unit = MINUTES)
         )
         val actions = listOf(actionThrottleEnabled)
-        val trigger = randomTrigger(condition = ALWAYS_RUN, actions = actions)
+        val trigger = randomQueryLevelTrigger(condition = ALWAYS_RUN, actions = actions)
         val monitor = createMonitor(
-            randomMonitor(
+            randomQueryLevelMonitor(
                 triggers = listOf(trigger),
                 schedule = IntervalSchedule(interval = 1, unit = ChronoUnit.MINUTES)
             )
@@ -777,8 +777,8 @@ class MonitorRunnerIT : AlertingRestTestCase() {
             )
         )
         val action = randomAction(destinationId = destination.id)
-        val trigger = randomTrigger(condition = ALWAYS_RUN, actions = listOf(action))
-        val monitor = createMonitor(randomMonitor(triggers = listOf(trigger)))
+        val trigger = randomQueryLevelTrigger(condition = ALWAYS_RUN, actions = listOf(action))
+        val monitor = createMonitor(randomQueryLevelMonitor(triggers = listOf(trigger)))
 
         executeMonitor(monitor.id)
 
@@ -803,8 +803,8 @@ class MonitorRunnerIT : AlertingRestTestCase() {
             )
         )
         val action = randomAction(destinationId = destination.id)
-        val trigger = randomTrigger(condition = ALWAYS_RUN, actions = listOf(action))
-        val monitor = createMonitor(randomMonitor(triggers = listOf(trigger)))
+        val trigger = randomQueryLevelTrigger(condition = ALWAYS_RUN, actions = listOf(action))
+        val monitor = createMonitor(randomQueryLevelMonitor(triggers = listOf(trigger)))
         executeMonitor(adminClient(), monitor.id)
 
         val alerts = searchAlerts(monitor)
@@ -832,8 +832,8 @@ class MonitorRunnerIT : AlertingRestTestCase() {
                     )
                 )
                 val action = randomAction(destinationId = destination.id)
-                val trigger = randomTrigger(condition = ALWAYS_RUN, actions = listOf(action))
-                val monitor = createMonitor(randomMonitor(triggers = listOf(trigger)))
+                val trigger = randomQueryLevelTrigger(condition = ALWAYS_RUN, actions = listOf(action))
+                val monitor = createMonitor(randomQueryLevelMonitor(triggers = listOf(trigger)))
                 executeMonitor(adminClient(), monitor.id)
 
                 val alerts = searchAlerts(monitor)

--- a/alerting/src/test/kotlin/org/opensearch/alerting/MonitorTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/MonitorTests.kt
@@ -34,7 +34,7 @@ import java.time.Instant
 class MonitorTests : OpenSearchTestCase() {
 
     fun `test enabled time`() {
-        val monitor = randomMonitor()
+        val monitor = randomQueryLevelMonitor()
         val enabledMonitor = monitor.copy(enabled = true, enabledTime = Instant.now())
         try {
             enabledMonitor.copy(enabled = false)
@@ -52,11 +52,11 @@ class MonitorTests : OpenSearchTestCase() {
     }
 
     fun `test max triggers`() {
-        val monitor = randomMonitor()
+        val monitor = randomQueryLevelMonitor()
 
         val tooManyTriggers = mutableListOf<Trigger>()
         for (i in 0..10) {
-            tooManyTriggers.add(randomTrigger())
+            tooManyTriggers.add(randomQueryLevelTrigger())
         }
 
         try {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/action/AcknowledgeAlertResponseTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/action/AcknowledgeAlertResponseTests.kt
@@ -45,7 +45,7 @@ class AcknowledgeAlertResponseTests : OpenSearchTestCase() {
                 "1234", 0L, 1, "monitor-1234", "test-monitor", 0L, randomUser(),
                 "trigger-14", "test-trigger", Alert.State.ACKNOWLEDGED,
                 Instant.now(), Instant.now(), Instant.now(), Instant.now(), null, ArrayList(),
-                "sev-2", ArrayList()
+                "sev-2", ArrayList(), null
             )
         )
         val failed = mutableListOf(
@@ -53,7 +53,7 @@ class AcknowledgeAlertResponseTests : OpenSearchTestCase() {
                 "1234", 0L, 1, "monitor-1234", "test-monitor", 0L, randomUser(),
                 "trigger-14", "test-trigger", Alert.State.ERROR, Instant.now(), Instant.now(),
                 Instant.now(), Instant.now(), null, mutableListOf(AlertError(Instant.now(), "Error msg")),
-                "sev-2", mutableListOf(ActionExecutionResult("7890", null, 0))
+                "sev-2", mutableListOf(ActionExecutionResult("7890", null, 0)), null
             )
         )
         val missing = mutableListOf("1", "2", "3", "4")

--- a/alerting/src/test/kotlin/org/opensearch/alerting/action/ExecuteMonitorRequestTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/action/ExecuteMonitorRequestTests.kt
@@ -27,7 +27,7 @@
 package org.opensearch.alerting.action
 
 import org.opensearch.alerting.core.model.SearchInput
-import org.opensearch.alerting.randomMonitor
+import org.opensearch.alerting.randomQueryLevelMonitor
 import org.opensearch.common.io.stream.BytesStreamOutput
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.unit.TimeValue
@@ -52,7 +52,7 @@ class ExecuteMonitorRequestTests : OpenSearchTestCase() {
     }
 
     fun `test execute monitor request with monitor`() {
-        val monitor = randomMonitor().copy(inputs = listOf(SearchInput(emptyList(), SearchSourceBuilder())))
+        val monitor = randomQueryLevelMonitor().copy(inputs = listOf(SearchInput(emptyList(), SearchSourceBuilder())))
         val req = ExecuteMonitorRequest(false, TimeValue.timeValueSeconds(100L), null, monitor)
         assertNotNull(req.monitor)
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/action/ExecuteMonitorResponseTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/action/ExecuteMonitorResponseTests.kt
@@ -27,15 +27,29 @@
 package org.opensearch.alerting.action
 
 import org.junit.Assert
-import org.opensearch.alerting.randomMonitorRunResult
+import org.opensearch.alerting.randomBucketLevelMonitorRunResult
+import org.opensearch.alerting.randomQueryLevelMonitorRunResult
 import org.opensearch.common.io.stream.BytesStreamOutput
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.test.OpenSearchTestCase
 
 class ExecuteMonitorResponseTests : OpenSearchTestCase() {
 
-    fun `test exec monitor response`() {
-        val req = ExecuteMonitorResponse(randomMonitorRunResult())
+    fun `test exec query-level monitor response`() {
+        val req = ExecuteMonitorResponse(randomQueryLevelMonitorRunResult())
+        Assert.assertNotNull(req)
+
+        val out = BytesStreamOutput()
+        req.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val newReq = ExecuteMonitorResponse(sin)
+        assertNotNull(newReq.monitorRunResult)
+        assertEquals("test-monitor", newReq.monitorRunResult.monitorName)
+        assertNotNull(newReq.monitorRunResult.inputResults)
+    }
+
+    fun `test exec bucket-level monitor response`() {
+        val req = ExecuteMonitorResponse(randomBucketLevelMonitorRunResult())
         Assert.assertNotNull(req)
 
         val out = BytesStreamOutput()

--- a/alerting/src/test/kotlin/org/opensearch/alerting/action/GetAlertsResponseTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/action/GetAlertsResponseTests.kt
@@ -72,7 +72,8 @@ class GetAlertsResponseTests : OpenSearchTestCase() {
             null,
             Collections.emptyList(),
             "severity",
-            Collections.emptyList()
+            Collections.emptyList(),
+            null
         )
         val req = GetAlertsResponse(listOf(alert), 1)
         assertNotNull(req)
@@ -107,7 +108,8 @@ class GetAlertsResponseTests : OpenSearchTestCase() {
             null,
             Collections.emptyList(),
             "severity",
-            Collections.emptyList()
+            Collections.emptyList(),
+            null
         )
         val req = GetAlertsResponse(listOf(alert), 1)
         var actualXContentString = req.toXContent(builder(), ToXContent.EMPTY_PARAMS).string()

--- a/alerting/src/test/kotlin/org/opensearch/alerting/action/GetMonitorResponseTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/action/GetMonitorResponseTests.kt
@@ -57,13 +57,22 @@ class GetMonitorResponseTests : OpenSearchTestCase() {
         val testInstance = Instant.ofEpochSecond(1538164858L)
 
         val cronSchedule = CronSchedule(cronExpression, ZoneId.of("Asia/Kolkata"), testInstance)
-        val req = GetMonitorResponse(
-            "1234", 1L, 2L, 0L, RestStatus.OK,
-            Monitor(
-                "123", 0L, "test-monitor", true, cronSchedule, Instant.now(),
-                Instant.now(), randomUser(), 0, mutableListOf(), mutableListOf(), mutableMapOf()
-            )
+        val monitor = Monitor(
+            id = "123",
+            version = 0L,
+            name = "test-monitor",
+            enabled = true,
+            schedule = cronSchedule,
+            lastUpdateTime = Instant.now(),
+            enabledTime = Instant.now(),
+            monitorType = Monitor.MonitorType.QUERY_LEVEL_MONITOR,
+            user = randomUser(),
+            schemaVersion = 0,
+            inputs = mutableListOf(),
+            triggers = mutableListOf(),
+            uiMetadata = mutableMapOf()
         )
+        val req = GetMonitorResponse("1234", 1L, 2L, 0L, RestStatus.OK, monitor)
         assertNotNull(req)
 
         val out = BytesStreamOutput()

--- a/alerting/src/test/kotlin/org/opensearch/alerting/action/IndexMonitorRequestTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/action/IndexMonitorRequestTests.kt
@@ -28,7 +28,7 @@ package org.opensearch.alerting.action
 
 import org.opensearch.action.support.WriteRequest
 import org.opensearch.alerting.core.model.SearchInput
-import org.opensearch.alerting.randomMonitor
+import org.opensearch.alerting.randomQueryLevelMonitor
 import org.opensearch.common.io.stream.BytesStreamOutput
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.rest.RestRequest
@@ -41,7 +41,7 @@ class IndexMonitorRequestTests : OpenSearchTestCase() {
 
         val req = IndexMonitorRequest(
             "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.POST,
-            randomMonitor().copy(inputs = listOf(SearchInput(emptyList(), SearchSourceBuilder())))
+            randomQueryLevelMonitor().copy(inputs = listOf(SearchInput(emptyList(), SearchSourceBuilder())))
         )
         assertNotNull(req)
 
@@ -60,7 +60,7 @@ class IndexMonitorRequestTests : OpenSearchTestCase() {
 
         val req = IndexMonitorRequest(
             "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.PUT,
-            randomMonitor().copy(inputs = listOf(SearchInput(emptyList(), SearchSourceBuilder())))
+            randomQueryLevelMonitor().copy(inputs = listOf(SearchInput(emptyList(), SearchSourceBuilder())))
         )
         assertNotNull(req)
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/action/IndexMonitorResponseTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/action/IndexMonitorResponseTests.kt
@@ -43,13 +43,21 @@ class IndexMonitorResponseTests : OpenSearchTestCase() {
         val testInstance = Instant.ofEpochSecond(1538164858L)
 
         val cronSchedule = CronSchedule(cronExpression, ZoneId.of("Asia/Kolkata"), testInstance)
-        val req = IndexMonitorResponse(
-            "1234", 1L, 2L, 0L, RestStatus.OK,
-            Monitor(
-                "123", 0L, "test-monitor", true, cronSchedule, Instant.now(),
-                Instant.now(), randomUser(), 0, mutableListOf(), mutableListOf(), mutableMapOf()
-            )
-        )
+        val monitor = Monitor(
+            id = "123",
+            version = 0L,
+            name = "test-monitor",
+            enabled = true,
+            schedule = cronSchedule,
+            lastUpdateTime = Instant.now(),
+            enabledTime = Instant.now(),
+            monitorType = Monitor.MonitorType.QUERY_LEVEL_MONITOR,
+            user = randomUser(),
+            schemaVersion = 0,
+            inputs = mutableListOf(),
+            triggers = mutableListOf(),
+            uiMetadata = mutableMapOf())
+        val req = IndexMonitorResponse("1234", 1L, 2L, 0L, RestStatus.OK, monitor)
         assertNotNull(req)
 
         val out = BytesStreamOutput()

--- a/alerting/src/test/kotlin/org/opensearch/alerting/model/AlertTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/model/AlertTests.kt
@@ -26,7 +26,9 @@
 
 package org.opensearch.alerting.model
 
+import org.junit.Assert
 import org.opensearch.alerting.randomAlert
+import org.opensearch.alerting.randomAlertWithAggregationResultBucket
 import org.opensearch.test.OpenSearchTestCase
 
 class AlertTests : OpenSearchTestCase() {
@@ -44,6 +46,26 @@ class AlertTests : OpenSearchTestCase() {
         assertEquals("Template args start time does not", templateArgs[Alert.START_TIME_FIELD], alert.startTime.toEpochMilli())
         assertEquals("Template args last notification time does not match", templateArgs[Alert.LAST_NOTIFICATION_TIME_FIELD], null)
         assertEquals("Template args severity does not match", templateArgs[Alert.SEVERITY_FIELD], alert.severity)
+    }
+
+    fun `test agg alert as template args`() {
+        val alert = randomAlertWithAggregationResultBucket().copy(acknowledgedTime = null, lastNotificationTime = null)
+
+        val templateArgs = alert.asTemplateArg()
+
+        assertEquals("Template args id does not match", templateArgs[Alert.ALERT_ID_FIELD], alert.id)
+        assertEquals("Template args version does not match", templateArgs[Alert.ALERT_VERSION_FIELD], alert.version)
+        assertEquals("Template args state does not match", templateArgs[Alert.STATE_FIELD], alert.state.toString())
+        assertEquals("Template args error message does not match", templateArgs[Alert.ERROR_MESSAGE_FIELD], alert.errorMessage)
+        assertEquals("Template args acknowledged time does not match", templateArgs[Alert.ACKNOWLEDGED_TIME_FIELD], null)
+        assertEquals("Template args end time does not", templateArgs[Alert.END_TIME_FIELD], alert.endTime?.toEpochMilli())
+        assertEquals("Template args start time does not", templateArgs[Alert.START_TIME_FIELD], alert.startTime.toEpochMilli())
+        assertEquals("Template args last notification time does not match", templateArgs[Alert.LAST_NOTIFICATION_TIME_FIELD], null)
+        assertEquals("Template args severity does not match", templateArgs[Alert.SEVERITY_FIELD], alert.severity)
+        Assert.assertEquals("Template args bucketKeys do not match",
+            templateArgs[Alert.BUCKET_KEYS], alert.aggregationResultBucket?.bucketKeys?.joinToString(","))
+        Assert.assertEquals("Template args parentBucketPath does not match",
+            templateArgs[Alert.PARENTS_BUCKET_PATH], alert.aggregationResultBucket?.parentBucketPath)
     }
 
     fun `test alert acknowledged`() {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/model/WriteableTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/model/WriteableTests.kt
@@ -28,19 +28,24 @@ package org.opensearch.alerting.model
 
 import org.opensearch.alerting.core.model.SearchInput
 import org.opensearch.alerting.model.action.Action
+import org.opensearch.alerting.model.action.ActionExecutionPolicy
 import org.opensearch.alerting.model.action.Throttle
 import org.opensearch.alerting.model.destination.email.EmailAccount
 import org.opensearch.alerting.model.destination.email.EmailGroup
 import org.opensearch.alerting.randomAction
+import org.opensearch.alerting.randomActionExecutionPolicy
 import org.opensearch.alerting.randomActionRunResult
+import org.opensearch.alerting.randomBucketLevelMonitorRunResult
+import org.opensearch.alerting.randomBucketLevelTrigger
+import org.opensearch.alerting.randomBucketLevelTriggerRunResult
 import org.opensearch.alerting.randomEmailAccount
 import org.opensearch.alerting.randomEmailGroup
 import org.opensearch.alerting.randomInputRunResults
-import org.opensearch.alerting.randomMonitor
-import org.opensearch.alerting.randomMonitorRunResult
+import org.opensearch.alerting.randomQueryLevelMonitor
+import org.opensearch.alerting.randomQueryLevelMonitorRunResult
 import org.opensearch.alerting.randomThrottle
-import org.opensearch.alerting.randomTrigger
-import org.opensearch.alerting.randomTriggerRunResult
+import org.opensearch.alerting.randomQueryLevelTrigger
+import org.opensearch.alerting.randomQueryLevelTriggerRunResult
 import org.opensearch.alerting.randomUser
 import org.opensearch.alerting.randomUserEmpty
 import org.opensearch.common.io.stream.BytesStreamOutput
@@ -96,22 +101,31 @@ class WriteableTests : OpenSearchTestCase() {
         assertEquals("Round tripping Action doesn't work", action, newAction)
     }
 
-    fun `test monitor as stream`() {
-        val monitor = randomMonitor().copy(inputs = listOf(SearchInput(emptyList(), SearchSourceBuilder())))
+    fun `test query-level monitor as stream`() {
+        val monitor = randomQueryLevelMonitor().copy(inputs = listOf(SearchInput(emptyList(), SearchSourceBuilder())))
         val out = BytesStreamOutput()
         monitor.writeTo(out)
         val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
         val newMonitor = Monitor(sin)
-        assertEquals("Round tripping Monitor doesn't work", monitor, newMonitor)
+        assertEquals("Round tripping QueryLevelMonitor doesn't work", monitor, newMonitor)
     }
 
-    fun `test trigger as stream`() {
-        val trigger = randomTrigger()
+    fun `test query-level trigger as stream`() {
+        val trigger = randomQueryLevelTrigger()
         val out = BytesStreamOutput()
         trigger.writeTo(out)
         val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
-        val newTrigger = Trigger(sin)
-        assertEquals("Round tripping Trigger doesn't work", trigger, newTrigger)
+        val newTrigger = QueryLevelTrigger.readFrom(sin)
+        assertEquals("Round tripping QueryLevelTrigger doesn't work", trigger, newTrigger)
+    }
+
+    fun `test bucket-level trigger as stream`() {
+        val trigger = randomBucketLevelTrigger()
+        val out = BytesStreamOutput()
+        trigger.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val newTrigger = BucketLevelTrigger.readFrom(sin)
+        assertEquals("Round tripping BucketLevelTrigger doesn't work", trigger, newTrigger)
     }
 
     fun `test actionrunresult as stream`() {
@@ -123,12 +137,21 @@ class WriteableTests : OpenSearchTestCase() {
         assertEquals("Round tripping ActionRunResult doesn't work", actionRunResult, newActionRunResult)
     }
 
-    fun `test triggerrunresult as stream`() {
-        val runResult = randomTriggerRunResult()
+    fun `test query-level triggerrunresult as stream`() {
+        val runResult = randomQueryLevelTriggerRunResult()
         val out = BytesStreamOutput()
         runResult.writeTo(out)
         val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
-        val newRunResult = TriggerRunResult(sin)
+        val newRunResult = QueryLevelTriggerRunResult(sin)
+        assertEquals("Round tripping ActionRunResult doesn't work", runResult, newRunResult)
+    }
+
+    fun `test bucket-level triggerrunresult as stream`() {
+        val runResult = randomBucketLevelTriggerRunResult()
+        val out = BytesStreamOutput()
+        runResult.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val newRunResult = BucketLevelTriggerRunResult(sin)
         assertEquals("Round tripping ActionRunResult doesn't work", runResult, newRunResult)
     }
 
@@ -141,12 +164,21 @@ class WriteableTests : OpenSearchTestCase() {
         assertEquals("Round tripping InputRunResults doesn't work", runResult, newRunResult)
     }
 
-    fun `test monitorrunresult as stream`() {
-        val runResult = randomMonitorRunResult()
+    fun `test query-level monitorrunresult as stream`() {
+        val runResult = randomQueryLevelMonitorRunResult()
         val out = BytesStreamOutput()
         runResult.writeTo(out)
         val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
-        val newRunResult = MonitorRunResult(sin)
+        val newRunResult = MonitorRunResult<QueryLevelTriggerRunResult>(sin)
+        assertEquals("Round tripping MonitorRunResult doesn't work", runResult, newRunResult)
+    }
+
+    fun `test bucket-level monitorrunresult as stream`() {
+        val runResult = randomBucketLevelMonitorRunResult()
+        val out = BytesStreamOutput()
+        runResult.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val newRunResult = MonitorRunResult<BucketLevelTriggerRunResult>(sin)
         assertEquals("Round tripping MonitorRunResult doesn't work", runResult, newRunResult)
     }
 
@@ -193,5 +225,14 @@ class WriteableTests : OpenSearchTestCase() {
         val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
         val newEmailGroup = EmailGroup.readFrom(sin)
         assertEquals("Round tripping EmailGroup doesn't work", emailGroup, newEmailGroup)
+    }
+
+    fun `test action execution policy as stream`() {
+        val actionExecutionPolicy = randomActionExecutionPolicy()
+        val out = BytesStreamOutput()
+        actionExecutionPolicy.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val newActionExecutionPolicy = ActionExecutionPolicy.readFrom(sin)
+        assertEquals("Round tripping ActionExecutionPolicy doesn't work", actionExecutionPolicy, newActionExecutionPolicy)
     }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/model/XContentTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/model/XContentTests.kt
@@ -27,26 +27,33 @@
 package org.opensearch.alerting.model
 
 import org.opensearch.alerting.builder
+import org.opensearch.alerting.core.model.SearchInput
 import org.opensearch.alerting.elasticapi.string
 import org.opensearch.alerting.model.action.Action
+import org.opensearch.alerting.model.action.ActionExecutionPolicy
 import org.opensearch.alerting.model.action.Throttle
 import org.opensearch.alerting.model.destination.email.EmailAccount
 import org.opensearch.alerting.model.destination.email.EmailGroup
 import org.opensearch.alerting.parser
 import org.opensearch.alerting.randomAction
+import org.opensearch.alerting.randomActionExecutionPolicy
 import org.opensearch.alerting.randomActionExecutionResult
 import org.opensearch.alerting.randomAlert
+import org.opensearch.alerting.randomBucketLevelMonitor
+import org.opensearch.alerting.randomBucketLevelTrigger
 import org.opensearch.alerting.randomEmailAccount
 import org.opensearch.alerting.randomEmailGroup
-import org.opensearch.alerting.randomMonitor
-import org.opensearch.alerting.randomMonitorWithoutUser
+import org.opensearch.alerting.randomQueryLevelMonitor
+import org.opensearch.alerting.randomQueryLevelMonitorWithoutUser
 import org.opensearch.alerting.randomThrottle
-import org.opensearch.alerting.randomTrigger
+import org.opensearch.alerting.randomQueryLevelTrigger
 import org.opensearch.alerting.randomUser
 import org.opensearch.alerting.randomUserEmpty
 import org.opensearch.alerting.toJsonString
 import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.commons.authuser.User
+import org.opensearch.index.query.QueryBuilders
+import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.test.OpenSearchTestCase
 import kotlin.test.assertFailsWith
 
@@ -56,29 +63,28 @@ class XContentTests : OpenSearchTestCase() {
         val action = randomAction()
         val actionString = action.toXContent(builder(), ToXContent.EMPTY_PARAMS).string()
         val parsedAction = Action.parse(parser(actionString))
-        assertEquals("Round tripping Monitor doesn't work", action, parsedAction)
+        assertEquals("Round tripping Action doesn't work", action, parsedAction)
     }
 
     fun `test action parsing with null subject template`() {
         val action = randomAction().copy(subjectTemplate = null)
         val actionString = action.toXContent(builder(), ToXContent.EMPTY_PARAMS).string()
         val parsedAction = Action.parse(parser(actionString))
-        assertEquals("Round tripping Monitor doesn't work", action, parsedAction)
+        assertEquals("Round tripping Action doesn't work", action, parsedAction)
     }
 
     fun `test action parsing with null throttle`() {
         val action = randomAction().copy(throttle = null)
         val actionString = action.toXContent(builder(), ToXContent.EMPTY_PARAMS).string()
         val parsedAction = Action.parse(parser(actionString))
-        assertEquals("Round tripping Monitor doesn't work", action, parsedAction)
+        assertEquals("Round tripping Action doesn't work", action, parsedAction)
     }
 
     fun `test action parsing with throttled enabled and null throttle`() {
         val action = randomAction().copy(throttle = null).copy(throttleEnabled = true)
         val actionString = action.toXContent(builder(), ToXContent.EMPTY_PARAMS).string()
         assertFailsWith<IllegalArgumentException>("Action throttle enabled but not set throttle value") {
-            Action.parse(parser(actionString))
-        }
+            Action.parse(parser(actionString)) }
     }
 
     fun `test throttle parsing`() {
@@ -103,21 +109,30 @@ class XContentTests : OpenSearchTestCase() {
         assertFailsWith<IllegalArgumentException>("Can only set positive throttle period") { Throttle.parse(parser(throttleString)) }
     }
 
-    fun `test monitor parsing`() {
-        val monitor = randomMonitor()
+    fun `test query-level monitor parsing`() {
+        val monitor = randomQueryLevelMonitor()
 
         val monitorString = monitor.toJsonString()
         val parsedMonitor = Monitor.parse(parser(monitorString))
-        assertEquals("Round tripping Monitor doesn't work", monitor, parsedMonitor)
+        assertEquals("Round tripping QueryLevelMonitor doesn't work", monitor, parsedMonitor)
     }
 
-    fun `test trigger parsing`() {
-        val trigger = randomTrigger()
+    fun `test query-level trigger parsing`() {
+        val trigger = randomQueryLevelTrigger()
 
         val triggerString = trigger.toXContent(builder(), ToXContent.EMPTY_PARAMS).string()
         val parsedTrigger = Trigger.parse(parser(triggerString))
 
-        assertEquals("Round tripping Trigger doesn't work", trigger, parsedTrigger)
+        assertEquals("Round tripping QueryLevelTrigger doesn't work", trigger, parsedTrigger)
+    }
+
+    fun `test bucket-level trigger parsing`() {
+        val trigger = randomBucketLevelTrigger()
+
+        val triggerString = trigger.toXContent(builder(), ToXContent.EMPTY_PARAMS).string()
+        val parsedTrigger = Trigger.parse(parser(triggerString))
+
+        assertEquals("Round tripping BucketLevelTrigger doesn't work", trigger, parsedTrigger)
     }
 
     fun `test alert parsing`() {
@@ -162,8 +177,8 @@ class XContentTests : OpenSearchTestCase() {
 
     fun `test creating a monitor with duplicate trigger ids fails`() {
         try {
-            val repeatedTrigger = randomTrigger()
-            randomMonitor().copy(triggers = listOf(repeatedTrigger, repeatedTrigger))
+            val repeatedTrigger = randomQueryLevelTrigger()
+            randomQueryLevelMonitor().copy(triggers = listOf(repeatedTrigger, repeatedTrigger))
             fail("Creating a monitor with duplicate triggers did not fail.")
         } catch (ignored: IllegalArgumentException) {
         }
@@ -186,12 +201,12 @@ class XContentTests : OpenSearchTestCase() {
         assertEquals(0, parsedUser.roles.size)
     }
 
-    fun `test monitor parsing without user`() {
-        val monitor = randomMonitorWithoutUser()
+    fun `test query-level monitor parsing without user`() {
+        val monitor = randomQueryLevelMonitorWithoutUser()
 
         val monitorString = monitor.toJsonString()
         val parsedMonitor = Monitor.parse(parser(monitorString))
-        assertEquals("Round tripping Monitor doesn't work", monitor, parsedMonitor)
+        assertEquals("Round tripping QueryLevelMonitor doesn't work", monitor, parsedMonitor)
         assertNull(parsedMonitor.user)
     }
 
@@ -209,5 +224,128 @@ class XContentTests : OpenSearchTestCase() {
         val emailGroupString = emailGroup.toJsonString()
         val parsedEmailGroup = EmailGroup.parse(parser(emailGroupString))
         assertEquals("Round tripping EmailGroup doesn't work", emailGroup, parsedEmailGroup)
+    }
+
+    fun `test old monitor format parsing`() {
+        val monitorString = """
+            {
+              "type": "monitor",
+              "schema_version": 3,
+              "name": "asdf",
+              "user": {
+                "name": "admin123",
+                "backend_roles": [],
+                "roles": [
+                  "all_access",
+                  "security_manager"
+                ],
+                "custom_attribute_names": [],
+                "user_requested_tenant": null
+              },
+              "enabled": true,
+              "enabled_time": 1613530078244,
+              "schedule": {
+                "period": {
+                  "interval": 1,
+                  "unit": "MINUTES"
+                }
+              },
+              "inputs": [
+                {
+                  "search": {
+                    "indices": [
+                      "test_index"
+                    ],
+                    "query": {
+                      "size": 0,
+                      "query": {
+                        "bool": {
+                          "filter": [
+                            {
+                              "range": {
+                                "order_date": {
+                                  "from": "{{period_end}}||-1h",
+                                  "to": "{{period_end}}",
+                                  "include_lower": true,
+                                  "include_upper": true,
+                                  "format": "epoch_millis",
+                                  "boost": 1.0
+                                }
+                              }
+                            }
+                          ],
+                          "adjust_pure_negative": true,
+                          "boost": 1.0
+                        }
+                      },
+                      "aggregations": {}
+                    }
+                  }
+                }
+              ],
+              "triggers": [
+                {
+                  "id": "e_sc0XcB98Q42rHjTh4K",
+                  "name": "abc",
+                  "severity": "1",
+                  "condition": {
+                    "script": {
+                      "source": "ctx.results[0].hits.total.value > 100000",
+                      "lang": "painless"
+                    }
+                  },
+                  "actions": []
+                }
+              ],
+              "last_update_time": 1614121489719
+            }
+        """.trimIndent()
+        val parsedMonitor = Monitor.parse(parser(monitorString))
+        assertEquals("Incorrect monitor type", Monitor.MonitorType.QUERY_LEVEL_MONITOR, parsedMonitor.monitorType)
+        assertEquals("Incorrect trigger count", 1, parsedMonitor.triggers.size)
+        val trigger = parsedMonitor.triggers.first()
+        assertTrue("Incorrect trigger type", trigger is QueryLevelTrigger)
+        assertEquals("Incorrect name for parsed trigger", "abc", trigger.name)
+    }
+
+    fun `test creating an query-level monitor with invalid trigger type fails`() {
+        try {
+            val bucketLevelTrigger = randomBucketLevelTrigger()
+            randomQueryLevelMonitor().copy(triggers = listOf(bucketLevelTrigger))
+            fail("Creating a query-level monitor with bucket-level triggers did not fail.")
+        } catch (ignored: IllegalArgumentException) {
+        }
+    }
+
+    fun `test creating an bucket-level monitor with invalid trigger type fails`() {
+        try {
+            val queryLevelTrigger = randomQueryLevelTrigger()
+            randomBucketLevelMonitor().copy(triggers = listOf(queryLevelTrigger))
+            fail("Creating a bucket-level monitor with query-level triggers did not fail.")
+        } catch (ignored: IllegalArgumentException) {
+        }
+    }
+
+    fun `test creating an bucket-level monitor with invalid input fails`() {
+        try {
+            val invalidInput = SearchInput(emptyList(), SearchSourceBuilder().query(QueryBuilders.matchAllQuery()))
+            randomBucketLevelMonitor().copy(inputs = listOf(invalidInput))
+            fail("Creating an bucket-level monitor with an invalid input did not fail.")
+        } catch (ignored: IllegalArgumentException) {
+        }
+    }
+
+    fun `test action execution policy`() {
+        val actionExecutionPolicy = randomActionExecutionPolicy()
+        val actionExecutionPolicyString = actionExecutionPolicy.toXContent(builder(), ToXContent.EMPTY_PARAMS).string()
+        val parsedActionExecutionPolicy = ActionExecutionPolicy.parse(parser(actionExecutionPolicyString))
+        assertEquals("Round tripping ActionExecutionPolicy doesn't work", actionExecutionPolicy, parsedActionExecutionPolicy)
+    }
+
+    fun `test action execution policy with null throttle`() {
+        val actionExecutionPolicy = randomActionExecutionPolicy().copy(throttle = null)
+        val actionExecutionPolicyString = actionExecutionPolicy.toXContent(builder(), ToXContent.EMPTY_PARAMS).string()
+        val parsedActionExecutionPolicy = ActionExecutionPolicy.parse(parser(actionExecutionPolicyString))
+        assertEquals("Round tripping ActionExecutionPolicy doesn't work", actionExecutionPolicy, parsedActionExecutionPolicy)
     }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -24,9 +24,9 @@ import org.opensearch.alerting.makeRequest
 import org.opensearch.alerting.model.Alert
 import org.opensearch.alerting.randomAction
 import org.opensearch.alerting.randomAlert
-import org.opensearch.alerting.randomMonitor
+import org.opensearch.alerting.randomQueryLevelMonitor
 import org.opensearch.alerting.randomTemplateScript
-import org.opensearch.alerting.randomTrigger
+import org.opensearch.alerting.randomQueryLevelTrigger
 import org.opensearch.client.Response
 import org.opensearch.client.ResponseException
 import org.opensearch.client.RestClient
@@ -72,7 +72,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         createUserRolesMapping("alerting_full_access", arrayOf(user))
         try {
             // randomMonitor has a dummy user, api ignores the User passed as part of monitor, it picks user info from the logged-in user.
-            val monitor = randomMonitor().copy(
+            val monitor = randomQueryLevelMonitor().copy(
                 inputs = listOf(
                     SearchInput(
                         indices = listOf("hr_data"), query = SearchSourceBuilder().query(QueryBuilders.matchAllQuery())
@@ -106,7 +106,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
 
         createUserWithTestData(user, "hr_data", "hr_role", "HR")
         try {
-            val monitor = randomMonitor().copy(
+            val monitor = randomQueryLevelMonitor().copy(
                 inputs = listOf(
                     SearchInput(
                         indices = listOf("hr_data"), query = SearchSourceBuilder().query(QueryBuilders.matchAllQuery())
@@ -129,7 +129,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         createUserWithTestData(user, "hr_data", "hr_role", "HR")
         createUserRolesMapping("alerting_full_access", arrayOf(user))
         try {
-            val monitor = randomMonitor().copy(
+            val monitor = randomQueryLevelMonitor().copy(
                 inputs = listOf(
                     SearchInput(
                         indices = listOf("not_hr_data"), query = SearchSourceBuilder().query(QueryBuilders.matchAllQuery())
@@ -150,14 +150,14 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
 
     fun `test create monitor with disable filter by`() {
         disableFilterBy()
-        val monitor = randomMonitor()
+        val monitor = randomQueryLevelMonitor()
         val createResponse = client().makeRequest("POST", ALERTING_BASE_URI, emptyMap(), monitor.toHttpEntity())
         assertEquals("Create monitor failed", RestStatus.CREATED, createResponse.restStatus())
     }
 
     fun `test create monitor with enable filter by`() {
         enableFilterBy()
-        val monitor = randomMonitor()
+        val monitor = randomQueryLevelMonitor()
 
         if (securityEnabled()) {
             // when security is enabled. No errors, must succeed.
@@ -185,7 +185,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
     // Query Monitors related security tests
     fun `test update monitor with disable filter by`() {
         disableFilterBy()
-        val monitor = randomMonitor(enabled = true)
+        val monitor = randomQueryLevelMonitor(enabled = true)
 
         val createdMonitor = createMonitor(monitor = monitor)
 
@@ -205,7 +205,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             // refer: `test create monitor with enable filter by`
             return
         }
-        val monitor = randomMonitor(enabled = true)
+        val monitor = randomQueryLevelMonitor(enabled = true)
 
         val createdMonitor = createMonitor(monitor = monitor)
 
@@ -220,7 +220,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
 
     fun `test delete monitor with disable filter by`() {
         disableFilterBy()
-        val monitor = randomMonitor(enabled = true)
+        val monitor = randomQueryLevelMonitor(enabled = true)
 
         val createdMonitor = createMonitor(monitor = monitor)
 
@@ -254,7 +254,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             // refer: `test create monitor with enable filter by`
             return
         }
-        val monitor = randomMonitor(enabled = true)
+        val monitor = randomQueryLevelMonitor(enabled = true)
 
         val createdMonitor = createMonitor(monitor = monitor)
 
@@ -463,7 +463,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
                 query = SearchSourceBuilder().query(QueryBuilders.matchAllQuery())
             )
         )
-        val monitor = randomMonitor(triggers = listOf(randomTrigger(condition = ALWAYS_RUN, actions = listOf(action))), inputs = inputs)
+        val monitor = randomQueryLevelMonitor(triggers = listOf(randomQueryLevelTrigger(condition = ALWAYS_RUN, actions = listOf(action))), inputs = inputs)
 
         // Make sure the elevating the permissions fails execute.
         val adminUser = User("admin", listOf("admin"), listOf("all_access"), listOf())

--- a/alerting/src/test/kotlin/org/opensearch/alerting/util/AnomalyDetectionUtilsTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/util/AnomalyDetectionUtilsTests.kt
@@ -29,7 +29,7 @@ package org.opensearch.alerting.util
 import org.opensearch.alerting.ANOMALY_RESULT_INDEX
 import org.opensearch.alerting.core.model.Input
 import org.opensearch.alerting.core.model.SearchInput
-import org.opensearch.alerting.randomMonitor
+import org.opensearch.alerting.randomQueryLevelMonitor
 import org.opensearch.common.io.stream.StreamOutput
 import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentBuilder
@@ -41,7 +41,7 @@ import org.opensearch.test.OpenSearchTestCase
 class AnomalyDetectionUtilsTests : OpenSearchTestCase() {
 
     fun `test is ad monitor`() {
-        val monitor = randomMonitor(
+        val monitor = randomQueryLevelMonitor(
             inputs = listOf(
                 SearchInput(
                     listOf(ANOMALY_RESULT_INDEX),
@@ -54,14 +54,14 @@ class AnomalyDetectionUtilsTests : OpenSearchTestCase() {
 
     fun `test not ad monitor if monitor have no inputs`() {
 
-        val monitor = randomMonitor(
+        val monitor = randomQueryLevelMonitor(
             inputs = listOf()
         )
         assertFalse(isADMonitor(monitor))
     }
 
     fun `test not ad monitor if monitor input is not search input`() {
-        val monitor = randomMonitor(
+        val monitor = randomQueryLevelMonitor(
             inputs = listOf(object : Input {
                 override fun name(): String {
                     TODO("Not yet implemented")
@@ -80,7 +80,7 @@ class AnomalyDetectionUtilsTests : OpenSearchTestCase() {
     }
 
     fun `test not ad monitor if monitor input has more than 1 indices`() {
-        val monitor = randomMonitor(
+        val monitor = randomQueryLevelMonitor(
             inputs = listOf(
                 SearchInput(
                     listOf(randomAlphaOfLength(5), randomAlphaOfLength(5)),
@@ -92,7 +92,7 @@ class AnomalyDetectionUtilsTests : OpenSearchTestCase() {
     }
 
     fun `test not ad monitor if monitor input's index name is not AD result index`() {
-        val monitor = randomMonitor(
+        val monitor = randomQueryLevelMonitor(
             inputs = listOf(SearchInput(listOf(randomAlphaOfLength(5)), SearchSourceBuilder().query(QueryBuilders.matchAllQuery())))
         )
         assertFalse(isADMonitor(monitor))

--- a/core/src/main/resources/mappings/scheduled-jobs.json
+++ b/core/src/main/resources/mappings/scheduled-jobs.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 3
+    "schema_version": 4
   },
   "properties": {
     "monitor": {
@@ -17,6 +17,9 @@
               "ignore_above": 256
             }
           }
+        },
+        "monitor_type": {
+          "type": "keyword"
         },
         "user": {
           "properties": {
@@ -115,6 +118,15 @@
             }
           }
         },
+        "group_by_fields": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
         "triggers": {
           "type": "nested",
           "properties": {
@@ -167,6 +179,64 @@
                     },
                     "unit": {
                       "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
+            "query_level_trigger": {
+              "properties": {
+                "name": {
+                  "type": "text",
+                  "fields": {
+                    "keyword": {
+                      "type": "keyword",
+                      "ignore_above": 256
+                    }
+                  }
+                },
+                "min_time_between_executions": {
+                  "type": "integer"
+                },
+                "condition": {
+                  "type": "object",
+                  "enabled": false
+                },
+                "actions": {
+                  "type": "nested",
+                  "properties": {
+                    "name": {
+                      "type": "text",
+                      "fields": {
+                        "keyword": {
+                          "type": "keyword",
+                          "ignore_above": 256
+                        }
+                      }
+                    },
+                    "destination_id": {
+                      "type": "keyword"
+                    },
+                    "subject_template": {
+                      "type": "object",
+                      "enabled": false
+                    },
+                    "message_template": {
+                      "type": "object",
+                      "enabled": false
+                    },
+                    "throttle_enabled": {
+                      "type": "boolean"
+                    },
+                    "throttle": {
+                      "properties": {
+                        "value": {
+                          "type": "integer"
+                        },
+                        "unit": {
+                          "type": "keyword"
+                        }
+                      }
                     }
                   }
                 }


### PR DESCRIPTION
…el Monitors

Signed-off-by: Mohammad Qureshi <qreshi@amazon.com>

*Issue #, if available:*

*Description of changes:*
* Updates Monitor to have `monitor_type`
* Refactors Trigger into an interface
* Add Query-Level Trigger and Bucket-Level Trigger which extend the Trigger interface
* Update run result (MonitorRunResult, TriggerRunResult, etc.) and context classes (TriggerContext, etc.) to work with the difference in execution/results in Query-Level and Bucket-Level Monitors
* Update tests

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).