### PR TITLE
Integrate with Notifications plugin for Alerting backend

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
@@ -658,6 +658,7 @@ object MonitorRunner : JobRunner, CoroutineScope, AbstractLifecycleComponent() {
                 throw IllegalStateException("Message content missing in the Destination with id: ${action.destinationId}")
             }
             if (!dryrun) {
+                // TODO: Inject user here so only Destination/Notifications that the user has permissions to are retrieved
                 withContext(Dispatchers.IO) {
                     actionOutput[MESSAGE_ID] = getConfigAndSendNotification(action, actionOutput[SUBJECT], actionOutput[MESSAGE]!!)
                 }
@@ -679,6 +680,7 @@ object MonitorRunner : JobRunner, CoroutineScope, AbstractLifecycleComponent() {
                 throw IllegalStateException("Message content missing in the Destination with id: ${action.destinationId}")
             }
             if (!dryrun) {
+                // TODO: Inject user here so only Destination/Notifications that the user has permissions to are retrieved
                 withContext(Dispatchers.IO) {
                     actionOutput[MESSAGE_ID] = getConfigAndSendNotification(action, actionOutput[SUBJECT], actionOutput[MESSAGE]!!)
                 }
@@ -709,14 +711,12 @@ object MonitorRunner : JobRunner, CoroutineScope, AbstractLifecycleComponent() {
         }
 
         var actionResponseContent = ""
-        // TODO: For now, the sendNotification just returns an event ID. If the response changes to return
-        //  some form of response content, similar to Alerting's legacy Destination, use it for the actionOutput
-        config.channel
+        actionResponseContent = config.channel
             ?.sendNotification(
                 client,
                 "Alerting-Notification Action",
                 constructMessageContent(subject, message)
-            )
+            ) ?: actionResponseContent
 
         actionResponseContent = config.destination
             ?.buildLegacyBaseMessage(subject, message, destinationContextFactory.getDestinationContext(config.destination))
@@ -739,7 +739,6 @@ object MonitorRunner : JobRunner, CoroutineScope, AbstractLifecycleComponent() {
      * To cover both of these cases, the Notification config will take precedence and if it is not found, the Destination will be retrieved.
      */
     private suspend fun getConfigForNotificationAction(action: Action): NotificationActionConfigs {
-        // TODO: Inject user here so only Destination/Notifications that the user has permissions to are retrieved
         var destination: Destination? = null
         val channel: NotificationConfigInfo? = getNotificationConfigInfo(client as NodeClient, action.destinationId)
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
@@ -57,7 +57,8 @@ import org.opensearch.alerting.settings.DestinationSettings.Companion.loadDestin
 import org.opensearch.alerting.settings.LegacyOpenDistroDestinationSettings.Companion.HOST_DENY_LIST_NONE
 import org.opensearch.alerting.util.destinationmigration.NotificationActionConfigs
 import org.opensearch.alerting.util.destinationmigration.NotificationApiUtils.Companion.getNotificationConfigInfo
-import org.opensearch.alerting.util.destinationmigration.constructMessageContent
+import org.opensearch.alerting.util.destinationmigration.createMessageContent
+import org.opensearch.alerting.util.destinationmigration.getTitle
 import org.opensearch.alerting.util.destinationmigration.publishLegacyNotification
 import org.opensearch.alerting.util.destinationmigration.sendNotification
 import org.opensearch.alerting.util.getActionExecutionPolicy
@@ -714,8 +715,8 @@ object MonitorRunner : JobRunner, CoroutineScope, AbstractLifecycleComponent() {
         actionResponseContent = config.channel
             ?.sendNotification(
                 client,
-                "Alerting-Notification Action",
-                constructMessageContent(subject, message)
+                config.channel.getTitle(subject),
+                config.channel.createMessageContent(subject, message)
             ) ?: actionResponseContent
 
         actionResponseContent = config.destination

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/destination/Chime.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/destination/Chime.kt
@@ -5,16 +5,13 @@
 
 package org.opensearch.alerting.model.destination
 
-import org.opensearch.alerting.opensearchapi.string
 import org.opensearch.common.Strings
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.StreamOutput
 import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentBuilder
-import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
-import org.opensearch.common.xcontent.XContentType
 import java.io.IOException
 import java.lang.IllegalStateException
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/destination/Chime.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/destination/Chime.kt
@@ -71,12 +71,8 @@ data class Chime(val url: String) : ToXContent {
         }
     }
 
-    fun constructMessageContent(subject: String?, message: String?): String {
-        val messageContent: String? = if (Strings.isNullOrEmpty(subject)) message else "$subject \n\n $message"
-        val builder = XContentFactory.contentBuilder(XContentType.JSON)
-        builder.startObject()
-            .field("Content", messageContent)
-            .endObject()
-        return builder.string()
+    // Complete JSON structure is now constructed in the notification plugin
+    fun constructMessageContent(subject: String?, message: String): String {
+        return if (Strings.isNullOrEmpty(subject)) message else "$subject \n\n $message"
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/destination/Destination.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/destination/Destination.kt
@@ -264,11 +264,10 @@ data class Destination(
                     .withHeaderParams(customWebhook?.headerParams)
                     .withMessage(compiledMessage).build()
             }
-            // TODO: Need to update common-utils to support EMAIL as a legacy destination before adding this
             DestinationType.EMAIL -> {
                 val emailAccount = destinationCtx.emailAccount
-                // Use the account name as the Destination name here, Notifications will use it to resolve credentials
-                destinationMessage = LegacyEmailMessage.Builder(emailAccount?.name ?: name)
+                destinationMessage = LegacyEmailMessage.Builder(name)
+                    .withAccountName(emailAccount?.name)
                     .withHost(emailAccount?.host)
                     .withPort(emailAccount?.port)
                     .withMethod(emailAccount?.method?.let { convertAlertingToNotificationMethodType(it).toString() })

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/destination/Destination.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/destination/Destination.kt
@@ -6,9 +6,6 @@
 package org.opensearch.alerting.model.destination
 
 import org.apache.logging.log4j.LogManager
-import org.opensearch.alerting.destination.Notification
-import org.opensearch.alerting.destination.message.BaseMessage
-import org.opensearch.alerting.destination.message.EmailMessage
 import org.opensearch.alerting.model.destination.email.Email
 import org.opensearch.alerting.opensearchapi.convertToMap
 import org.opensearch.alerting.opensearchapi.instant

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/destination/Destination.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/destination/Destination.kt
@@ -6,12 +6,6 @@
 package org.opensearch.alerting.model.destination
 
 import org.apache.logging.log4j.LogManager
-import org.opensearch.alerting.destination.Notification
-import org.opensearch.alerting.destination.message.BaseMessage
-import org.opensearch.alerting.destination.message.ChimeMessage
-import org.opensearch.alerting.destination.message.CustomWebhookMessage
-import org.opensearch.alerting.destination.message.EmailMessage
-import org.opensearch.alerting.destination.message.SlackMessage
 import org.opensearch.alerting.model.destination.email.Email
 import org.opensearch.alerting.opensearchapi.convertToMap
 import org.opensearch.alerting.opensearchapi.instant
@@ -19,7 +13,6 @@ import org.opensearch.alerting.opensearchapi.optionalTimeField
 import org.opensearch.alerting.opensearchapi.optionalUserField
 import org.opensearch.alerting.util.DestinationType
 import org.opensearch.alerting.util.IndexUtils.Companion.NO_SCHEMA_VERSION
-import org.opensearch.alerting.util.isHostInDenylist
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.StreamOutput
 import org.opensearch.common.xcontent.ToXContent
@@ -32,7 +25,6 @@ import org.opensearch.commons.destination.message.LegacyChimeMessage
 import org.opensearch.commons.destination.message.LegacyCustomWebhookMessage
 import org.opensearch.commons.destination.message.LegacySlackMessage
 import java.io.IOException
-import java.net.InetAddress
 import java.time.Instant
 import java.util.Locale
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/destination/Slack.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/destination/Slack.kt
@@ -5,16 +5,13 @@
 
 package org.opensearch.alerting.model.destination
 
-import org.opensearch.alerting.opensearchapi.string
 import org.opensearch.common.Strings
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.StreamOutput
 import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentBuilder
-import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
-import org.opensearch.common.xcontent.XContentType
 import java.io.IOException
 import java.lang.IllegalStateException
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/destination/Slack.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/destination/Slack.kt
@@ -71,12 +71,8 @@ data class Slack(val url: String) : ToXContent {
         }
     }
 
+    // Complete JSON structure is now constructed in the notification plugin
     fun constructMessageContent(subject: String?, message: String): String {
-        val messageContent: String? = if (Strings.isNullOrEmpty(subject)) message else "$subject \n\n $message"
-        val builder = XContentFactory.contentBuilder(XContentType.JSON)
-        builder.startObject()
-            .field("text", messageContent)
-            .endObject()
-        return builder.string()
+        return if (Strings.isNullOrEmpty(subject)) message else "$subject \n\n $message"
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
@@ -36,6 +36,8 @@ fun isValidEmail(email: String): Boolean {
 /** Allowed Destinations are ones that are specified in the [DestinationSettings.ALLOW_LIST] setting. */
 fun Destination.isAllowed(allowList: List<String>): Boolean = allowList.contains(this.type.value)
 
+fun Destination.isTestAction(): Boolean = this.type == DestinationType.TEST_ACTION
+
 fun BaseMessage.isHostInDenylist(networks: List<String>): Boolean {
     if (this.url != null || this.uri.host != null) {
         val ipStr = IPAddressString(this.uri.host)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/DestinationConversionUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/DestinationConversionUtils.kt
@@ -173,7 +173,7 @@ class DestinationConversionUtils {
             }
         }
 
-        private fun convertAlertingToNotificationMethodType(alertMethodType: EmailAccount.MethodType): MethodType {
+        fun convertAlertingToNotificationMethodType(alertMethodType: EmailAccount.MethodType): MethodType {
             return when (alertMethodType) {
                 EmailAccount.MethodType.NONE -> MethodType.NONE
                 EmailAccount.MethodType.SSL -> MethodType.SSL

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/NotificationApiUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/NotificationApiUtils.kt
@@ -209,7 +209,7 @@ suspend fun LegacyBaseMessage.publishLegacyNotification(client: Client): String 
 /**
  * Extension function for publishing a notification to a channel in the Notification plugin.
  */
-suspend fun NotificationConfigInfo.sendNotification(client: Client, title: String, compiledMessage: String) {
+suspend fun NotificationConfigInfo.sendNotification(client: Client, title: String, compiledMessage: String): String {
     val config = this
     val res: SendNotificationResponse = NotificationsPluginInterface.suspendUntil {
         this.sendNotification(
@@ -220,7 +220,8 @@ suspend fun NotificationConfigInfo.sendNotification(client: Client, title: Strin
             it
         )
     }
-    validateResponseStatus(res.getStatus(), res.notificationId)
+    validateResponseStatus(res.getStatus(), res.notificationEvent.toString())
+    return res.notificationEvent.toString()
 }
 
 /**

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/NotificationApiUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/NotificationApiUtils.kt
@@ -20,16 +20,11 @@ import org.opensearch.commons.destination.message.LegacyBaseMessage
 import org.opensearch.commons.notifications.NotificationsPluginInterface
 import org.opensearch.commons.notifications.action.CreateNotificationConfigRequest
 import org.opensearch.commons.notifications.action.CreateNotificationConfigResponse
-import org.opensearch.commons.notifications.action.DeleteNotificationConfigRequest
-import org.opensearch.commons.notifications.action.DeleteNotificationConfigResponse
 import org.opensearch.commons.notifications.action.GetNotificationConfigRequest
 import org.opensearch.commons.notifications.action.GetNotificationConfigResponse
 import org.opensearch.commons.notifications.action.LegacyPublishNotificationRequest
 import org.opensearch.commons.notifications.action.LegacyPublishNotificationResponse
-import org.opensearch.commons.notifications.action.SendNotificationRequest
 import org.opensearch.commons.notifications.action.SendNotificationResponse
-import org.opensearch.commons.notifications.action.UpdateNotificationConfigRequest
-import org.opensearch.commons.notifications.action.UpdateNotificationConfigResponse
 import org.opensearch.commons.notifications.model.ChannelMessage
 import org.opensearch.commons.notifications.model.EventSource
 import org.opensearch.commons.notifications.model.NotificationConfigInfo
@@ -62,8 +57,7 @@ class NotificationApiUtils {
 
         private suspend fun getNotificationConfig(
             client: NodeClient,
-            getNotificationConfigRequest: GetNotificationConfigRequest,
-            retryPolicy: BackoffPolicy = defaultRetryPolicy
+            getNotificationConfigRequest: GetNotificationConfigRequest
         ): GetNotificationConfigResponse {
             lateinit var getNotificationConfigResponse: GetNotificationConfigResponse
             val userStr = client.threadPool().threadContext
@@ -102,77 +96,6 @@ class NotificationApiUtils {
                 }
             }
             return createNotificationConfigResponse
-        }
-
-        suspend fun updateNotificationConfig(
-            client: NodeClient,
-            updateNotificationConfigRequest: UpdateNotificationConfigRequest,
-            retryPolicy: BackoffPolicy = defaultRetryPolicy
-        ): UpdateNotificationConfigResponse {
-            lateinit var updateNotificationConfigResponse: UpdateNotificationConfigResponse
-            val userStr = client.threadPool()
-                .threadContext.getTransient<String>(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT)
-            client.threadPool().threadContext.stashContext().use {
-                client.threadPool().threadContext.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, userStr)
-                retryPolicy.retryForNotification(logger) {
-                    updateNotificationConfigResponse = NotificationsPluginInterface.suspendUntil {
-                        this.updateNotificationConfig(
-                            client,
-                            updateNotificationConfigRequest,
-                            it
-                        )
-                    }
-                }
-            }
-            return updateNotificationConfigResponse
-        }
-
-        suspend fun deleteNotificationConfig(
-            client: NodeClient,
-            deleteNotificationConfigRequest: DeleteNotificationConfigRequest,
-            retryPolicy: BackoffPolicy = defaultRetryPolicy
-        ): DeleteNotificationConfigResponse {
-            lateinit var deleteNotificationConfigResponse: DeleteNotificationConfigResponse
-            val userStr = client.threadPool()
-                .threadContext.getTransient<String>(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT)
-            client.threadPool().threadContext.stashContext().use {
-                client.threadPool().threadContext.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, userStr)
-                retryPolicy.retryForNotification(logger) {
-                    deleteNotificationConfigResponse = NotificationsPluginInterface.suspendUntil {
-                        this.deleteNotificationConfig(
-                            client,
-                            deleteNotificationConfigRequest,
-                            it
-                        )
-                    }
-                }
-            }
-            return deleteNotificationConfigResponse
-        }
-
-        suspend fun sendNotification(
-            client: NodeClient,
-            sendNotificationRequest: SendNotificationRequest,
-            retryPolicy: BackoffPolicy = defaultRetryPolicy
-        ): SendNotificationResponse {
-            lateinit var sendNotificationResponse: SendNotificationResponse
-            val userStr = client.threadPool().threadContext
-                .getTransient<String>(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT)
-            client.threadPool().threadContext.stashContext().use {
-                client.threadPool().threadContext.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, userStr)
-                retryPolicy.retryForNotification(logger) {
-                    sendNotificationResponse = NotificationsPluginInterface.suspendUntil {
-                        this.sendNotification(
-                            client,
-                            sendNotificationRequest.eventSource,
-                            sendNotificationRequest.channelMessage,
-                            sendNotificationRequest.channelIds,
-                            it
-                        )
-                    }
-                }
-            }
-            return sendNotificationResponse
         }
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/NotificationApiUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/NotificationApiUtils.kt
@@ -26,6 +26,7 @@ import org.opensearch.commons.notifications.action.LegacyPublishNotificationRequ
 import org.opensearch.commons.notifications.action.LegacyPublishNotificationResponse
 import org.opensearch.commons.notifications.action.SendNotificationResponse
 import org.opensearch.commons.notifications.model.ChannelMessage
+import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.notifications.model.EventSource
 import org.opensearch.commons.notifications.model.NotificationConfigInfo
 import org.opensearch.commons.notifications.model.SeverityType
@@ -101,14 +102,6 @@ class NotificationApiUtils {
 }
 
 /**
- * Similar to Destinations, this is a generic utility method for constructing message content from
- * a subject and message body when sending through Notifications since the Action definition in Monitors can have both.
- */
-fun constructMessageContent(subject: String?, message: String): String {
-    return if (Strings.isNullOrEmpty(subject)) message else "$subject \n\n $message"
-}
-
-/**
  * Extension function for publishing a notification to a legacy destination.
  *
  * We now support the new channels from the Notification plugin. However, we still need to support
@@ -145,6 +138,36 @@ suspend fun NotificationConfigInfo.sendNotification(client: Client, title: Strin
     }
     validateResponseStatus(res.getStatus(), res.notificationEvent.toString())
     return res.notificationEvent.toString()
+}
+
+/**
+ * For most channel types, a placeholder Alerting title will be used but the email channel will
+ * use the subject, so it appears as the actual subject of the email.
+ */
+fun NotificationConfigInfo.getTitle(subject: String?): String {
+    val defaultTitle = "Alerting-Notification Action"
+    if (this.notificationConfig.configType == ConfigType.EMAIL) {
+        return if (subject.isNullOrEmpty()) defaultTitle else subject
+    }
+
+    return defaultTitle
+}
+
+fun NotificationConfigInfo.createMessageContent(subject: String?, message: String): String {
+    // For Email Channels, the subject is not passed in the main message since it's used as the title
+    if (this.notificationConfig.configType == ConfigType.EMAIL) {
+        return constructMessageContent("", message)
+    }
+
+    return constructMessageContent(subject, message)
+}
+
+/**
+ * Similar to Destinations, this is a generic utility method for constructing message content from
+ * a subject and message body when sending through Notifications since the Action definition in Monitors can have both.
+ */
+private fun constructMessageContent(subject: String?, message: String): String {
+    return if (Strings.isNullOrEmpty(subject)) message else "$subject \n\n $message"
 }
 
 /**

--- a/notification/src/main/java/org/opensearch/alerting/destination/client/DestinationEmailClient.java
+++ b/notification/src/main/java/org/opensearch/alerting/destination/client/DestinationEmailClient.java
@@ -9,8 +9,6 @@ import org.opensearch.alerting.destination.message.BaseMessage;
 import org.opensearch.alerting.destination.message.EmailMessage;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.alerting.destination.message.BaseMessage;
-import org.opensearch.alerting.destination.message.EmailMessage;
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
*Issue #, if available:* #105

*Description of changes:*
This PR depends on https://github.com/opensearch-project/common-utils/pull/158 and https://github.com/opensearch-project/notifications/pull/406 so the GitHub Actions are expected to fail without at least `common-utils` being merged in

The main changes in this PR are:
* Integrating with the Notifications plugin, supporting execution of the notification actions before/after migration of the Destination configs to Notifications
  * In the case of the Destination failing migration, it will be sent through the passthrough API (this avoids hard failures on a write block but still requires the Notification plugin to be installed since the passthrough API does not work without it)
* Fixes some bugs
  * For the Destination migration, `email_group` configs were being checked with a string match which could also appear in the Email Destination (this would cause it to use the wrong parser so the fetching of the different config types has been split up)
  * The Alerting email keystore settings were not correctly declaring the fallback setting to the legacy `opendistro*.` variants this would cause runtime errors when it tried to load the keystore settings and failed on falling back to the old setting
    * This has been fixed (although it should not be used anymore since the Notification plugin has its own namespace for these settings that will take precedence, Alerting's will be used as a fallback for that)

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).