### PR TITLE
Fixed a bug that was preventing the AcknowledgeAlerts API from acknowledging more than 10 alerts at once.

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
@@ -75,7 +75,13 @@ class TransportAcknowledgeAlertAction @Inject constructor(
             val searchRequest = SearchRequest()
                 .indices(AlertIndices.ALERT_INDEX)
                 .routing(request.monitorId)
-                .source(SearchSourceBuilder().query(queryBuilder).version(true).seqNoAndPrimaryTerm(true))
+                .source(
+                    SearchSourceBuilder()
+                        .query(queryBuilder)
+                        .version(true)
+                        .seqNoAndPrimaryTerm(true)
+                        .size(request.alertIds.size)
+                )
 
             client.search(
                 searchRequest,

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -556,6 +556,78 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         assertFalse("Alert in state ${activeAlert.state} found in failed list", failedResponseList.contains(activeAlert.id))
     }
 
+    fun `test acknowledging more than 10 alerts at once`() {
+        // GIVEN
+        putAlertMappings() // Required as we do not have a create alert API.
+        val monitor = createRandomMonitor(refresh = true)
+        val alertsToAcknowledge = (1..15).map { createAlert(randomAlert(monitor).copy(state = Alert.State.ACTIVE)) }.toTypedArray()
+
+        // WHEN
+        val response = acknowledgeAlerts(monitor, *alertsToAcknowledge)
+
+        // THEN
+        val responseMap = response.asMap()
+        val expectedAcknowledgedCount = alertsToAcknowledge.size
+
+        val acknowledgedAlerts = responseMap["success"] as List<String>
+        assertTrue("Expected $expectedAcknowledgedCount alerts to be acknowledged successfully.", acknowledgedAlerts.size == expectedAcknowledgedCount)
+
+        val acknowledgedAlertsList = acknowledgedAlerts.toString()
+        alertsToAcknowledge.forEach { alert -> assertTrue("Alert with ID ${alert.id} not found in failed list.", acknowledgedAlertsList.contains(alert.id)) }
+
+        val failedResponse = responseMap["failed"] as List<String>
+        assertTrue("Expected 0 alerts to fail acknowledgment.", failedResponse.isEmpty())
+    }
+
+    fun `test acknowledging more than 10 alerts at once, including acknowledged alerts`() {
+        // GIVEN
+        putAlertMappings() // Required as we do not have a create alert API.
+        val monitor = createRandomMonitor(refresh = true)
+        val alertsGroup1 = (1..15).map { createAlert(randomAlert(monitor).copy(state = Alert.State.ACTIVE)) }.toTypedArray()
+        acknowledgeAlerts(monitor, *alertsGroup1) // Acknowledging the first array of alerts.
+
+        val alertsGroup2 = (1..15).map { createAlert(randomAlert(monitor).copy(state = Alert.State.ACTIVE)) }.toTypedArray()
+
+        val alertsToAcknowledge = arrayOf(*alertsGroup1, *alertsGroup2) // Creating an array of alerts that includes alerts that have been already acknowledged, and new alerts.
+
+        // WHEN
+        val response = acknowledgeAlerts(monitor, *alertsToAcknowledge)
+
+        // THEN
+        val responseMap = response.asMap()
+        val expectedAcknowledgedCount = alertsToAcknowledge.size - alertsGroup1.size
+
+        val acknowledgedAlerts = responseMap["success"] as List<String>
+        assertTrue("Expected $expectedAcknowledgedCount alerts to be acknowledged successfully.", acknowledgedAlerts.size == expectedAcknowledgedCount)
+
+        val acknowledgedAlertsList = acknowledgedAlerts.toString()
+        alertsGroup2.forEach { alert -> assertTrue("Alert with ID ${alert.id} not found in failed list.", acknowledgedAlertsList.contains(alert.id)) }
+        alertsGroup1.forEach { alert -> assertFalse("Alert with ID ${alert.id} found in failed list.", acknowledgedAlertsList.contains(alert.id)) }
+
+        val failedResponse = responseMap["failed"] as List<String>
+        assertTrue("Expected ${alertsGroup1.size} alerts to fail acknowledgment.", failedResponse.size == alertsGroup1.size)
+
+        val failedResponseList = failedResponse.toString()
+        alertsGroup1.forEach { alert -> assertTrue("Alert with ID ${alert.id} not found in failed list.", failedResponseList.contains(alert.id)) }
+        alertsGroup2.forEach { alert -> assertFalse("Alert with ID ${alert.id} found in failed list.", failedResponseList.contains(alert.id)) }
+    }
+
+    @Throws(Exception::class)
+    fun `test acknowledging 0 alerts`() {
+        // GIVEN
+        putAlertMappings() // Required as we do not have a create alert API.
+        val monitor = createRandomMonitor(refresh = true)
+        val alertsToAcknowledge = arrayOf<Alert>()
+
+        // WHEN & THEN
+        try {
+            acknowledgeAlerts(monitor, *alertsToAcknowledge)
+            fail("Expected acknowledgeAlerts to throw an exception.")
+        } catch (e: ResponseException) {
+            assertEquals("Unexpected status", RestStatus.BAD_REQUEST, e.response.restStatus())
+        }
+    }
+
     fun `test get all alerts in all states`() {
         putAlertMappings() // Required as we do not have a create alert API.
         val monitor = createRandomMonitor(refresh = true)


### PR DESCRIPTION
Signed-off-by: Thomas Hurney <hurneyt@amazon.com>

*Issue #, if available:*
1. #203 
2. Alerting-Dashboard-Plugin [PR #126](https://github.com/opensearch-project/alerting-dashboards-plugin/issues/126)

*Description of changes:*
Porting fix implemented in PR #205.

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).