### PR TITLE
Fix security tests with partial permissions

### DIFF
--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
@@ -87,8 +87,8 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         return entityAsMap(this)
     }
 
-    protected fun createMonitor(monitor: Monitor, refresh: Boolean = true): Monitor {
-        val response = client().makeRequest(
+    protected fun createMonitorWithClient(client: RestClient, monitor: Monitor, refresh: Boolean = true): Monitor {
+        val response = client.makeRequest(
             "POST", "$ALERTING_BASE_URI?refresh=$refresh", emptyMap(),
             monitor.toHttpEntity()
         )
@@ -100,6 +100,10 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         ).map()
         assertUserNull(monitorJson as HashMap<String, Any>)
         return monitor.copy(id = monitorJson["_id"] as String, version = (monitorJson["_version"] as Int).toLong())
+    }
+
+    protected fun createMonitor(monitor: Monitor, refresh: Boolean = true): Monitor {
+        return createMonitorWithClient(client(), monitor, refresh)
     }
 
     protected fun deleteMonitor(monitor: Monitor, refresh: Boolean = true): Response {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
@@ -218,7 +218,10 @@ val TEST_HR_INDEX = "hr_data"
 val TEST_NON_HR_INDEX = "not_hr_data"
 val TEST_HR_ROLE = "hr_role"
 val TEST_HR_BACKEND_ROLE = "HR"
-val TERM_DLS_QUERY = "{\"term\": { \"accessible\": true}}"
+// Using a triple-quote string for the query so escaped quotes are kept as-is
+// in the request made using triple-quote strings (i.e. createIndexRoleWithDocLevelSecurity).
+// Removing the escape slash in the request causes the security API role request to fail with parsing exception.
+val TERM_DLS_QUERY = """{\"term\": { \"accessible\": true}}"""
 
 fun randomTemplateScript(
     source: String,

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -645,7 +645,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             """.trimIndent()
         )
 
-        // Add a second doc that is not accesible to the user
+        // Add a second doc that is not accessible to the user
         indexDoc(
             TEST_HR_INDEX, "2",
             """
@@ -662,11 +662,14 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             return ctx.results[0].hits.hits.size() == 1
         """.trimIndent()
 
-        val trigger = randomQueryLevelTrigger(condition = Script(triggerScript))
-        val monitor = randomQueryLevelMonitor(inputs = listOf(input), triggers = listOf(trigger))
+        val trigger = randomQueryLevelTrigger(condition = Script(triggerScript)).copy(actions = listOf())
+        val monitor = createMonitorWithClient(
+            userClient!!,
+            randomQueryLevelMonitor(inputs = listOf(input), triggers = listOf(trigger))
+        )
 
         try {
-            executeMonitor(monitor.id, params = DRYRUN_MONITOR)
+            executeMonitor(monitor.id)
             val alerts = searchAlerts(monitor)
             assertEquals("Incorrect number of alerts", 1, alerts.size)
         } finally {
@@ -696,7 +699,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             """.trimIndent()
         )
 
-        // Add a second doc that is not accesible to the user
+        // Add a second doc that is not accessible to the user
         indexDoc(
             TEST_HR_INDEX, "2",
             """
@@ -727,12 +730,16 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
                 script = Script(triggerScript),
                 parentBucketPath = "composite_agg",
                 filter = null
-            )
+            ),
+            actions = listOf()
         )
-        val monitor = createMonitor(randomBucketLevelMonitor(inputs = listOf(input), enabled = false, triggers = listOf(trigger)))
+        val monitor = createMonitorWithClient(
+            userClient!!,
+            randomBucketLevelMonitor(inputs = listOf(input), enabled = false, triggers = listOf(trigger))
+        )
 
         try {
-            executeMonitor(monitor.id, params = DRYRUN_MONITOR)
+            executeMonitor(monitor.id)
             val alerts = searchAlerts(monitor)
             assertEquals("Incorrect number of alerts", 1, alerts.size)
         } finally {


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <qreshi@amazon.com>

*Issue #, if available:*

*Description of changes:*
The security tests added as part of #281 were failing but did not get reflected in the recent GitHub Action runs because the workflow was skipping the test since it did not find the security plugin in the `_cat/plugins` response (this still appears as a workflow pass which should also probably be updated). This change is to update the tests so that they work properly. Since the parent change was backported up to `1.1`, the security test fixes will also be backported that far so all test are passing in all relevant branches.

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).