### PR TITLE
Resolve default for ActionExecutionPolicy at runtime

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
@@ -58,6 +58,7 @@ import org.opensearch.alerting.model.action.Action.Companion.SUBJECT
 import org.opensearch.alerting.model.action.ActionExecutionScope
 import org.opensearch.alerting.model.action.AlertCategory
 import org.opensearch.alerting.model.action.PerAlertActionScope
+import org.opensearch.alerting.model.action.PerExecutionActionScope
 import org.opensearch.alerting.model.destination.DestinationContextFactory
 import org.opensearch.alerting.script.BucketLevelTriggerExecutionContext
 import org.opensearch.alerting.script.QueryLevelTriggerExecutionContext
@@ -74,7 +75,7 @@ import org.opensearch.alerting.settings.DestinationSettings.Companion.ALLOW_LIST
 import org.opensearch.alerting.settings.DestinationSettings.Companion.HOST_DENY_LIST
 import org.opensearch.alerting.settings.DestinationSettings.Companion.loadDestinationSettings
 import org.opensearch.alerting.settings.LegacyOpenDistroDestinationSettings.Companion.HOST_DENY_LIST_NONE
-import org.opensearch.alerting.util.getActionScope
+import org.opensearch.alerting.util.getActionExecutionPolicy
 import org.opensearch.alerting.util.getBucketKeysHash
 import org.opensearch.alerting.util.getCombinedTriggerRunResult
 import org.opensearch.alerting.util.isADMonitor
