### PR TITLE
Use OpenSearch 2.0.0-alpha1

### DIFF
--- a/.github/workflows/bwc-test-workflow.yml
+++ b/.github/workflows/bwc-test-workflow.yml
@@ -34,4 +34,4 @@ jobs:
       - name: Run Alerting Backwards Compatibility Tests
         run: |
           echo "Running backwards compatibility tests..."
-          ./gradlew bwcTestSuite
+          ./gradlew bwcTestSuite -Dbuild.qualifier=alpha1

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v2
       - name: Run integration tests with multi node config
-        run: ./gradlew integTest -PnumNodes=3
+        run: ./gradlew integTest -PnumNodes=3 -Dbuild.qualifier=alpha1

--- a/.github/workflows/security-test-workflow.yml
+++ b/.github/workflows/security-test-workflow.yml
@@ -33,7 +33,7 @@ jobs:
           java-version: 11
       - name: Build Alerting
         # Only assembling since the full build is governed by other workflows
-        run: ./gradlew assemble
+        run: ./gradlew assemble -Dbuild.qualifier=alpha1
       - name: Pull and Run Docker
         run: |
           plugin=`ls alerting/build/distributions/*.zip`

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Build and run with Gradle
-        run: ./gradlew build
+        run: ./gradlew build -Dbuild.qualifier=alpha1
       - name: Create Artifact Path
         run: |
           mkdir -p alerting-artifacts

--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -161,7 +161,7 @@ String bwcFilePath = "src/test/resources/bwc"
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-            versions = ["7.10.2","2.0.0-SNAPSHOT"]
+            versions = ["7.10.2","2.0.0-alpha1-SNAPSHOT"]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>(){
                 @Override

--- a/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
@@ -79,9 +79,6 @@ class AlertIndices(
         /** The in progress alert history index. */
         const val ALERT_INDEX = ".opendistro-alerting-alerts"
 
-        /** The Elastic mapping type */
-        const val MAPPING_TYPE = "_doc"
-
         /** The alias of the index in which to write alert history */
         const val HISTORY_WRITE_INDEX = ".opendistro-alerting-alert-history-write"
 
@@ -212,7 +209,7 @@ class AlertIndices(
         if (existsResponse.isExists) return true
 
         val request = CreateIndexRequest(index)
-            .mapping(MAPPING_TYPE, alertMapping(), XContentType.JSON)
+            .mapping(alertMapping())
             .settings(Settings.builder().put("index.hidden", true).build())
 
         if (alias != null) request.alias(Alias(alias))
@@ -267,7 +264,7 @@ class AlertIndices(
         // We have to pass null for newIndexName in order to get Elastic to increment the index count.
         val request = RolloverRequest(HISTORY_WRITE_INDEX, null)
         request.createIndexRequest.index(HISTORY_INDEX_PATTERN)
-            .mapping(MAPPING_TYPE, alertMapping(), XContentType.JSON)
+            .mapping(alertMapping())
             .settings(Settings.builder().put("index.hidden", true).build())
         request.addMaxIndexDocsCondition(historyMaxDocs)
         request.addMaxIndexAgeCondition(historyMaxAge)

--- a/alerting/src/test/kotlin/org/opensearch/alerting/aggregation/bucketselectorext/BucketSelectorExtAggregatorTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/aggregation/bucketselectorext/BucketSelectorExtAggregatorTests.kt
@@ -9,9 +9,9 @@ import org.apache.lucene.document.Document
 import org.apache.lucene.document.SortedNumericDocValuesField
 import org.apache.lucene.document.SortedSetDocValuesField
 import org.apache.lucene.index.DirectoryReader
-import org.apache.lucene.index.RandomIndexWriter
 import org.apache.lucene.search.MatchAllDocsQuery
 import org.apache.lucene.search.Query
+import org.apache.lucene.tests.index.RandomIndexWriter
 import org.apache.lucene.util.BytesRef
 import org.hamcrest.CoreMatchers
 import org.opensearch.common.CheckedConsumer

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     apply from: 'build-tools/repositories.gradle'
 
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.0.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.0.0-alpha1-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         // 2.0.0-alpha1-SNAPSHOT -> 2.0.0.0-alpha1-SNAPSHOT

--- a/core/src/main/kotlin/org/opensearch/alerting/core/ScheduledJobIndices.kt
+++ b/core/src/main/kotlin/org/opensearch/alerting/core/ScheduledJobIndices.kt
@@ -13,7 +13,6 @@ import org.opensearch.client.AdminClient
 import org.opensearch.cluster.health.ClusterIndexHealth
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.settings.Settings
-import org.opensearch.common.xcontent.XContentType
 
 /**
  * Initialize the OpenSearch components required to run [ScheduledJobs].
@@ -38,7 +37,7 @@ class ScheduledJobIndices(private val client: AdminClient, private val clusterSe
     fun initScheduledJobIndex(actionListener: ActionListener<CreateIndexResponse>) {
         if (!scheduledJobIndexExists()) {
             var indexRequest = CreateIndexRequest(ScheduledJob.SCHEDULED_JOBS_INDEX)
-                .mapping(ScheduledJob.SCHEDULED_JOB_TYPE, scheduledJobMappings(), XContentType.JSON)
+                .mapping(scheduledJobMappings())
                 .settings(Settings.builder().put("index.hidden", true).build())
             client.indices().create(indexRequest, actionListener)
         }

--- a/core/src/main/kotlin/org/opensearch/alerting/core/model/ScheduledJob.kt
+++ b/core/src/main/kotlin/org/opensearch/alerting/core/model/ScheduledJob.kt
@@ -37,14 +37,6 @@ interface ScheduledJob : Writeable, ToXContentObject {
         /** The name of the ElasticSearch index in which we store jobs */
         const val SCHEDULED_JOBS_INDEX = ".opendistro-alerting-config"
 
-        /**
-         * The mapping type of [ScheduledJob]s in the OpenSearch index. Unrelated to [ScheduledJob.type].
-         *
-         * This should go away starting ES 7. We use "_doc" for future compatibility as described here:
-         * https://www.elastic.co/guide/en/elasticsearch/reference/6.x/removal-of-types.html#_schedule_for_removal_of_mapping_types
-         */
-        const val SCHEDULED_JOB_TYPE = "_doc"
-
         const val NO_ID = ""
 
         const val NO_VERSION = 1L


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Bumps OpenSearch version being used from `2.0.0` to `2.0.0-alpha1`
* Removes mapping type usage
* Adds `-Dbuild.qualifier=alpha1` to the GitHub Actions to ensure we're using `alpha` for dependencies as well (i.e. `common-utils`)

The security workflow is still expected to fail for now since the Docker image with security plugin 2.0 is not available yet.

*CheckList:*
[ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).