### PR TITLE
Update maven publication to include cksums.

### DIFF
--- a/notification/build.gradle
+++ b/notification/build.gradle
@@ -57,16 +57,13 @@ task javadocJar(type: Jar) {
     from javadoc.destinationDir
 }
 
-tasks.withType(Jar) { task ->
-    task.doLast {
-        ant.checksum algorithm: 'md5', file: it.archivePath
-        ant.checksum algorithm: 'sha1', file: it.archivePath
-        ant.checksum algorithm: 'sha-256', file: it.archivePath, fileext: '.sha256'
-        ant.checksum algorithm: 'sha-512', file: it.archivePath, fileext: '.sha512'
-    }
-}
-
 publishing {
+    repositories {
+        maven {
+            name = 'staging'
+            url = "${rootProject.buildDir}/local-staging-repo"
+        }
+    }
     publications {
         shadow(MavenPublication) {
             project.shadow.component(it)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -69,7 +69,9 @@ echo "COPY ${distributions}/*.zip"
 cp ${distributions}/*.zip ./$OUTPUT/plugins
 
 ./gradlew publishShadowPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -x ktlint
+./gradlew publishShadowPublicationToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 
 mkdir -p $OUTPUT/maven/org/opensearch
-cp -r ./notification/build/libs $OUTPUT/maven/org/opensearch/notification
+cp -r ./build/local-staging-repo/org/opensearch/notification $OUTPUT/maven/org/opensearch/notification
+
 


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

*Issue #, if available:*
closes #223 

*Description of changes:*
This change adds a task to publish to a local staging repo under build/ that includes cksums.  It also updates build.sh to use this new task and copy the contents of the staging repo to the output directory.
The maven publish plugin will not include these cksums when publishing to maven local but will when published to a separate folder.
```
./scripts/build.sh -v 1.2.0 -s false
```
```
~/workspace/alerting (maven)$ find ./artifacts/maven/org/opensearch/notification/
./artifacts/maven/org/opensearch/notification/
./artifacts/maven/org/opensearch/notification//maven-metadata.xml.sha256
./artifacts/maven/org/opensearch/notification//maven-metadata.xml
./artifacts/maven/org/opensearch/notification//maven-metadata.xml.sha512
./artifacts/maven/org/opensearch/notification//1.2.0.0
./artifacts/maven/org/opensearch/notification//1.2.0.0/notification-1.2.0.0.pom.sha256
./artifacts/maven/org/opensearch/notification//1.2.0.0/notification-1.2.0.0.jar.sha512
./artifacts/maven/org/opensearch/notification//1.2.0.0/notification-1.2.0.0.jar.sha1
./artifacts/maven/org/opensearch/notification//1.2.0.0/notification-1.2.0.0-sources.jar.sha256
./artifacts/maven/org/opensearch/notification//1.2.0.0/notification-1.2.0.0-sources.jar.sha1
./artifacts/maven/org/opensearch/notification//1.2.0.0/notification-1.2.0.0-javadoc.jar.md5
./artifacts/maven/org/opensearch/notification//1.2.0.0/notification-1.2.0.0-javadoc.jar.sha512
./artifacts/maven/org/opensearch/notification//1.2.0.0/notification-1.2.0.0-javadoc.jar
./artifacts/maven/org/opensearch/notification//1.2.0.0/notification-1.2.0.0-sources.jar
./artifacts/maven/org/opensearch/notification//1.2.0.0/notification-1.2.0.0.pom.sha1
./artifacts/maven/org/opensearch/notification//1.2.0.0/notification-1.2.0.0-sources.jar.sha512
./artifacts/maven/org/opensearch/notification//1.2.0.0/notification-1.2.0.0.pom.md5
./artifacts/maven/org/opensearch/notification//1.2.0.0/notification-1.2.0.0.pom.sha512
./artifacts/maven/org/opensearch/notification//1.2.0.0/notification-1.2.0.0.jar.sha256
./artifacts/maven/org/opensearch/notification//1.2.0.0/notification-1.2.0.0.pom
./artifacts/maven/org/opensearch/notification//1.2.0.0/notification-1.2.0.0.jar.md5
./artifacts/maven/org/opensearch/notification//1.2.0.0/notification-1.2.0.0-sources.jar.md5
./artifacts/maven/org/opensearch/notification//1.2.0.0/notification-1.2.0.0-javadoc.jar.sha1
./artifacts/maven/org/opensearch/notification//1.2.0.0/notification-1.2.0.0.jar
./artifacts/maven/org/opensearch/notification//1.2.0.0/notification-1.2.0.0-javadoc.jar.sha256
./artifacts/maven/org/opensearch/notification//maven-metadata.xml.md5
./artifacts/maven/org/opensearch/notification//maven-metadata.xml.sha1
```


*CheckList:*
[x ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).