### PR TITLE
Bug fix for: Admin Users must be able to access all monitors #139

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
@@ -86,6 +86,8 @@ interface SecureTransportAction {
                     )
                 )
                 return false
+            } else if (isAdmin(user)) {
+                return true
             } else if (user.backendRoles.isNullOrEmpty()) {
                 actionListener.onFailure(
                     AlertingException.wrap(
@@ -112,7 +114,7 @@ interface SecureTransportAction {
         resourceId: String
     ): Boolean {
 
-        if (!filterByEnabled) return true
+        if (!doFilterForUser(requesterUser)) return true
 
         val resourceBackendRoles = resourceUser?.backendRoles
         val requesterBackendRoles = requesterUser?.backendRoles

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -509,6 +509,25 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             )
             assertEquals("Search monitor failed", RestStatus.OK, adminSearchResponse.restStatus())
             assertEquals("Monitor not found during search", 1, getDocs(adminSearchResponse))
+
+            // get as "admin" - must get 1 docs
+            val id: String = monitorJson["_id"] as String
+            val adminGetResponse = client().makeRequest(
+                "GET",
+                "$ALERTING_BASE_URI/$id",
+                emptyMap(),
+                NStringEntity(search, ContentType.APPLICATION_JSON)
+            )
+            assertEquals("Get monitor failed", RestStatus.OK, adminGetResponse.restStatus())
+
+            // delete as "admin"
+            val adminDeleteResponse = client().makeRequest(
+                "DELETE",
+                "$ALERTING_BASE_URI/$id",
+                emptyMap(),
+                NStringEntity(search, ContentType.APPLICATION_JSON)
+            )
+            assertEquals("Delete monitor failed", RestStatus.OK, adminGetResponse.restStatus())
         } finally {
             deleteRoleMapping("hr_role")
             deleteRole("hr_role")


### PR DESCRIPTION
*Issue #, if available:*
Bug fix for: Admin Users must be able to access all monitors #139

*Description of changes:*
Fix GET /monitor DELETE /monitor when 
`plugins.alerting.filter_by_backend_roles : true`

*CheckList:*
[X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).