### PR TITLE
Add setting to limit per alert action executions and don't save Alerts for test Bucket-Level Monitors

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -301,6 +301,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             AlertingSettings.REQUEST_TIMEOUT,
             AlertingSettings.MAX_ACTION_THROTTLE_VALUE,
             AlertingSettings.FILTER_BY_BACKEND_ROLES,
+            AlertingSettings.MAX_ACTIONABLE_ALERT_COUNT,
             LegacyOpenDistroAlertingSettings.INPUT_TIMEOUT,
             LegacyOpenDistroAlertingSettings.INDEX_TIMEOUT,
             LegacyOpenDistroAlertingSettings.BULK_TIMEOUT,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
@@ -38,6 +38,7 @@ class AlertingSettings {
 
         const val MONITOR_MAX_INPUTS = 1
         const val MONITOR_MAX_TRIGGERS = 10
+        const val DEFAULT_MAX_ACTIONABLE_ALERT_COUNT = 50L
 
         val ALERTING_MAX_MONITORS = Setting.intSetting(
             "plugins.alerting.monitor.max_monitors",
@@ -132,6 +133,13 @@ class AlertingSettings {
         val FILTER_BY_BACKEND_ROLES = Setting.boolSetting(
             "plugins.alerting.filter_by_backend_roles",
             LegacyOpenDistroAlertingSettings.FILTER_BY_BACKEND_ROLES,
+            Setting.Property.NodeScope, Setting.Property.Dynamic
+        )
+
+        val MAX_ACTIONABLE_ALERT_COUNT = Setting.longSetting(
+            "plugins.alerting.max_actionable_alert_count",
+            DEFAULT_MAX_ACTIONABLE_ALERT_COUNT,
+            -1L,
             Setting.Property.NodeScope, Setting.Property.Dynamic
         )
     }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/MonitorRunnerIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/MonitorRunnerIT.kt
@@ -972,10 +972,6 @@ class MonitorRunnerIT : AlertingRestTestCase() {
         }
     }
 
-    // TODO: The composite aggregation will paginate through all results during the Bucket-Level Monitor run.
-    //  The last page (when after_key is null) is empty if all the contents fit on the previous page, meaning the
-    //  input results returned by the monitor execution is empty.
-    //  Skipping this test for now until this is resolved to show a non-empty result.
     fun `test execute bucket-level monitor returns search result`() {
         val testIndex = createTestIndex()
         insertSampleTimeSerializedData(
@@ -1058,7 +1054,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
             )
         )
         val monitor = createMonitor(randomBucketLevelMonitor(inputs = listOf(input), enabled = false, triggers = listOf(trigger)))
-        executeMonitor(monitor.id, params = DRYRUN_MONITOR)
+        executeMonitor(monitor.id)
 
         // Check created alerts
         var alerts = searchAlerts(monitor)
@@ -1077,7 +1073,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
         )
 
         // Execute monitor again
-        executeMonitor(monitor.id, params = DRYRUN_MONITOR)
+        executeMonitor(monitor.id)
 
         // Verify expected alert was completed
         alerts = searchAlerts(monitor, AlertIndices.ALL_INDEX_PATTERN)
@@ -1121,7 +1117,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
             )
         )
         val monitor = createMonitor(randomBucketLevelMonitor(inputs = listOf(input), enabled = false, triggers = listOf(trigger)))
-        executeMonitor(monitor.id, params = DRYRUN_MONITOR)
+        executeMonitor(monitor.id)
 
         // Check created Alerts
         var currentAlerts = searchAlerts(monitor)
@@ -1140,7 +1136,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
         // Runner uses ThreadPool.CachedTimeThread thread which only updates once every 200 ms. Wait a bit to
         // let lastNotificationTime change.  W/o this sleep the test can result in a false negative.
         Thread.sleep(200)
-        executeMonitor(monitor.id, params = DRYRUN_MONITOR)
+        executeMonitor(monitor.id)
 
         // Check that the lastNotification time of the acknowledged Alert wasn't updated and the active Alert's was
         currentAlerts = searchAlerts(monitor)
@@ -1160,7 +1156,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
 
         // Execute Monitor and check that both Alerts were updated
         Thread.sleep(200)
-        executeMonitor(monitor.id, params = DRYRUN_MONITOR)
+        executeMonitor(monitor.id)
         currentAlerts = searchAlerts(monitor, AlertIndices.ALL_INDEX_PATTERN)
         val completedAlerts = currentAlerts.filter { it.state == COMPLETED }
         assertEquals("Incorrect number of completed alerts", 2, completedAlerts.size)


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <qreshi@amazon.com>

*Issue #, if available:*

*Description of changes:*
* Adds a setting for max actionable Alerts when using `PER_ALERT` Action execution scope for Bucket-Level Alerting, if this value is exceeded, the Action execution will fallback to `PER_EXECUTION` scope regardless of the Action configuration
* Adds check to skip saving Alerts for test Monitors (similar to what is already done in the Query-Level Monitor execution)

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).