### PR TITLE
Fix flaky BWC test

### DIFF
--- a/alerting/src/test/kotlin/org/opensearch/alerting/bwc/AlertingBackwardsCompatibilityIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/bwc/AlertingBackwardsCompatibilityIT.kt
@@ -59,11 +59,6 @@ class AlertingBackwardsCompatibilityIT : AlertingRestTestCase() {
                 ClusterType.MIXED -> {
                     assertTrue(pluginNames.contains("opensearch-alerting"))
                     verifyMonitorExists(LEGACY_OPENDISTRO_ALERTING_BASE_URI)
-                    // Waiting a minute to ensure the Monitor ran again at least once before checking if the job is running
-                    // on time
-                    // TODO: Should probably change the next execution time of the Monitor manually instead since this inflates
-                    //  the test execution by a lot
-                    Thread.sleep(60000)
                     // TODO: Need to move the base URI being used here into a constant and rename ALERTING_BASE_URI to
                     //  MONITOR_BASE_URI
                     verifyMonitorStats("/_opendistro/_alerting")
@@ -71,6 +66,10 @@ class AlertingBackwardsCompatibilityIT : AlertingRestTestCase() {
                 ClusterType.UPGRADED -> {
                     assertTrue(pluginNames.contains("opensearch-alerting"))
                     verifyMonitorExists(ALERTING_BASE_URI)
+                    // TODO: Change the next execution time of the Monitor manually instead since this inflates
+                    //  the test execution by a lot (might have to wait for Job Scheduler plugin integration first)
+                    // Waiting a minute to ensure the Monitor ran again at least once before checking if the job is running
+                    // on time
                     Thread.sleep(60000)
                     verifyMonitorStats("/_plugins/_alerting")
                 }


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <qreshi@amazon.com>

*Issue #, if available:* #241

*Description of changes:*
The BWC tests will occasionally fail on the `twoThirdsUpgradedClusterTask`. It seems that there is some race condition that can lead to some test cluster changes to not go through due to the sleep being done in the mixed cluster scenario. For the time being, the sleep will be removed from `MIXED_CLUSTER` scenario as this was shown to remove flakiness.

The sleeps were initially put in to give time for a Monitor execution in between assertions but the current checks in mixed state will suffice. Once we have an easy way to artificially forward Monitor executions (which will likely be after integration with Job Scheduler since the next execution time isn't stored in the Monitor job currently) then we can add additional checks without relying on sleeps.

**Some local verification**:
### Multiple test runs before change
```
(22-01-31 17:22:48) <0> [~/workspace/opensearch-alerting]
qreshi % for i in {1..10}; do ./gradlew bwcTestSuite &> /dev/null || echo "Run $i failed"; done
Run 1 failed
Run 4 failed
Run 6 failed
Run 7 failed
Run 9 failed
```

### Multiple test runs after removal of sleep
```
(22-01-29 1:06:34) <0> [~/workspace/opensearch-alerting]
qreshi % for i in {1..10}; do ./gradlew bwcTestSuite &> /dev/null || echo "Run $i failed"; done
```

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).