### PR TITLE
Add back opendistro prefixed sweeper enabled field to alerting stats response

### DIFF
--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
@@ -69,8 +69,8 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
     protected val numberOfNodes = System.getProperty("cluster.number_of_nodes", "1")!!.toInt()
     protected val isMultiNode = numberOfNodes > 1
 
-    protected val statsResponseOpendistroSweeperEnabledSetting = "opendistro.scheduled_jobs.enabled"
-    protected val statsResponseOpenSearchSweeperEnabledSetting = "plugins.scheduled_jobs.enabled"
+    protected val statsResponseOpendistroSweeperEnabledField = "opendistro.scheduled_jobs.enabled"
+    protected val statsResponseOpenSearchSweeperEnabledField = "plugins.scheduled_jobs.enabled"
 
     override fun xContentRegistry(): NamedXContentRegistry {
         return NamedXContentRegistry(

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
@@ -69,6 +69,9 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
     protected val numberOfNodes = System.getProperty("cluster.number_of_nodes", "1")!!.toInt()
     protected val isMultiNode = numberOfNodes > 1
 
+    protected val statsResponseOpendistroSweeperEnabledSetting = "opendistro.scheduled_jobs.enabled"
+    protected val statsResponseOpenSearchSweeperEnabledSetting = "plugins.scheduled_jobs.enabled"
+
     override fun xContentRegistry(): NamedXContentRegistry {
         return NamedXContentRegistry(
             mutableListOf(

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -1103,12 +1103,12 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         assertEquals(
             "Legacy scheduled job enabled field is not set to $expected",
             expected,
-            alertingStatsResponse[statsResponseOpendistroSweeperEnabledSetting]
+            alertingStatsResponse[statsResponseOpendistroSweeperEnabledField]
         )
         assertEquals(
             "Scheduled job is not ${if (expected) "enabled" else "disabled"}",
             expected,
-            alertingStatsResponse[statsResponseOpenSearchSweeperEnabledSetting]
+            alertingStatsResponse[statsResponseOpenSearchSweeperEnabledField]
         )
     }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -886,8 +886,7 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         disableScheduledJob()
 
         val responseMap = getAlertingStats()
-        // assertEquals("Cluster name is incorrect", responseMap["cluster_name"], "alerting_integTestCluster")
-        assertEquals("Scheduled job is not enabled", false, responseMap[ScheduledJobSettings.SWEEPER_ENABLED.key])
+        assertAlertingStatsSweeperEnabled(responseMap, false)
         assertEquals("Scheduled job index exists but there are no scheduled jobs.", false, responseMap["scheduled_job_index_exists"])
         val _nodes = responseMap["_nodes"] as Map<String, Int>
         validateAlertingStatsNodeResponse(_nodes)
@@ -899,7 +898,7 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         val monitorId = createMonitor(randomQueryLevelMonitor(enabled = true), refresh = true).id
 
         var alertingStats = getAlertingStats()
-        assertEquals("Scheduled job is not enabled", true, alertingStats[ScheduledJobSettings.SWEEPER_ENABLED.key])
+        assertAlertingStatsSweeperEnabled(alertingStats, true)
         assertEquals("Scheduled job index does not exist", true, alertingStats["scheduled_job_index_exists"])
         assertEquals("Scheduled job index is not yellow", "yellow", alertingStats["scheduled_job_index_status"])
         assertEquals("Nodes are not on schedule", numberOfNodes, alertingStats["nodes_on_schedule"])
@@ -916,7 +915,7 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         disableScheduledJob()
 
         alertingStats = getAlertingStats()
-        assertEquals("Scheduled job is still enabled", false, alertingStats[ScheduledJobSettings.SWEEPER_ENABLED.key])
+        assertAlertingStatsSweeperEnabled(alertingStats, false)
         assertFalse(
             "Monitor [$monitorId] was still scheduled based on the alerting stats response: $alertingStats",
             isMonitorScheduled(monitorId, alertingStats)
@@ -929,7 +928,7 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         Thread.sleep(2000)
 
         alertingStats = getAlertingStats()
-        assertEquals("Scheduled job is not enabled", true, alertingStats[ScheduledJobSettings.SWEEPER_ENABLED.key])
+        assertAlertingStatsSweeperEnabled(alertingStats, true)
         assertTrue(
             "Monitor [$monitorId] was not re-scheduled based on the alerting stats response: $alertingStats",
             isMonitorScheduled(monitorId, alertingStats)
@@ -941,8 +940,7 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         enableScheduledJob()
 
         val responseMap = getAlertingStats()
-        // assertEquals("Cluster name is incorrect", responseMap["cluster_name"], "alerting_integTestCluster")
-        assertEquals("Scheduled job is not enabled", true, responseMap[ScheduledJobSettings.SWEEPER_ENABLED.key])
+        assertAlertingStatsSweeperEnabled(responseMap, true)
         assertEquals("Scheduled job index exists but there are no scheduled jobs.", false, responseMap["scheduled_job_index_exists"])
         val _nodes = responseMap["_nodes"] as Map<String, Int>
         validateAlertingStatsNodeResponse(_nodes)
@@ -954,8 +952,7 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         createRandomMonitor(refresh = true)
 
         val responseMap = getAlertingStats()
-        // assertEquals("Cluster name is incorrect", responseMap["cluster_name"], "alerting_integTestCluster")
-        assertEquals("Scheduled job is not enabled", true, responseMap[ScheduledJobSettings.SWEEPER_ENABLED.key])
+        assertAlertingStatsSweeperEnabled(responseMap, true)
         assertEquals("Scheduled job index does not exist", true, responseMap["scheduled_job_index_exists"])
         assertEquals("Scheduled job index is not yellow", "yellow", responseMap["scheduled_job_index_status"])
         assertEquals("Nodes are not on schedule", numberOfNodes, responseMap["nodes_on_schedule"])
@@ -983,8 +980,7 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         createRandomMonitor(refresh = true)
 
         val responseMap = getAlertingStats("/jobs_info")
-        // assertEquals("Cluster name is incorrect", responseMap["cluster_name"], "alerting_integTestCluster")
-        assertEquals("Scheduled job is not enabled", true, responseMap[ScheduledJobSettings.SWEEPER_ENABLED.key])
+        assertAlertingStatsSweeperEnabled(responseMap, true)
         assertEquals("Scheduled job index does not exist", true, responseMap["scheduled_job_index_exists"])
         assertEquals("Scheduled job index is not yellow", "yellow", responseMap["scheduled_job_index_status"])
         assertEquals("Nodes not on schedule", numberOfNodes, responseMap["nodes_on_schedule"])
@@ -1101,5 +1097,18 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         }
 
         return false
+    }
+
+    private fun assertAlertingStatsSweeperEnabled(alertingStatsResponse: Map<String, Any>, expected: Boolean) {
+        assertEquals(
+            "Legacy scheduled job enabled field is not set to $expected",
+            expected,
+            alertingStatsResponse[statsResponseOpendistroSweeperEnabledSetting]
+        )
+        assertEquals(
+            "Scheduled job is not ${if (expected) "enabled" else "disabled"}",
+            expected,
+            alertingStatsResponse[statsResponseOpenSearchSweeperEnabledSetting]
+        )
     }
 }

--- a/core/src/main/kotlin/org/opensearch/alerting/core/action/node/ScheduledJobsStatsResponse.kt
+++ b/core/src/main/kotlin/org/opensearch/alerting/core/action/node/ScheduledJobsStatsResponse.kt
@@ -7,6 +7,7 @@ package org.opensearch.alerting.core.action.node
 
 import org.opensearch.action.FailedNodeException
 import org.opensearch.action.support.nodes.BaseNodesResponse
+import org.opensearch.alerting.core.settings.LegacyOpenDistroScheduledJobSettings
 import org.opensearch.alerting.core.settings.ScheduledJobSettings
 import org.opensearch.cluster.ClusterName
 import org.opensearch.cluster.health.ClusterIndexHealth
@@ -56,6 +57,7 @@ class ScheduledJobsStatsResponse : BaseNodesResponse<ScheduledJobStats>, ToXCont
     }
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        builder.field(LegacyOpenDistroScheduledJobSettings.SWEEPER_ENABLED.key, scheduledJobEnabled)
         builder.field(ScheduledJobSettings.SWEEPER_ENABLED.key, scheduledJobEnabled)
         builder.field("scheduled_job_index_exists", indexExists)
         builder.field("scheduled_job_index_status", indexHealth?.status?.name?.toLowerCase())


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <qreshi@amazon.com>

*Issue #, if available:*

*Description of changes:*
The `opendistro` prefixed field response for sweeper/scheduled jobs enabled in the [Alerting Stats API](https://opensearch.org/docs/latest/monitoring-plugins/alerting/api/#monitor-stats) was inadvertently changed to `plugins` during the migration to OpenSearch. This change reintroduces the legacy field back alongside the existing `plugins` one to maintain backwards compatibility and to not break behavior for anyone using the current field.

This PR also updates the existing tests asserting on the response of the stats API to use hardcoded values for the scheduled jobs enabled field instead of referring to the `Setting.key` so it can catch a change like this in the future. We should also see if any other tests are currently checking API responses this way. Fixing those, however, is out of scope for this particular PR.

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).