### PR TITLE
Various bug fixes for Bucket-Level Alerting

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -258,7 +258,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             .registerSettings(settings)
             .registerThreadPool(threadPool)
             .registerAlertIndices(alertIndices)
-            .registerInputService(InputService(client, scriptService, xContentRegistry))
+            .registerInputService(InputService(client, scriptService, namedWriteableRegistry, xContentRegistry))
             .registerTriggerService(TriggerService(scriptService))
             .registerAlertService(AlertService(client, xContentRegistry, alertIndices))
             .registerConsumers()

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/AggregationQueryRewriter.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/AggregationQueryRewriter.kt
@@ -31,7 +31,7 @@ class AggregationQueryRewriter {
          * Add the bucket selector conditions for each trigger in input query. It also adds afterKeys from previous result
          * for each trigger.
          */
-        fun rewriteQuery(query: SearchSourceBuilder, prevResult: InputRunResults?, triggers: List<Trigger>) {
+        fun rewriteQuery(query: SearchSourceBuilder, prevResult: InputRunResults?, triggers: List<Trigger>): SearchSourceBuilder {
             triggers.forEach { trigger ->
                 if (trigger is BucketLevelTrigger) {
                     // add bucket selector pipeline aggregation for each trigger in query
@@ -65,6 +65,8 @@ class AggregationQueryRewriter {
                     }
                 }
             }
+
+            return query
         }
 
         /**

--- a/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
@@ -254,7 +254,7 @@ fun randomThrottle(
 
 fun randomActionExecutionPolicy(
     throttle: Throttle = randomThrottle(),
-    actionExecutionScope: ActionExecutionScope = randomActionExecutionFrequency()
+    actionExecutionScope: ActionExecutionScope = randomActionExecutionScope()
 ): ActionExecutionPolicy {
     return if (actionExecutionScope is PerExecutionActionScope) {
         // Return null for throttle when using PerExecutionActionScope since throttling is currently not supported for it
@@ -264,7 +264,7 @@ fun randomActionExecutionPolicy(
     }
 }
 
-fun randomActionExecutionFrequency(): ActionExecutionScope {
+fun randomActionExecutionScope(): ActionExecutionScope {
     return if (randomBoolean()) {
         val alertCategories = AlertCategory.values()
         PerAlertActionScope(actionableAlerts = (1..randomInt(alertCategories.size)).map { alertCategories[it - 1] }.toSet())


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <qreshi@amazon.com>

*Issue #, if available:*

*Description of changes:*
* Fixes bug where throttle response was not being properly reflected when running Action for `PER_ALERT` scope
* Fixes bug where COMPLETED Alerts were not being saved when all the Actions were of `PER_ALERT` scope with the default actionable categories of new and de-duped Alerts
* Fixes bug where rewriting query changes the input on the Monitor directly

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).