### PR TITLE
Add build qualifier default to alpha1 for 2.0.0

### DIFF
--- a/.github/workflows/bwc-test-workflow.yml
+++ b/.github/workflows/bwc-test-workflow.yml
@@ -34,4 +34,4 @@ jobs:
       - name: Run Alerting Backwards Compatibility Tests
         run: |
           echo "Running backwards compatibility tests..."
-          ./gradlew bwcTestSuite -Dbuild.qualifier=alpha1
+          ./gradlew bwcTestSuite

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v2
       - name: Run integration tests with multi node config
-        run: ./gradlew integTest -PnumNodes=3 -Dbuild.qualifier=alpha1
+        run: ./gradlew integTest -PnumNodes=3

--- a/.github/workflows/security-test-workflow.yml
+++ b/.github/workflows/security-test-workflow.yml
@@ -33,7 +33,7 @@ jobs:
           java-version: 11
       - name: Build Alerting
         # Only assembling since the full build is governed by other workflows
-        run: ./gradlew assemble -Dbuild.qualifier=alpha1
+        run: ./gradlew assemble
       - name: Pull and Run Docker
         run: |
           plugin=`ls alerting/build/distributions/*.zip`

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Build and run with Gradle
-        run: ./gradlew build -Dbuild.qualifier=alpha1
+        run: ./gradlew build
       - name: Create Artifact Path
         run: |
           mkdir -p alerting-artifacts

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 
     ext {
         opensearch_version = System.getProperty("opensearch.version", "2.0.0-alpha1-SNAPSHOT")
-        buildVersionQualifier = System.getProperty("build.version_qualifier")
+        buildVersionQualifier = System.getProperty("build.version_qualifier", "alpha1")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         // 2.0.0-alpha1-SNAPSHOT -> 2.0.0.0-alpha1-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

*Issue #, if available:*
#348

*Description of changes:*
Add build qualifier default to alpha1 for 2.0.0

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).