### PR TITLE
Fixed a bug that was preventing the AcknowledgeAlerts API from acknowledging more than 10 alerts at once.

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
@@ -75,7 +75,13 @@ class TransportAcknowledgeAlertAction @Inject constructor(
             val searchRequest = SearchRequest()
                 .indices(AlertIndices.ALERT_INDEX)
                 .routing(request.monitorId)
-                .source(SearchSourceBuilder().query(queryBuilder).version(true).seqNoAndPrimaryTerm(true))
+                .source(
+                    SearchSourceBuilder()
+                        .query(queryBuilder)
+                        .version(true)
+                        .seqNoAndPrimaryTerm(true)
+                        .size(request.alertIds.size)
+                )
 
             client.search(
                 searchRequest,


### PR DESCRIPTION
Signed-off-by: Thomas Hurney <hurneyt@amazon.com>

*Issue #, if available:*
1. #203 
2. Alerting-Dashboard-Plugin [PR #126](https://github.com/opensearch-project/alerting-dashboards-plugin/issues/126)

*Description of changes:*
Porting fix implemented in PR #205.

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).