### PR TITLE
Update build to use public Maven repo

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -29,28 +29,6 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
 
-      # dependencies: OpenSearch
-      - name: Checkout OpenSearch
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/OpenSearch'
-          path: OpenSearch
-          ref: '1.1'
-      - name: Build OpenSearch
-        working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal
-
-      # dependencies: common-utils
-      - name: Checkout common-utils
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/common-utils'
-          path: common-utils
-          ref: 'main'
-      - name: Build common-utils
-        working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
-
       - name: Build and run with Gradle
         run: ./gradlew build -Dopensearch.version=1.1.0-SNAPSHOT
 

--- a/build-tools/repositories.gradle
+++ b/build-tools/repositories.gradle
@@ -26,6 +26,7 @@
 
 repositories {
     mavenLocal()
+    maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     mavenCentral()
     jcenter()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ buildscript {
 
     repositories {
         mavenLocal()
+        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
         jcenter()


### PR DESCRIPTION
Signed-off-by: Abbas Hussain <abbas_10690@yahoo.com>

*Issue #, if available:*
#183 

*Description of changes:*
Updates build to use public [Maven repo](https://aws.oss.sonatype.org/content/repositories/snapshots) for snapshot builds.

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).