### PR TITLE
Delete gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,0 @@
-#
-# Copyright OpenSearch Contributors
-# SPDX-License-Identifier: Apache-2.0
-#
-# Modifications Copyright OpenSearch Contributors. See
-# GitHub history for details.
-#
-
-version = 1.0.0


### PR DESCRIPTION
This file is misleading and is not used. The version of the plugin is derived from `-Dopensearch.version`. That mechanism prevents a conflict between the version in gradle.properties and the OpenSearch version passed in.

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).