### PR TITLE
Fix running Alerting security tests in GitHub Actions

### DIFF
--- a/.github/workflows/bwc-test-workflow.yml
+++ b/.github/workflows/bwc-test-workflow.yml
@@ -1,4 +1,4 @@
-name: Multi-node Test Workflow
+name: BWC Test Workflow
 # This workflow is triggered on pull requests and pushes to main or an OpenSearch release branch
 on:
   pull_request:
@@ -31,5 +31,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 14
-      - name: Run integration tests with multi node config
-        run: ./gradlew integTest -PnumNodes=3 -Dopensearch.version=1.3.0-SNAPSHOT
+      - name: Run Alerting Backwards Compatibility Tests
+        run: |
+          echo "Running backwards compatibility tests..."
+          ./gradlew bwcTestSuite

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -44,9 +44,9 @@ jobs:
           echo $version $plugin_version $candidate_version
           echo $ls $list_of_all_files
 
-          if docker pull opensearchstaging/opensearch:$version-$candidate_version
+          if docker pull opensearchstaging/opensearch:$version
           then
-            echo "FROM opensearchstaging/opensearch:$version-$candidate_version" >> Dockerfile
+            echo "FROM opensearchstaging/opensearch:$version" >> Dockerfile
             echo "RUN if [ -d /usr/share/opensearch/plugins/opensearch-alerting ]; then /usr/share/opensearch/bin/opensearch-plugin remove opensearch-alerting; fi" >> Dockerfile
             echo "ADD alerting/build/distributions/opensearch-alerting-$plugin_version-$candidate_version.zip /tmp/" >> Dockerfile
             echo "RUN /usr/share/opensearch/bin/opensearch-plugin install --batch file:/tmp/opensearch-alerting-$plugin_version-$candidate_version.zip" >> Dockerfile

--- a/.github/workflows/security-test-workflow.yml
+++ b/.github/workflows/security-test-workflow.yml
@@ -1,0 +1,81 @@
+name: Security Test Workflow
+# This workflow is triggered on pull requests and pushes to main or an OpenSearch release branch
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - "*"
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        java: [ 14 ]
+    # Job name
+    name: Build and test Alerting
+    # This job runs on Linux
+    runs-on: ubuntu-latest
+    steps:
+      # This step uses the setup-java Github action: https://github.com/actions/setup-java
+      - name: Set Up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      # This step uses the checkout Github action: https://github.com/actions/checkout
+      - name: Checkout Branch
+        uses: actions/checkout@v2
+      # This step uses the setup-java Github action: https://github.com/actions/setup-java
+      - name: Set Up JDK 14
+        uses: actions/setup-java@v1
+        with:
+          java-version: 14
+      - name: Build Alerting
+        # Only assembling since the full build is governed by other workflows
+        run: ./gradlew assemble -Dopensearch.version=1.3.0-SNAPSHOT
+      - name: Pull and Run Docker
+        run: |
+          plugin=`ls alerting/build/distributions/*.zip`
+          list_of_files=`ls`
+          list_of_all_files=`ls alerting/build/distributions/`
+          version=`echo $plugin|awk -F- '{print $3}'| cut -d. -f 1-3`
+          plugin_version=`echo $plugin|awk -F- '{print $3}'| cut -d. -f 1-4`
+          candidate_version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-1`
+          echo $version $plugin_version $candidate_version
+          echo $ls $list_of_all_files
+
+          if docker pull opensearchstaging/opensearch:$version
+          then
+            echo "FROM opensearchstaging/opensearch:$version" >> Dockerfile
+            echo "RUN if [ -d /usr/share/opensearch/plugins/opensearch-alerting ]; then /usr/share/opensearch/bin/opensearch-plugin remove opensearch-alerting; fi" >> Dockerfile
+            echo "ADD alerting/build/distributions/opensearch-alerting-$plugin_version-$candidate_version.zip /tmp/" >> Dockerfile
+            echo "RUN /usr/share/opensearch/bin/opensearch-plugin install --batch file:/tmp/opensearch-alerting-$plugin_version-$candidate_version.zip" >> Dockerfile
+
+            docker build -t opensearch-alerting:test .
+            echo "imagePresent=true" >> $GITHUB_ENV
+          else
+            echo "imagePresent=false" >> $GITHUB_ENV
+          fi
+
+      - name: Run Docker Image
+        if: env.imagePresent == 'true'
+        run: |
+          cd ..
+          docker run -p 9200:9200 -d -p 9600:9600 -e "discovery.type=single-node" opensearch-alerting:test
+          sleep 120
+
+      - name: Run Alerting Test for security enabled test cases
+        if: env.imagePresent == 'true'
+        run: |
+          cluster_running=`curl -XGET https://localhost:9200/_cat/plugins -u admin:admin --insecure`
+          echo $cluster_running
+          security=`curl -XGET https://localhost:9200/_cat/plugins -u admin:admin --insecure |grep opensearch-security|wc -l`
+          echo $security
+          if [ $security -gt 0 ]
+          then
+            echo "Security plugin is available"
+            ./gradlew :alerting:integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=docker-cluster -Dsecurity=true -Dhttps=true -Duser=admin -Dpassword=admin
+          else
+            echo "Security plugin is NOT available skipping this run as tests without security have already been run"
+          fi

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           mkdir -p alerting-artifacts
           cp ./alerting/build/distributions/*.zip alerting-artifacts
-       This step uses the codecov-action Github action: https://github.com/codecov/codecov-action
+      # This step uses the codecov-action Github action: https://github.com/codecov/codecov-action
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -1,14 +1,12 @@
 name: Test Workflow
-# This workflow is triggered on pull requests and pushes to main or an opensearch release branch
+# This workflow is triggered on pull requests and pushes to main or an OpenSearch release branch
 on:
   pull_request:
     branches:
-      - main
-      - opendistro-*
+      - "*"
   push:
     branches:
-      - main
-      - opendistro-*
+      - "*"
 
 jobs:
   build:
@@ -28,26 +26,20 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-
-
       - name: Build and run with Gradle
         run: ./gradlew build -Dopensearch.version=1.3.0-SNAPSHOT
-
-#      - name: Create Artifact Path
-#        run: |
-#          mkdir -p alerting-artifacts
-#          cp ./alerting/build/distributions/*.zip alerting-artifacts
-      # This step uses the codecov-action Github action: https://github.com/codecov/codecov-action
+      - name: Create Artifact Path
+        run: |
+          mkdir -p alerting-artifacts
+          cp ./alerting/build/distributions/*.zip alerting-artifacts
+       This step uses the codecov-action Github action: https://github.com/codecov/codecov-action
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-#      # This step uses the upload-artifact Github action: https://github.com/actions/upload-artifact
-#      - name: Upload Artifacts
-#        uses: actions/upload-artifact@v1
-#        with:
-#          name: alerting-plugin
-#          path: alerting-artifacts
-      # Publish to local maven
-      - name: Publish to Maven Local
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.3.0-SNAPSHOT
+      # This step uses the upload-artifact Github action: https://github.com/actions/upload-artifact
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: alerting-plugin
+          path: alerting-artifacts


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <qreshi@amazon.com>

*Issue #, if available:*

*Description of changes:*
* Remove `candidate_version` from the reference to OpenSearch docker image since the tags don't include `SNAPSHOT`  for snapshot builds ([reference](https://hub.docker.com/r/opensearchstaging/opensearch/tags))

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).