### PR TITLE
Admin Users must be able to access all monitors #139

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
@@ -1,0 +1,143 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.alerting.transport
+
+import org.apache.logging.log4j.LogManager
+import org.opensearch.OpenSearchStatusException
+import org.opensearch.action.ActionListener
+import org.opensearch.alerting.settings.AlertingSettings
+import org.opensearch.alerting.util.AlertingException
+import org.opensearch.client.Client
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.commons.ConfigConstants
+import org.opensearch.commons.authuser.User
+import org.opensearch.rest.RestStatus
+
+private val log = LogManager.getLogger(SecureTransportAction::class.java)
+
+/**
+ * TransportActon classes extend this interface to add filter-by-backend-roles functionality.
+ */
+interface SecureTransportAction {
+
+    var filterByEnabled: Boolean
+
+    fun registerForUpdate(clusterService: ClusterService) {
+        clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.FILTER_BY_BACKEND_ROLES) { filterByEnabled = it }
+    }
+
+    /**
+     * Reads user info from the thread context.Also sets filterByBackend roles to true if the user is admin.
+     * If admin, we want to shows all objects irrespective of the filterBy condition.
+     */
+    fun resolveUser(client: Client): User? {
+        val userStr = client.threadPool().threadContext.getTransient<String>(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT)
+        log.debug("User and roles string from thread context: $userStr")
+        return User.parse(userStr)
+    }
+
+    fun filterByRolesAndUser(user: User?): Boolean {
+        log.debug("Is filterByEnabled: $filterByEnabled ; Is admin user: ${isAdmin(user)}")
+        return if (isAdmin(user)) {
+            false
+        } else {
+            filterByEnabled
+        }
+    }
+
+    /*
+     *  'all_access' role users are treated as admins.
+     */
+    private fun isAdmin(user: User?): Boolean {
+        return when {
+            user == null -> {
+                false
+            }
+            user.roles?.isNullOrEmpty() == true -> {
+                false
+            }
+            else -> {
+                user.roles?.contains("all_access") == true
+            }
+        }
+    }
+
+    /**
+     * 1. If filterBy is enabled
+     * a) Don't allow to create monitor/ destination (throw error) if the logged-on user has no backend roles configured.
+     * 2. If filterBy is enabled & monitors are created when filterBy is disabled:
+     * a) If backend_roles are saved with config, results will get filtered and data is shown
+     * b) If backend_roles are not saved with monitor config, results will get filtered and no monitors
+     * will be displayed.
+     * c) Users can edit and save the monitors to associate their backend_roles.
+     * 3. If filterBy is enabled & monitors are created by older version:
+     * a) No User details are present on monitor.
+     * b) No monitors will be displayed.
+     * c) Users can edit and save the monitors to associate their backend_roles.
+     */
+    fun <T : Any> checkFilterByUserBackendRoles(filterByEnabled: Boolean, user: User?, actionListener: ActionListener<T>): Boolean {
+        if (filterByEnabled) {
+            if (user == null) {
+                actionListener.onFailure(
+                    AlertingException.wrap(
+                        OpenSearchStatusException(
+                            "Filter by user backend roles is not enabled with security disabled.", RestStatus.FORBIDDEN
+                        )
+                    )
+                )
+                return false
+            } else if (user.backendRoles.isNullOrEmpty()) {
+                actionListener.onFailure(
+                    AlertingException.wrap(
+                        OpenSearchStatusException("User doesn't have backend roles configured. Contact administrator.", RestStatus.FORBIDDEN)
+                    )
+                )
+                return false
+            }
+        }
+        return true
+    }
+
+    /**
+     * If FilterBy is enabled, this function verifies that the requester user has FilterBy permissions to access
+     * the resource. If FilterBy is disabled, we will assume the user has permissions and return true.
+     *
+     * This check will later to moved to the security plugin.
+     */
+    fun <T : Any> checkUserFilterByPermissions(
+        filterByEnabled: Boolean,
+        requesterUser: User?,
+        resourceUser: User?,
+        actionListener: ActionListener<T>,
+        resourceType: String,
+        resourceId: String
+    ): Boolean {
+
+        if (!filterByEnabled) return true
+
+        val resourceBackendRoles = resourceUser?.backendRoles
+        val requesterBackendRoles = requesterUser?.backendRoles
+
+        if (resourceBackendRoles == null || requesterBackendRoles == null || resourceBackendRoles.intersect(requesterBackendRoles).isEmpty()) {
+            actionListener.onFailure(
+                AlertingException.wrap(
+                    OpenSearchStatusException(
+                        "Do not have permissions to resource, $resourceType, with id, $resourceId",
+                        RestStatus.FORBIDDEN
+                    )
+                )
+            )
+            return false
+        }
+        return true
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteDestinationAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteDestinationAction.kt
@@ -41,8 +41,6 @@ import org.opensearch.alerting.core.model.ScheduledJob
 import org.opensearch.alerting.model.destination.Destination
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.util.AlertingException
-import org.opensearch.alerting.util.checkFilterByUserBackendRoles
-import org.opensearch.alerting.util.checkUserFilterByPermissions
 import org.opensearch.client.Client
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
@@ -53,7 +51,6 @@ import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.common.xcontent.XContentType
-import org.opensearch.commons.ConfigConstants
 import org.opensearch.commons.authuser.User
 import org.opensearch.rest.RestStatus
 import org.opensearch.tasks.Task
@@ -71,22 +68,21 @@ class TransportDeleteDestinationAction @Inject constructor(
     val xContentRegistry: NamedXContentRegistry
 ) : HandledTransportAction<DeleteDestinationRequest, DeleteResponse>(
     DeleteDestinationAction.NAME, transportService, actionFilters, ::DeleteDestinationRequest
-) {
+),
+    SecureTransportAction {
 
-    @Volatile private var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
 
     init {
-        clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.FILTER_BY_BACKEND_ROLES) { filterByEnabled = it }
+        registerForUpdate(clusterService)
     }
 
     override fun doExecute(task: Task, request: DeleteDestinationRequest, actionListener: ActionListener<DeleteResponse>) {
-        val userStr = client.threadPool().threadContext.getTransient<String>(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT)
-        log.debug("User and roles string from thread context: $userStr")
-        val user: User? = User.parse(userStr)
+        val user = resolveUser(client)
         val deleteRequest = DeleteRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, request.destinationId)
             .setRefreshPolicy(request.refreshPolicy)
 
-        if (!checkFilterByUserBackendRoles(filterByEnabled, user, actionListener)) {
+        if (!checkFilterByUserBackendRoles(filterByRolesAndUser(user), user, actionListener)) {
             return
         }
         client.threadPool().threadContext.stashContext().use {
@@ -106,7 +102,7 @@ class TransportDeleteDestinationAction @Inject constructor(
             if (user == null) {
                 // Security is disabled, so we can delete the destination without issues
                 deleteDestination()
-            } else if (!filterByEnabled) {
+            } else if (!filterByRolesAndUser(user)) {
                 // security is enabled and filterby is disabled.
                 deleteDestination()
             } else {
@@ -153,7 +149,11 @@ class TransportDeleteDestinationAction @Inject constructor(
         }
 
         private fun onGetResponse(destination: Destination) {
-            if (!checkUserFilterByPermissions(filterByEnabled, user, destination.user, actionListener, "destination", destinationId)) {
+            if (
+                !checkUserFilterByPermissions(
+                    filterByRolesAndUser(user), user, destination.user, actionListener, "destination", destinationId
+                )
+            ) {
                 return
             } else {
                 deleteDestination()

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
@@ -41,8 +41,6 @@ import org.opensearch.alerting.core.model.ScheduledJob
 import org.opensearch.alerting.model.Monitor
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.util.AlertingException
-import org.opensearch.alerting.util.checkFilterByUserBackendRoles
-import org.opensearch.alerting.util.checkUserFilterByPermissions
 import org.opensearch.client.Client
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
@@ -51,7 +49,6 @@ import org.opensearch.common.xcontent.LoggingDeprecationHandler
 import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
-import org.opensearch.commons.ConfigConstants
 import org.opensearch.commons.authuser.User
 import org.opensearch.rest.RestStatus
 import org.opensearch.tasks.Task
@@ -69,22 +66,21 @@ class TransportDeleteMonitorAction @Inject constructor(
     val xContentRegistry: NamedXContentRegistry
 ) : HandledTransportAction<DeleteMonitorRequest, DeleteResponse>(
     DeleteMonitorAction.NAME, transportService, actionFilters, ::DeleteMonitorRequest
-) {
+),
+    SecureTransportAction {
 
-    @Volatile private var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
 
     init {
-        clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.FILTER_BY_BACKEND_ROLES) { filterByEnabled = it }
+        registerForUpdate(clusterService)
     }
 
     override fun doExecute(task: Task, request: DeleteMonitorRequest, actionListener: ActionListener<DeleteResponse>) {
-        val userStr = client.threadPool().threadContext.getTransient<String>(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT)
-        log.debug("User and roles string from thread context: $userStr")
-        val user: User? = User.parse(userStr)
+        val user = resolveUser(client)
         val deleteRequest = DeleteRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, request.monitorId)
             .setRefreshPolicy(request.refreshPolicy)
 
-        if (!checkFilterByUserBackendRoles(filterByEnabled, user, actionListener)) {
+        if (!checkFilterByUserBackendRoles(filterByRolesAndUser(user), user, actionListener)) {
             return
         }
         client.threadPool().threadContext.stashContext().use {
@@ -104,7 +100,7 @@ class TransportDeleteMonitorAction @Inject constructor(
             if (user == null) {
                 // Security is disabled, so we can delete the destination without issues
                 deleteMonitor()
-            } else if (!filterByEnabled) {
+            } else if (!filterByRolesAndUser(user)) {
                 // security is enabled and filterby is disabled.
                 deleteMonitor()
             } else {
@@ -145,7 +141,7 @@ class TransportDeleteMonitorAction @Inject constructor(
         }
 
         private fun onGetResponse(monitor: Monitor) {
-            if (!checkUserFilterByPermissions(filterByEnabled, user, monitor.user, actionListener, "monitor", monitorId)) {
+            if (!checkUserFilterByPermissions(filterByRolesAndUser(user), user, monitor.user, actionListener, "monitor", monitorId)) {
                 return
             } else {
                 deleteMonitor()

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
@@ -50,7 +50,6 @@ import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.common.xcontent.XContentType
-import org.opensearch.commons.ConfigConstants
 import org.opensearch.commons.authuser.User
 import org.opensearch.index.query.Operator
 import org.opensearch.index.query.QueryBuilders
@@ -72,12 +71,13 @@ class TransportGetAlertsAction @Inject constructor(
     val xContentRegistry: NamedXContentRegistry
 ) : HandledTransportAction<GetAlertsRequest, GetAlertsResponse>(
     GetAlertsAction.NAME, transportService, actionFilters, ::GetAlertsRequest
-) {
+),
+    SecureTransportAction {
 
-    @Volatile private var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
 
     init {
-        clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.FILTER_BY_BACKEND_ROLES) { filterByEnabled = it }
+        registerForUpdate(clusterService)
     }
 
     override fun doExecute(
@@ -85,11 +85,7 @@ class TransportGetAlertsAction @Inject constructor(
         getAlertsRequest: GetAlertsRequest,
         actionListener: ActionListener<GetAlertsResponse>
     ) {
-        val userStr = client.threadPool().threadContext.getTransient<String>(
-            ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT
-        )
-        log.debug("User and roles string from thread context: $userStr")
-        val user: User? = User.parse(userStr)
+        val user = resolveUser(client)
 
         val tableProp = getAlertsRequest.table
         val sortBuilder = SortBuilders
@@ -143,7 +139,7 @@ class TransportGetAlertsAction @Inject constructor(
         if (user == null) {
             // user is null when: 1/ security is disabled. 2/when user is super-admin.
             search(searchSourceBuilder, actionListener)
-        } else if (!filterByEnabled) {
+        } else if (!filterByRolesAndUser(user)) {
             // security is enabled and filterby is disabled.
             search(searchSourceBuilder, actionListener)
         } else {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetDestinationsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetDestinationsAction.kt
@@ -51,7 +51,6 @@ import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.common.xcontent.XContentType
-import org.opensearch.commons.ConfigConstants
 import org.opensearch.commons.authuser.User
 import org.opensearch.index.query.Operator
 import org.opensearch.index.query.QueryBuilders
@@ -75,12 +74,13 @@ class TransportGetDestinationsAction @Inject constructor(
     val xContentRegistry: NamedXContentRegistry
 ) : HandledTransportAction<GetDestinationsRequest, GetDestinationsResponse> (
     GetDestinationsAction.NAME, transportService, actionFilters, ::GetDestinationsRequest
-) {
+),
+    SecureTransportAction {
 
-    @Volatile private var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
 
     init {
-        clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.FILTER_BY_BACKEND_ROLES) { filterByEnabled = it }
+        registerForUpdate(clusterService)
     }
 
     override fun doExecute(
@@ -88,12 +88,7 @@ class TransportGetDestinationsAction @Inject constructor(
         getDestinationsRequest: GetDestinationsRequest,
         actionListener: ActionListener<GetDestinationsResponse>
     ) {
-        val userStr = client.threadPool().threadContext.getTransient<String>(
-            ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT
-        )
-        log.debug("User and roles string from thread context: $userStr")
-        val user: User? = User.parse(userStr)
-
+        val user = resolveUser(client)
         val tableProp = getDestinationsRequest.table
 
         val sortBuilder = SortBuilders
@@ -144,7 +139,7 @@ class TransportGetDestinationsAction @Inject constructor(
         if (user == null) {
             // user is null when: 1/ security is disabled. 2/when user is super-admin.
             search(searchSourceBuilder, actionListener)
-        } else if (!filterByEnabled) {
+        } else if (!filterByRolesAndUser(user)) {
             // security is enabled and filterby is disabled.
             search(searchSourceBuilder, actionListener)
         } else {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetDestinationsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetDestinationsAction.kt
@@ -80,7 +80,7 @@ class TransportGetDestinationsAction @Inject constructor(
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
 
     init {
-        registerForUpdate(clusterService)
+        listenFilterBySettingChange(clusterService)
     }
 
     override fun doExecute(
@@ -88,7 +88,7 @@ class TransportGetDestinationsAction @Inject constructor(
         getDestinationsRequest: GetDestinationsRequest,
         actionListener: ActionListener<GetDestinationsResponse>
     ) {
-        val user = resolveUser(client)
+        val user = readUserFromThreadContext(client)
         val tableProp = getDestinationsRequest.table
 
         val sortBuilder = SortBuilders
@@ -139,7 +139,7 @@ class TransportGetDestinationsAction @Inject constructor(
         if (user == null) {
             // user is null when: 1/ security is disabled. 2/when user is super-admin.
             search(searchSourceBuilder, actionListener)
-        } else if (!filterByRolesAndUser(user)) {
+        } else if (!doFilterForUser(user)) {
             // security is enabled and filterby is disabled.
             search(searchSourceBuilder, actionListener)
         } else {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetMonitorAction.kt
@@ -40,8 +40,6 @@ import org.opensearch.alerting.core.model.ScheduledJob
 import org.opensearch.alerting.model.Monitor
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.util.AlertingException
-import org.opensearch.alerting.util.checkFilterByUserBackendRoles
-import org.opensearch.alerting.util.checkUserFilterByPermissions
 import org.opensearch.client.Client
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
@@ -50,8 +48,6 @@ import org.opensearch.common.xcontent.LoggingDeprecationHandler
 import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
-import org.opensearch.commons.ConfigConstants
-import org.opensearch.commons.authuser.User
 import org.opensearch.rest.RestStatus
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService
@@ -67,24 +63,23 @@ class TransportGetMonitorAction @Inject constructor(
     settings: Settings
 ) : HandledTransportAction<GetMonitorRequest, GetMonitorResponse> (
     GetMonitorAction.NAME, transportService, actionFilters, ::GetMonitorRequest
-) {
+),
+    SecureTransportAction {
 
-    @Volatile private var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
 
     init {
-        clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.FILTER_BY_BACKEND_ROLES) { filterByEnabled = it }
+        registerForUpdate(clusterService)
     }
 
     override fun doExecute(task: Task, getMonitorRequest: GetMonitorRequest, actionListener: ActionListener<GetMonitorResponse>) {
-        val userStr = client.threadPool().threadContext.getTransient<String>(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT)
-        log.debug("User and roles string from thread context: $userStr")
-        val user: User? = User.parse(userStr)
+        val user = resolveUser(client)
 
         val getRequest = GetRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, getMonitorRequest.monitorId)
             .version(getMonitorRequest.version)
             .fetchSourceContext(getMonitorRequest.srcContext)
 
-        if (!checkFilterByUserBackendRoles(filterByEnabled, user, actionListener)) {
+        if (!checkFilterByUserBackendRoles(filterByRolesAndUser(user), user, actionListener)) {
             return
         }
 
@@ -116,7 +111,7 @@ class TransportGetMonitorAction @Inject constructor(
 
                                 // security is enabled and filterby is enabled
                                 if (!checkUserFilterByPermissions(
-                                        filterByEnabled,
+                                        filterByRolesAndUser(user),
                                         user,
                                         monitor?.user,
                                         actionListener,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexDestinationAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexDestinationAction.kt
@@ -32,8 +32,6 @@ import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.settings.DestinationSettings
 import org.opensearch.alerting.util.AlertingException
 import org.opensearch.alerting.util.IndexUtils
-import org.opensearch.alerting.util.checkFilterByUserBackendRoles
-import org.opensearch.alerting.util.checkUserFilterByPermissions
 import org.opensearch.client.Client
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
@@ -46,7 +44,6 @@ import org.opensearch.common.xcontent.XContentFactory.jsonBuilder
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.common.xcontent.XContentType
-import org.opensearch.commons.ConfigConstants
 import org.opensearch.commons.authuser.User
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestStatus
@@ -66,24 +63,23 @@ class TransportIndexDestinationAction @Inject constructor(
     val xContentRegistry: NamedXContentRegistry
 ) : HandledTransportAction<IndexDestinationRequest, IndexDestinationResponse>(
     IndexDestinationAction.NAME, transportService, actionFilters, ::IndexDestinationRequest
-) {
+),
+    SecureTransportAction {
 
     @Volatile private var indexTimeout = AlertingSettings.INDEX_TIMEOUT.get(settings)
     @Volatile private var allowList = DestinationSettings.ALLOW_LIST.get(settings)
-    @Volatile private var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
 
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.INDEX_TIMEOUT) { indexTimeout = it }
         clusterService.clusterSettings.addSettingsUpdateConsumer(DestinationSettings.ALLOW_LIST) { allowList = it }
-        clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.FILTER_BY_BACKEND_ROLES) { filterByEnabled = it }
+        registerForUpdate(clusterService)
     }
 
     override fun doExecute(task: Task, request: IndexDestinationRequest, actionListener: ActionListener<IndexDestinationResponse>) {
-        val userStr = client.threadPool().threadContext.getTransient<String>(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT)
-        log.debug("User and roles string from thread context: $userStr")
-        val user: User? = User.parse(userStr)
+        val user = resolveUser(client)
 
-        if (!checkFilterByUserBackendRoles(filterByEnabled, user, actionListener)) {
+        if (!checkFilterByUserBackendRoles(filterByRolesAndUser(user), user, actionListener)) {
             return
         }
         client.threadPool().threadContext.stashContext().use {
@@ -268,7 +264,7 @@ class TransportIndexDestinationAction @Inject constructor(
 
         private fun onGetResponse(destination: Destination) {
             if (!checkUserFilterByPermissions(
-                    filterByEnabled,
+                    filterByRolesAndUser(user),
                     user,
                     destination.user,
                     actionListener,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -51,7 +51,6 @@ import org.opensearch.alerting.core.model.SearchInput
 import org.opensearch.alerting.model.Monitor
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.settings.AlertingSettings.Companion.ALERTING_MAX_MONITORS
-import org.opensearch.alerting.settings.AlertingSettings.Companion.FILTER_BY_BACKEND_ROLES
 import org.opensearch.alerting.settings.AlertingSettings.Companion.INDEX_TIMEOUT
 import org.opensearch.alerting.settings.AlertingSettings.Companion.MAX_ACTION_THROTTLE_VALUE
 import org.opensearch.alerting.settings.AlertingSettings.Companion.REQUEST_TIMEOUT
@@ -59,8 +58,6 @@ import org.opensearch.alerting.settings.DestinationSettings.Companion.ALLOW_LIST
 import org.opensearch.alerting.util.AlertingException
 import org.opensearch.alerting.util.IndexUtils
 import org.opensearch.alerting.util.addUserBackendRolesFilter
-import org.opensearch.alerting.util.checkFilterByUserBackendRoles
-import org.opensearch.alerting.util.checkUserFilterByPermissions
 import org.opensearch.alerting.util.isADMonitor
 import org.opensearch.client.Client
 import org.opensearch.cluster.service.ClusterService
@@ -96,14 +93,15 @@ class TransportIndexMonitorAction @Inject constructor(
     val xContentRegistry: NamedXContentRegistry
 ) : HandledTransportAction<IndexMonitorRequest, IndexMonitorResponse>(
     IndexMonitorAction.NAME, transportService, actionFilters, ::IndexMonitorRequest
-) {
+),
+    SecureTransportAction {
 
     @Volatile private var maxMonitors = ALERTING_MAX_MONITORS.get(settings)
     @Volatile private var requestTimeout = REQUEST_TIMEOUT.get(settings)
     @Volatile private var indexTimeout = INDEX_TIMEOUT.get(settings)
     @Volatile private var maxActionThrottle = MAX_ACTION_THROTTLE_VALUE.get(settings)
     @Volatile private var allowList = ALLOW_LIST.get(settings)
-    @Volatile private var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
 
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(ALERTING_MAX_MONITORS) { maxMonitors = it }
@@ -111,7 +109,7 @@ class TransportIndexMonitorAction @Inject constructor(
         clusterService.clusterSettings.addSettingsUpdateConsumer(INDEX_TIMEOUT) { indexTimeout = it }
         clusterService.clusterSettings.addSettingsUpdateConsumer(MAX_ACTION_THROTTLE_VALUE) { maxActionThrottle = it }
         clusterService.clusterSettings.addSettingsUpdateConsumer(ALLOW_LIST) { allowList = it }
-        clusterService.clusterSettings.addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES) { filterByEnabled = it }
+        registerForUpdate(clusterService)
     }
 
     override fun doExecute(task: Task, request: IndexMonitorRequest, actionListener: ActionListener<IndexMonitorResponse>) {
@@ -120,7 +118,7 @@ class TransportIndexMonitorAction @Inject constructor(
         log.debug("User and roles string from thread context: $userStr")
         val user: User? = User.parse(userStr)
 
-        if (!checkFilterByUserBackendRoles(filterByEnabled, user, actionListener)) {
+        if (!checkFilterByUserBackendRoles(filterByRolesAndUser(user), user, actionListener)) {
             return
         }
 
@@ -458,7 +456,7 @@ class TransportIndexMonitorAction @Inject constructor(
         }
 
         private fun onGetResponse(currentMonitor: Monitor) {
-            if (!checkUserFilterByPermissions(filterByEnabled, user, currentMonitor.user, actionListener, "monitor", request.monitorId)) {
+            if (!checkUserFilterByPermissions(filterByRolesAndUser(user), user, currentMonitor.user, actionListener, "monitor", request.monitorId)) {
                 return
             }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
@@ -41,7 +41,6 @@ import org.opensearch.client.Client
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
 import org.opensearch.common.settings.Settings
-import org.opensearch.commons.ConfigConstants
 import org.opensearch.commons.authuser.User
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService
@@ -56,18 +55,16 @@ class TransportSearchMonitorAction @Inject constructor(
     actionFilters: ActionFilters
 ) : HandledTransportAction<SearchMonitorRequest, SearchResponse>(
     SearchMonitorAction.NAME, transportService, actionFilters, ::SearchMonitorRequest
-) {
-    @Volatile private var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
-
+),
+    SecureTransportAction {
+    @Volatile
+    override var filterByEnabled: Boolean = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
     init {
-        clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.FILTER_BY_BACKEND_ROLES) { filterByEnabled = it }
+        registerForUpdate(clusterService)
     }
 
     override fun doExecute(task: Task, searchMonitorRequest: SearchMonitorRequest, actionListener: ActionListener<SearchResponse>) {
-        val userStr = client.threadPool().threadContext.getTransient<String>(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT)
-        log.debug("User and roles string from thread context: $userStr")
-        val user: User? = User.parse(userStr)
-
+        val user = resolveUser(client)
         client.threadPool().threadContext.stashContext().use {
             resolve(searchMonitorRequest, actionListener, user)
         }
@@ -77,7 +74,7 @@ class TransportSearchMonitorAction @Inject constructor(
         if (user == null) {
             // user header is null when: 1/ security is disabled. 2/when user is super-admin.
             search(searchMonitorRequest.searchRequest, actionListener)
-        } else if (!filterByEnabled) {
+        } else if (!filterByRolesAndUser(user)) {
             // security is enabled and filterby is disabled.
             search(searchMonitorRequest.searchRequest, actionListener)
         } else {

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
     apply from: 'build-tools/repositories.gradle'
 
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.1.0")
+        opensearch_version = System.getProperty("opensearch.version", "1.2.0-SNAPSHOT")
         // 1.0.0 -> 1.0.0.0, and 1.0.0-SNAPSHOT -> 1.0.0.0-SNAPSHOT
         opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
     apply from: 'build-tools/repositories.gradle'
 
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.2.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "1.1.0")
         // 1.0.0 -> 1.0.0.0, and 1.0.0-SNAPSHOT -> 1.0.0.0-SNAPSHOT
         opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)


### PR DESCRIPTION
*Issue #, if available:*
#139 

* Passed security integ tests using OpenSeach-1.1 release: `./gradlew :alerting:integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=opensearch -Dhttps=true -Dsecurity=true -Duser=admin -Dpassword=admin`. 

*Description of changes:*
#139 
* Added changes that will ensure that `admin` users can access all monitors.
* Refactored the transport classes which have filter-by-backend-role logic.
* There is scope to improve security tests added a seperate issue #219 , as fast follow up to this.


*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).