### PR TITLE
Bumped 1.x branch version to 1.4 to align with OpenSearch 1.x branch.

### DIFF
--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v2
       - name: Run integration tests with multi node config
-        run: ./gradlew integTest -PnumNodes=3 -Dopensearch.version=1.3.0-SNAPSHOT
+        run: ./gradlew integTest -PnumNodes=3 -Dopensearch.version=1.4.0-SNAPSHOT

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Build and run with Gradle
-        run: ./gradlew build -Dopensearch.version=1.3.0-SNAPSHOT
+        run: ./gradlew build -Dopensearch.version=1.4.0-SNAPSHOT
       - name: Create Artifact Path
         run: |
           mkdir -p alerting-artifacts

--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -161,7 +161,7 @@ String bwcFilePath = "src/test/resources/bwc"
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-            versions = ["7.10.2","1.3.0-SNAPSHOT"]
+            versions = ["7.10.2","1.4.0-SNAPSHOT"]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>(){
                 @Override

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     apply from: 'build-tools/repositories.gradle'
 
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.3.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "1.4.0-SNAPSHOT")
         // 1.0.0 -> 1.0.0.0, and 1.0.0-SNAPSHOT -> 1.0.0.0-SNAPSHOT
         opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bumped `1.x` branch version to `1.4` to align with [OpenSearch 1.x branch](https://github.com/dreamer-89/OpenSearch/blob/1.x/server/src/main/java/org/opensearch/Version.java#L85).

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).