### PR TITLE
Make sure alerting is using the build script in its own repo

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -18,7 +18,7 @@ function usage() {
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:p:a:" arg; do
+while getopts ":h:v:q:s:o:p:a:" arg; do
     case $arg in
         h)
             usage
@@ -78,6 +78,6 @@ cp ${distributions}/*.zip ./$OUTPUT/plugins
 ./gradlew publishShadowPublicationToStagingRepository -Dopensearch.version=$VERSION -Dbuild.version_qualifier=$QUALIFIER -Dbuild.snapshot=$SNAPSHOT
 
 mkdir -p $OUTPUT/maven/org/opensearch
-cp -r ./build/local-staging-repo/org/opensearch/notification $OUTPUT/maven/org/opensearch/notification
+cp -r ./build/local-staging-repo/org/opensearch/. $OUTPUT/maven/org/opensearch
 
 


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

*Issue #, if available:*
#348

*Description of changes:*
Make sure alerting is using the build script in its own repo


We have 2 Alerting build script, one in build repo one in Alerting repo.
Our code base define that build repo script take priority over the Alerting repo script.
It would be better for Alerting to host their own build script in Alerting repo.

This is a pre-requisite to keep both script consistent before we remove the build script from build repo.

Example existing calls:
```
2022-03-29 18:42:25 INFO     Executing "bash /var/jenkins/workspace/distribution-build-opensearch/scripts/components/alerting/build.sh -v 1.3.1 -p linux -a arm64 -s false -o builds" in /tmp/tmpz94r2nd7/alerting
```


*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).