### PR TITLE
Execute Actions on runTrigger exceptions for Bucket-Level Monitor

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/TriggerService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/TriggerService.kt
@@ -88,8 +88,7 @@ class TriggerService(val scriptService: ScriptService) {
             }
             BucketLevelTriggerRunResult(trigger.name, null, selectedBuckets)
         } catch (e: Exception) {
-            logger.info("Error running script for monitor ${monitor.id}, trigger: ${trigger.id}", e)
-            // TODO empty map here with error should be treated in the same way as QueryLevelTrigger with error running script
+            logger.info("Error running trigger [${trigger.id}] for monitor [${monitor.id}]", e)
             BucketLevelTriggerRunResult(trigger.name, e, emptyMap())
         }
     }


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <qreshi@amazon.com>

*Issue #, if available:*

*Description of changes:*
During a Bucket-Level Monitor execution, if we encounter exceptions at the Trigger level, we will skip categorization of Alerts for that Trigger but still execute the Actions (using `PER_EXECUTION` scope to avoid spam) so that `ctx.error` can be populated and propagate the issue to the user.

Also, in the case of a MonitorResult error (which is a Monitor-level failure) we will still enter the main triggers loop and run each Trigger (which will then fail since the search result probably failed). This is fine for now since it still leads to the categorization of Alerts under each Trigger being skipped and all actions for all Triggers being executed to notify the user. In the future, when the `runBucketLevelMonitor` logic is being refactored, one of the things that will be considered is to restructure the failure modes to short-circuit Monitor failures earlier (for this we might consider adding some type of metadata document that can exist at the Monitor level so Monitor/Trigger errors can be stored separately without having to propagate to individual Alerts or Actions `ctx.error` for them to be visible, which is currently a noisy model).

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).