### PR TITLE
Revert "Bumps cron-utils version to 9.1.6"

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.1'
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlin_version}"
-    compile "com.cronutils:cron-utils:9.1.6"
+    compile "com.cronutils:cron-utils:9.1.3"
     compile "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
     compile 'com.google.googlejavaformat:google-java-format:1.10.0'
     compile "org.opensearch:common-utils:${common_utils_version}"


### PR DESCRIPTION
Reverts opensearch-project/alerting#274 in favor of https://github.com/opensearch-project/alerting/pull/271 which flows from main -> 1.x -> 1.2