### PR TITLE
Update Monitor parse to not use lateinit for name and schedule

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/Monitor.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/Monitor.kt
@@ -237,11 +237,11 @@ data class Monitor(
         @JvmOverloads
         @Throws(IOException::class)
         fun parse(xcp: XContentParser, id: String = NO_ID, version: Long = NO_VERSION): Monitor {
-            lateinit var name: String
+            var name: String? = null
             // Default to QUERY_LEVEL_MONITOR to cover Monitors that existed before the addition of MonitorType
             var monitorType: String = MonitorType.QUERY_LEVEL_MONITOR.toString()
             var user: User? = null
-            lateinit var schedule: Schedule
+            var schedule: Schedule? = null
             var lastUpdateTime: Instant? = null
             var enabledTime: Instant? = null
             var uiMetadata: Map<String, Any> = mapOf()

--- a/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
@@ -130,7 +130,8 @@ fun randomBucketLevelMonitor(
     inputs: List<Input> = listOf(
         SearchInput(
             emptyList(),
-            SearchSourceBuilder().query(QueryBuilders.matchAllQuery()).aggregation(TermsAggregationBuilder("test_agg"))
+            SearchSourceBuilder().query(QueryBuilders.matchAllQuery())
+                .aggregation(TermsAggregationBuilder("test_agg").field("test_field"))
         )
     ),
     schedule: Schedule = IntervalSchedule(interval = 5, unit = ChronoUnit.MINUTES),

--- a/alerting/src/test/kotlin/org/opensearch/alerting/model/XContentTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/model/XContentTests.kt
@@ -134,6 +134,49 @@ class XContentTests : OpenSearchTestCase() {
         assertEquals("Round tripping QueryLevelMonitor doesn't work", monitor, parsedMonitor)
     }
 
+    fun `test monitor parsing with no name`() {
+        val monitorStringWithoutName = """
+            {
+              "type": "monitor",
+              "enabled": false,
+              "schedule": {
+                "period": {
+                  "interval": 1,
+                  "unit": "MINUTES"
+                }
+              },
+              "inputs": [],
+              "triggers": []
+            }
+        """.trimIndent()
+
+        assertFailsWith<IllegalArgumentException>("Monitor name is null") { Monitor.parse(parser(monitorStringWithoutName)) }
+    }
+
+    fun `test monitor parsing with no schedule`() {
+        val monitorStringWithoutSchedule = """
+            {
+              "type": "monitor",
+              "name": "asdf",
+              "enabled": false,
+              "inputs": [],
+              "triggers": []
+            }
+        """.trimIndent()
+
+        assertFailsWith<IllegalArgumentException>("Monitor schedule is null") {
+            Monitor.parse(parser(monitorStringWithoutSchedule))
+        }
+    }
+
+    fun `test bucket-level monitor parsing`() {
+        val monitor = randomBucketLevelMonitor()
+
+        val monitorString = monitor.toJsonStringWithUser()
+        val parsedMonitor = Monitor.parse(parser(monitorString))
+        assertEquals("Round tripping BucketLevelMonitor doesn't work", monitor, parsedMonitor)
+    }
+
     fun `test query-level trigger parsing`() {
         val trigger = randomQueryLevelTrigger()
 


### PR DESCRIPTION
*Issue #, if available:* #126

*Description of changes:*
Update Monitor parse to not use lateinit for name and schedule so it hits the assertion and throws an appropriate IllegalArgumentException when `name` and `schedule` is not present.

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).