### PR TITLE
Fix flaky tests for Bucket-Level Monitor

### DIFF
--- a/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
@@ -157,9 +157,12 @@ fun randomBucketLevelTrigger(
         name = name,
         severity = severity,
         bucketSelector = bucketSelector,
-        actions = if (actions.isEmpty()) (0..randomInt(10)).map { randomActionWithPolicy(destinationId = destinationId) } else actions
+        actions = if (actions.isEmpty()) randomActionsForBucketLevelTrigger(destinationId = destinationId) else actions
     )
 }
+
+fun randomActionsForBucketLevelTrigger(min: Int = 0, max: Int = 10, destinationId: String = ""): List<Action> =
+    (min..randomInt(max)).map { randomActionWithPolicy(destinationId = destinationId) }
 
 fun randomBucketSelectorExtAggregationBuilder(
     name: String = OpenSearchRestTestCase.randomAlphaOfLength(10),


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <47198598+qreshi@users.noreply.github.com>

*Issue #, if available:* #298

*Description of changes:*
Monitor configurations are randomized during the plugin integration tests for the components that aren't being explicitly tested for specific scenarios so the test cases aren't overfit for a single situation. For Bucket-Level Monitors, this could lead to the Actions under a Trigger to sometimes be empty (0 Actions) or contain Actions in such a configuration that it no-ops (i.e. PerExecutionScope with no Alert categories configured). These types of configurations were rare but led to resulting Alerts to either be null (for new Alerts) or not updated (for existing Alerts) in some tests which failed assertions, making these tests flaky. This PR updates those tests to account for this scenario to ensure that these cases don't happen.


**Commands used to reproduce the flaky tests (confirmed they passed after the changes)**:
```
./gradlew ':alerting:integTest' --tests "org.opensearch.alerting.MonitorRunnerIT.test bucket-level monitor with acknowledged alert" -Dtests.seed=39548DC170E2D9BD -Dtests.security.manager=false -Dtests.locale=hr-HR -Dtests.timezone=PNT -Druntime.java=14


./gradlew ':alerting:integTest' --tests "org.opensearch.alerting.MonitorRunnerIT.test bucket-level monitor alert creation and completion" -Dtests.seed=B2CAC72979FAC242 -Dtests.security.manager=false -Dtests.locale=ro-RO -Dtests.timezone=Europe/Lisbon -Druntime.java=14
```

**Re-ran tests multiple times afterwards to check for any other flaky tests**:
```
for i in {1..40}; do ./gradlew ':alerting:integTest' &> /dev/null || echo "Run $i failed"; done
```

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).