### PR TITLE
Return first page of input results in MonitorRunResult for Bucket-Level Monitor

### DIFF
--- a/alerting/src/test/kotlin/org/opensearch/alerting/MonitorRunnerIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/MonitorRunnerIT.kt
@@ -976,7 +976,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
     //  The last page (when after_key is null) is empty if all the contents fit on the previous page, meaning the
     //  input results returned by the monitor execution is empty.
     //  Skipping this test for now until this is resolved to show a non-empty result.
-    fun `skip test execute bucket-level monitor returns search result`() {
+    fun `test execute bucket-level monitor returns search result`() {
         val testIndex = createTestIndex()
         insertSampleTimeSerializedData(
             testIndex,


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <qreshi@amazon.com>

*Issue #, if available:*

*Description of changes:*
When iterating over paginated aggregation results (composite aggregations) for Bucket-Level Monitors, the next page of MonitorRunResults are retrieved for each iteration while an `after_key` is present. Whether there are results or not, the final page (the one with `after_key == null`) is empty and since the final state of MonitorRunResult is what is returned by the MonitorRunner for Bucket-Level Monitor execution, it ends up returning an empty result even in the case where there was data which can be misleading. This fixes that bug by returning the first page of results in all cases so if there was data, it is at least reflected in the output.

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).