@@ -486,9 +487,10 @@ object MonitorRunner : JobRunner, CoroutineScope, AbstractLifecycleComponent() {
                 monitorOrTriggerError = monitorOrTriggerError
             )
             for (action in trigger.actions) {
-                if (action.getActionScope() == ActionExecutionScope.Type.PER_ALERT && !shouldDefaultToPerExecution) {
-                    val perAlertActionScope = action.actionExecutionPolicy.actionExecutionScope as PerAlertActionScope
-                    for (alertCategory in perAlertActionScope.actionableAlerts) {
+                // ActionExecutionPolicy should not be null for Bucket-Level Monitors since it has a default config when not set explicitly
+                val actionExecutionScope = action.getActionExecutionPolicy(monitor)!!.actionExecutionScope
+                if (actionExecutionScope is PerAlertActionScope && !shouldDefaultToPerExecution) {
+                    for (alertCategory in actionExecutionScope.actionableAlerts) {
                         val alertsToExecuteActionsFor = nextAlerts[trigger.id]?.get(alertCategory) ?: mutableListOf()
                         for (alert in alertsToExecuteActionsFor) {
                             val actionCtx = getActionContextForAlertCategory(
@@ -502,11 +504,12 @@ object MonitorRunner : JobRunner, CoroutineScope, AbstractLifecycleComponent() {
 
                             // Keeping the throttled response separate from runAction for now since
                             // throttling is not supported for PER_EXECUTION
-                            val actionResult = if (isBucketLevelTriggerActionThrottled(action, alert)) {
-                                ActionRunResult(action.id, action.name, mapOf(), true, null, null)
-                            } else {
+                            val actionResult = if (isActionActionable(action, alert)) {
                                 runAction(action, actionCtx, dryrun)
+                            } else {
+                                ActionRunResult(action.id, action.name, mapOf(), true, null, null)
                             }
+
                             triggerResult.actionResultsMap[alertBucketKeysHash]?.set(action.id, actionResult)
                             alertsToUpdate.add(alert)
                             // Remove the alert from completedAlertsToUpdate in case it is present there since
@@ -514,7 +517,7 @@ object MonitorRunner : JobRunner, CoroutineScope, AbstractLifecycleComponent() {
                             completedAlertsToUpdate.remove(alert)
                         }
                     }
-                } else if (action.getActionScope() == ActionExecutionScope.Type.PER_EXECUTION || shouldDefaultToPerExecution) {
+                } else if (actionExecutionScope is PerExecutionActionScope || shouldDefaultToPerExecution) {
                     // If all categories of Alerts are empty, there is nothing to message on and we can skip the Action.
                     // If the error is not null, this is disregarded and the Action is executed anyway so the user can be notified.
                     if (monitorOrTriggerError == null && dedupedAlerts.isEmpty() && newAlerts.isEmpty() && completedAlerts.isEmpty()) continue
@@ -636,23 +639,6 @@ object MonitorRunner : JobRunner, CoroutineScope, AbstractLifecycleComponent() {
             return (lastExecutionTime == null || lastExecutionTime.isBefore(throttledTimeBound))
         }
         return true
-    }
-
-    // TODO: Add unit test for this method (or at least cover it in MonitorRunnerIT)
-    // Bucket-Level Monitors use the throttle configurations defined in ActionExecutionPolicy, this method evaluates that configuration.
-    private fun isBucketLevelTriggerActionThrottled(action: Action, alert: Alert): Boolean {
-        if (action.actionExecutionPolicy.throttle == null) return false
-        // TODO: This will need to be updated if throttleEnabled is moved to ActionExecutionPolicy
-        if (action.throttleEnabled) {
-            val result = alert.actionExecutionResults.firstOrNull { r -> r.actionId == action.id }
-            val lastExecutionTime: Instant? = result?.lastExecutionTime
-            val throttledTimeBound = currentTime().minus(
-                action.actionExecutionPolicy.throttle.value.toLong(),
-                action.actionExecutionPolicy.throttle.unit
-            )
-            return !(lastExecutionTime == null || lastExecutionTime.isBefore(throttledTimeBound))
-        }
-        return false
     }
 
     private fun getActionContextForAlertCategory(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/action/ActionExecutionPolicy.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/action/ActionExecutionPolicy.kt
@@ -25,41 +25,23 @@ import java.io.IOException
 /**
  * This class represents the container for various configurations which control Action behavior.
  */
-// TODO: Should throttleEnabled be included in here as well?
 data class ActionExecutionPolicy(
-    val throttle: Throttle? = null,
     val actionExecutionScope: ActionExecutionScope
 ) : Writeable, ToXContentObject {
 
-    init {
-        if (actionExecutionScope is PerExecutionActionScope) {
-            require(throttle == null) { "Throttle is currently not supported for per execution action scope" }
-        }
-    }
-
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this (
-        sin.readOptionalWriteable(::Throttle), // throttle
         ActionExecutionScope.readFrom(sin) // actionExecutionScope
     )
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        val xContentBuilder = builder.startObject()
-        if (throttle != null) {
-            xContentBuilder.field(THROTTLE_FIELD, throttle)
-        }
-        xContentBuilder.field(ACTION_EXECUTION_SCOPE, actionExecutionScope)
-        return xContentBuilder.endObject()
+        builder.startObject()
+            .field(ACTION_EXECUTION_SCOPE, actionExecutionScope)
+        return builder.endObject()
     }
 
     @Throws(IOException::class)
     override fun writeTo(out: StreamOutput) {
-        if (throttle != null) {
-            out.writeBoolean(true)
-            throttle.writeTo(out)
-        } else {
-            out.writeBoolean(false)
-        }
         if (actionExecutionScope is PerAlertActionScope) {
             out.writeEnum(ActionExecutionScope.Type.PER_ALERT)
         } else {
@@ -69,13 +51,11 @@ data class ActionExecutionPolicy(
     }
 
     companion object {
-        const val THROTTLE_FIELD = "throttle"
         const val ACTION_EXECUTION_SCOPE = "action_execution_scope"
 
         @JvmStatic
         @Throws(IOException::class)
         fun parse(xcp: XContentParser): ActionExecutionPolicy {
-            var throttle: Throttle? = null
             lateinit var actionExecutionScope: ActionExecutionScope
 
             ensureExpectedToken(Token.START_OBJECT, xcp.currentToken(), xcp)
@@ -84,15 +64,11 @@ data class ActionExecutionPolicy(
                 xcp.nextToken()
 
                 when (fieldName) {
-                    THROTTLE_FIELD -> {
-                        throttle = if (xcp.currentToken() == Token.VALUE_NULL) null else Throttle.parse(xcp)
-                    }
                     ACTION_EXECUTION_SCOPE -> actionExecutionScope = ActionExecutionScope.parse(xcp)
                 }
             }
 
             return ActionExecutionPolicy(
-                throttle,
                 requireNotNull(actionExecutionScope) { "Action execution scope is null" }
             )
         }
@@ -104,17 +80,16 @@ data class ActionExecutionPolicy(
         }
 
         /**
-         * The default [ActionExecutionPolicy] configuration.
+         * The default [ActionExecutionPolicy] configuration for Bucket-Level Monitors.
          *
-         * This is currently only used by Bucket-Level Monitors and was configured with that in mind.
          * If Query-Level Monitors integrate the use of [ActionExecutionPolicy] then a separate default configuration
-         * might need to be made depending on the desired behavior.
+         * will need to be made depending on the desired behavior.
          */
-        fun getDefaultConfiguration(): ActionExecutionPolicy {
+        fun getDefaultConfigurationForBucketLevelMonitor(): ActionExecutionPolicy {
             val defaultActionExecutionScope = PerAlertActionScope(
                 actionableAlerts = setOf(AlertCategory.DEDUPED, AlertCategory.NEW)
             )
-            return ActionExecutionPolicy(throttle = null, actionExecutionScope = defaultActionExecutionScope)
+            return ActionExecutionPolicy(actionExecutionScope = defaultActionExecutionScope)
         }
     }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/MonitorRunnerIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/MonitorRunnerIT.kt
@@ -1285,10 +1285,10 @@ class MonitorRunnerIT : AlertingRestTestCase() {
             params.docCount > 1
         """.trimIndent()
 
-        val action = randomAction(
+        val action = randomActionWithPolicy(
             template = randomTemplateScript("Hello {{ctx.monitor.name}}"),
             destinationId = createDestination().id,
-            actionExecutionPolicy = ActionExecutionPolicy(null, PerExecutionActionScope())
+            actionExecutionPolicy = ActionExecutionPolicy(PerExecutionActionScope())
         )
         var trigger = randomBucketLevelTrigger(actions = listOf(action))
         trigger = trigger.copy(
@@ -1352,10 +1352,10 @@ class MonitorRunnerIT : AlertingRestTestCase() {
             params.docCount > 1
         """.trimIndent()
 
-        val action = randomAction(
+        val action = randomActionWithPolicy(
             template = randomTemplateScript("Hello {{ctx.monitor.name}}"),
             destinationId = createDestination().id,
-            actionExecutionPolicy = ActionExecutionPolicy(null, PerAlertActionScope(setOf(AlertCategory.DEDUPED, AlertCategory.NEW)))
+            actionExecutionPolicy = ActionExecutionPolicy(PerAlertActionScope(setOf(AlertCategory.DEDUPED, AlertCategory.NEW)))
         )
         var trigger = randomBucketLevelTrigger(actions = listOf(action))
         trigger = trigger.copy(
@@ -1419,21 +1419,21 @@ class MonitorRunnerIT : AlertingRestTestCase() {
             params.docCount > 0
         """.trimIndent()
 
-        val actionThrottleEnabled = randomAction(
+        val actionThrottleEnabled = randomActionWithPolicy(
             template = randomTemplateScript("Hello {{ctx.monitor.name}}"),
             destinationId = createDestination().id,
             throttleEnabled = true,
+            throttle = Throttle(value = 5, unit = MINUTES),
             actionExecutionPolicy = ActionExecutionPolicy(
-                throttle = Throttle(value = 5, unit = MINUTES),
                 actionExecutionScope = PerAlertActionScope(setOf(AlertCategory.DEDUPED, AlertCategory.NEW))
             )
         )
-        val actionThrottleNotEnabled = randomAction(
+        val actionThrottleNotEnabled = randomActionWithPolicy(
             template = randomTemplateScript("Hello {{ctx.monitor.name}}"),
             destinationId = createDestination().id,
             throttleEnabled = false,
+            throttle = Throttle(value = 5, unit = MINUTES),
             actionExecutionPolicy = ActionExecutionPolicy(
-                throttle = Throttle(value = 5, unit = MINUTES),
                 actionExecutionScope = PerAlertActionScope(setOf(AlertCategory.DEDUPED, AlertCategory.NEW))
             )
         )


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <qreshi@amazon.com>

*Issue #, if available:*

*Description of changes:*
Previously, since the `ActionExecutionScope` was required for Bucket-Level Monitor executions, the default configuration was being put into the Action config itself. The problem with this was that Action is Monitor agnostic so it is not aware of the Monitor type it is being defined for. This means that the Action policy default (which is meant for Bucket-Level Monitors) would have been put into every Action defined in Query-Level Monitor if none were explicitly given which could cause backwards compatibility issues if the `ActionExecutionPolicy` integrates with Query-Level Monitors in the future.

To clean up the `ActionExecutionPolicy` behavior, the following changes were made:
* `throttle` was originally added into `ActionExecutionPolicy` with the intention that both `throttle` and `throttleEnabled` would be moved in there since it is considered an Action behavior config but it was moved out since `throttle` and `throttleEnabled` fields already exist outside of this config within the Action (this avoids any inconsistencies and lets us avoid backwards compatibility problems)
* The `ActionExecutionPolicy` is now nullable within the `Action` definition and in the case of Bucket-Level Monitors, it will be resolved to the default if not given during runtime. This gives us the flexibility to default different configurations based on the Monitor types 

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).