### PR TITLE
Updates testCompile mockito version to match OpenSearch changes

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     implementation "com.github.seancfoley:ipaddress:5.3.3"
 
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
-    testCompile "org.mockito:mockito-core:2.23.0"
+    testCompile "org.mockito:mockito-core:3.12.4"
 }
 
 javadoc.enabled = false // turn off javadoc as it barfs on Kotlin code


### PR DESCRIPTION
Signed-off-by: Clay Downs <downsrob@amazon.com>

*Description of changes:* Alerting builds are failing due to a dependency version mismatch for mockito between OpenSearch and Alerting. [This OpenSearch PR](https://github.com/opensearch-project/OpenSearch/commit/e9635d6bfeade4a50ee75a7c2f86f909481e41c1) introduced the mockito version change.

*CheckList:*
[X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).