### PR TITLE
Update security test GitHub Action workflow to use Docker staging repo again

### DIFF
--- a/.github/workflows/security-test-workflow.yml
+++ b/.github/workflows/security-test-workflow.yml
@@ -44,9 +44,9 @@ jobs:
           candidate_version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-1`
           echo $version $plugin_version $candidate_version
           echo $ls $list_of_all_files
-          if docker pull opensearchproject/opensearch:$version
+          if docker pull opensearchstaging/opensearch:$version
           then
-            echo "FROM opensearchproject/opensearch:$version" >> Dockerfile
+            echo "FROM opensearchstaging/opensearch:$version" >> Dockerfile
             echo "RUN if [ -d /usr/share/opensearch/plugins/opensearch-alerting ]; then /usr/share/opensearch/bin/opensearch-plugin remove opensearch-alerting; fi" >> Dockerfile
             echo "ADD alerting/build/distributions/opensearch-alerting-$plugin_version-$candidate_version.zip /tmp/" >> Dockerfile
             echo "RUN /usr/share/opensearch/bin/opensearch-plugin install --batch file:/tmp/opensearch-alerting-$plugin_version-$candidate_version.zip" >> Dockerfile


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The GitHub Action workflow for running Alerting security tests for `1.1` branch was recently updated to use the non-staging Docker image to pull the OpenSearch image since `1.1.0` was not available in staging. Since `1.1.0` is available in staging now, the workflow is being changed back to be consistent with the other branches.

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).