### PR TITLE
Skip execution of Actions on ACKNOWLEDGED Alerts for Bucket-Level Monitors

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
@@ -402,7 +402,7 @@ object MonitorRunner : JobRunner, CoroutineScope, AbstractLifecycleComponent() {
                  * Note: Index operations can fail for various reasons (such as write blocks on cluster), in such a case, the Actions
                  * will still execute with the Alert information in the ctx but the Alerts may not be visible.
                  */
-                alertService.saveAlerts(dedupedAlerts, retryPolicy)
+                alertService.saveAlerts(dedupedAlerts, retryPolicy, allowUpdatingAcknowledgedAlert = true)
                 newAlerts = alertService.saveNewAlerts(newAlerts, retryPolicy)
 
                 // Store deduped and new Alerts to accumulate across pages
@@ -425,7 +425,11 @@ object MonitorRunner : JobRunner, CoroutineScope, AbstractLifecycleComponent() {
 
         for (trigger in monitor.triggers) {
             val alertsToUpdate = mutableSetOf<Alert>()
-            val dedupedAlerts = nextAlerts[trigger.id]?.get(AlertCategory.DEDUPED) ?: mutableListOf()
+            // Filter ACKNOWLEDGED Alerts from the deduped list so they do not have Actions executed for them.
+            // New Alerts are ignored since they cannot be acknowledged yet.
+            val dedupedAlerts = nextAlerts[trigger.id]?.get(AlertCategory.DEDUPED)
+                ?.filterNot { it.state == Alert.State.ACKNOWLEDGED }
+                ?: mutableListOf()
             val newAlerts = nextAlerts[trigger.id]?.get(AlertCategory.NEW) ?: mutableListOf()
             val completedAlerts = nextAlerts[trigger.id]?.get(AlertCategory.COMPLETED) ?: mutableListOf()
 
@@ -436,7 +440,12 @@ object MonitorRunner : JobRunner, CoroutineScope, AbstractLifecycleComponent() {
                 if (action.getActionScope() == ActionExecutionScope.Type.PER_ALERT) {
                     val perAlertActionFrequency = action.actionExecutionPolicy.actionExecutionScope as PerAlertActionScope
                     for (alertCategory in perAlertActionFrequency.actionableAlerts) {
-                        val alertsToExecuteActionsFor = nextAlerts[trigger.id]?.get(alertCategory) ?: mutableListOf()
+                        var alertsToExecuteActionsFor = nextAlerts[trigger.id]?.get(alertCategory) ?: mutableListOf()
+                        // Filter out ACKNOWLEDGED Alerts from the deduped Alerts
+                        if (alertCategory == AlertCategory.DEDUPED) {
+                            alertsToExecuteActionsFor = alertsToExecuteActionsFor.filterNot { it.state == Alert.State.ACKNOWLEDGED }
+                                .toMutableList()
+                        }
                         for (alert in alertsToExecuteActionsFor) {
                             if (isBucketLevelTriggerActionThrottled(action, alert)) continue
 
@@ -483,7 +492,7 @@ object MonitorRunner : JobRunner, CoroutineScope, AbstractLifecycleComponent() {
                 val bucketKeysHash = alert.aggregationResultBucket!!.getBucketKeysHash()
                 val actionResults = triggerResult.actionResultsMap.getOrDefault(bucketKeysHash, emptyMap<String, ActionRunResult>())
                 alertService.updateActionResultsForBucketLevelAlert(
-                    alert,
+                    alert.copy(lastNotificationTime = currentTime()),
                     actionResults,
                     // TODO: Update BucketLevelTriggerRunResult.alertError() to retrieve error based on the first failed Action
                     monitorResult.alertError() ?: triggerResult.alertError()
@@ -491,7 +500,8 @@ object MonitorRunner : JobRunner, CoroutineScope, AbstractLifecycleComponent() {
             }
 
             // Update Alerts with action execution results
-            alertService.saveAlerts(updatedAlerts, retryPolicy)
+            // ACKNOWLEDGED Alerts should not be saved here since actions are not executed for them
+            alertService.saveAlerts(updatedAlerts, retryPolicy, allowUpdatingAcknowledgedAlert = false)
         }
 
         return monitorResult.copy(triggerResults = triggerResults)


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <qreshi@amazon.com>

*Issue #, if available:*

*Description of changes:*
Filter out Acknowledged Alerts when executing Actions for Bucket-Level Monitors

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).