### PR TITLE
Add Trigger condition parser and resolver for Doc Level Alerts

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/DocumentReturningMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/DocumentReturningMonitorRunner.kt
@@ -119,7 +119,7 @@ object DocumentReturningMonitorRunner : MonitorRunner {
                 monitor,
                 idQueryMap,
                 docsToQueries,
-                queryIds,
+                queryToDocIds,
                 dryrun
             )
         }
@@ -146,11 +146,11 @@ object DocumentReturningMonitorRunner : MonitorRunner {
         monitor: Monitor,
         idQueryMap: Map<String, DocLevelQuery>,
         docsToQueries: Map<String, List<String>>,
-        queryIds: List<String>,
+        queryToDocIds: Map<DocLevelQuery, Set<String>>,
         dryrun: Boolean
     ): DocumentLevelTriggerRunResult {
         val triggerCtx = DocumentLevelTriggerExecutionContext(monitor, trigger)
-        val triggerResult = monitorCtx.triggerService!!.runDocLevelTrigger(monitor, trigger, triggerCtx, docsToQueries, queryIds)
+        val triggerResult = monitorCtx.triggerService!!.runDocLevelTrigger(monitor, trigger, queryToDocIds)
 
         logger.info("trigger results")
         logger.info(triggerResult.triggeredDocs.toString())

--- a/alerting/src/main/kotlin/org/opensearch/alerting/triggercondition/parsers/ExpressionParser.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/triggercondition/parsers/ExpressionParser.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.triggercondition.parsers
+
+import org.opensearch.alerting.triggercondition.resolvers.TriggerExpressionResolver
+
+interface ExpressionParser {
+    fun parse(): TriggerExpressionResolver
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/triggercondition/parsers/TriggerExpressionParser.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/triggercondition/parsers/TriggerExpressionParser.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.triggercondition.parsers
+
+import org.opensearch.alerting.triggercondition.resolvers.TriggerExpressionRPNResolver
+import org.opensearch.alerting.triggercondition.tokens.TriggerExpressionOperator
+
+/**
+ * The postfix (Reverse Polish Notation) parser.
+ * Uses the Shunting-yard algorithm to parse a mathematical expression
+ * @param triggerExpression String containing the trigger expression for the monitor
+ */
+class TriggerExpressionParser(
+    triggerExpression: String
+) : TriggerExpressionRPNBaseParser(triggerExpression) {
+
+    override fun parse(): TriggerExpressionRPNResolver {
+        val expression = expressionToParse.replace(" ", "")
+
+        val splitters = ArrayList<String>()
+        TriggerExpressionOperator.values().forEach { splitters.add(it.value) }
+
+        val breaks = ArrayList<String>().apply { add(expression) }
+        for (s in splitters) {
+            val a = ArrayList<String>()
+            for (ind in 0 until breaks.size) {
+                breaks[ind].let {
+                    if (it.length > 1) {
+                        a.addAll(breakString(breaks[ind], s))
+                    } else a.add(it)
+                }
+            }
+            breaks.clear()
+            breaks.addAll(a)
+        }
+
+        return TriggerExpressionRPNResolver(convertInfixToPostfix(breaks))
+    }
+
+    private fun breakString(input: String, delimeter: String): ArrayList<String> {
+        val tokens = input.split(delimeter)
+        val array = ArrayList<String>()
+        for (t in tokens) {
+            array.add(t)
+            array.add(delimeter)
+        }
+        array.removeAt(array.size - 1)
+        return array
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/triggercondition/parsers/TriggerExpressionRPNBaseParser.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/triggercondition/parsers/TriggerExpressionRPNBaseParser.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.triggercondition.parsers
+
+import org.opensearch.alerting.triggercondition.tokens.ExpressionToken
+import org.opensearch.alerting.triggercondition.tokens.TriggerExpressionConstant
+import org.opensearch.alerting.triggercondition.tokens.TriggerExpressionOperator
+import org.opensearch.alerting.triggercondition.tokens.TriggerExpressionToken
+import java.util.Stack
+
+/**
+ * This is the abstract base class which holds the trigger expression parsing logic;
+ * using the Infix to Postfix a.k.a. Reverse Polish Notation (RPN) parser.
+ * It also uses the Shunting-Yard algorithm to parse the given trigger expression.
+ *
+ * @param expressionToParse Complete string containing the trigger expression
+ */
+abstract class TriggerExpressionRPNBaseParser(
+    protected val expressionToParse: String
+) : ExpressionParser {
+    /**
+     * To perform the Infix-to-postfix conversion of the trigger expression
+     */
+    protected fun convertInfixToPostfix(expTokens: List<String>): ArrayList<ExpressionToken> {
+        val expTokenStack = Stack<ExpressionToken>()
+        val outputExpTokens = ArrayList<ExpressionToken>()
+
+        for (tokenString in expTokens) {
+            if (tokenString.isEmpty()) continue
+            when (val expToken = assignToken(tokenString)) {
+                is TriggerExpressionToken -> outputExpTokens.add(expToken)
+                is TriggerExpressionOperator -> {
+                    when (expToken) {
+                        TriggerExpressionOperator.PAR_LEFT -> expTokenStack.push(expToken)
+                        TriggerExpressionOperator.PAR_RIGHT -> {
+                            var topExpToken = expTokenStack.popExpTokenOrNull<TriggerExpressionOperator>()
+                            while (topExpToken != null && topExpToken != TriggerExpressionOperator.PAR_LEFT) {
+                                outputExpTokens.add(topExpToken)
+                                topExpToken = expTokenStack.popExpTokenOrNull<TriggerExpressionOperator>()
+                            }
+                            if (topExpToken != TriggerExpressionOperator.PAR_LEFT)
+                                throw java.lang.IllegalArgumentException("No matching left parenthesis.")
+                        }
+                        else -> {
+                            var op2 = expTokenStack.peekExpTokenOrNull<TriggerExpressionOperator>()
+                            while (op2 != null) {
+                                val c = expToken.precedence.compareTo(op2.precedence)
+                                if (c < 0 || !expToken.rightAssociative && c <= 0) {
+                                    outputExpTokens.add(expTokenStack.pop())
+                                } else {
+                                    break
+                                }
+                                op2 = expTokenStack.peekExpTokenOrNull<TriggerExpressionOperator>()
+                            }
+                            expTokenStack.push(expToken)
+                        }
+                    }
+                }
+            }
+        }
+
+        while (!expTokenStack.isEmpty()) {
+            expTokenStack.peekExpTokenOrNull<TriggerExpressionOperator>()?.let {
+                if (it == TriggerExpressionOperator.PAR_LEFT)
+                    throw java.lang.IllegalArgumentException("No matching right parenthesis.")
+            }
+            val top = expTokenStack.pop()
+            outputExpTokens.add(top)
+        }
+
+        return outputExpTokens
+    }
+
+    /**
+     * Looks up and maps the expression token that matches the string version of that expression unit
+     */
+    private fun assignToken(tokenString: String): ExpressionToken {
+
+        // Check "query" string in trigger expression such as in 'query[name="abc"]'
+        if (tokenString.startsWith(TriggerExpressionConstant.ConstantType.QUERY.ident))
+            return TriggerExpressionToken(tokenString)
+
+        // Check operators in trigger expression such as in [&&, ||, !]
+        for (op in TriggerExpressionOperator.values()) {
+            if (op.value == tokenString) return op
+        }
+
+        // Check any constants in trigger expression such as in ["name, "id", "tag", [", "]", "="]
+        for (con in TriggerExpressionConstant.ConstantType.values()) {
+            if (tokenString == con.ident) return TriggerExpressionConstant(con)
+        }
+
+        throw IllegalArgumentException("Error while processing the trigger expression '$tokenString'")
+    }
+
+    private inline fun <reified T> Stack<ExpressionToken>.popExpTokenOrNull(): T? {
+        return try {
+            pop() as T
+        } catch (e: java.lang.Exception) {
+            null
+        }
+    }
+
+    private inline fun <reified T> Stack<ExpressionToken>.peekExpTokenOrNull(): T? {
+        return try {
+            peek() as T
+        } catch (e: java.lang.Exception) {
+            null
+        }
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/triggercondition/resolvers/TriggerExpression.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/triggercondition/resolvers/TriggerExpression.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.triggercondition.resolvers
+
+sealed class TriggerExpression {
+
+    fun resolve(): Set<String> = when (this) {
+        is And -> resolveAnd(docSet1, docSet2)
+        is Or -> resolveOr(docSet1, docSet2)
+        is Not -> resolveNot(allDocs, docSet2)
+    }
+
+    private fun resolveAnd(documentSet1: Set<String>, documentSet2: Set<String>): Set<String> {
+        return documentSet1.intersect(documentSet2)
+    }
+
+    private fun resolveOr(documentSet1: Set<String>, documentSet2: Set<String>): Set<String> {
+        return documentSet1.union(documentSet2)
+    }
+
+    private fun resolveNot(allDocs: Set<String>, documentSet2: Set<String>): Set<String> {
+        return allDocs.subtract(documentSet2)
+    }
+
+    // Operators implemented as operator functions
+    class And(val docSet1: Set<String>, val docSet2: Set<String>) : TriggerExpression()
+    class Or(val docSet1: Set<String>, val docSet2: Set<String>) : TriggerExpression()
+    class Not(val allDocs: Set<String>, val docSet2: Set<String>) : TriggerExpression()
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/triggercondition/resolvers/TriggerExpressionRPNResolver.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/triggercondition/resolvers/TriggerExpressionRPNResolver.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.triggercondition.resolvers
+
+import org.opensearch.alerting.core.model.DocLevelQuery
+import org.opensearch.alerting.triggercondition.tokens.ExpressionToken
+import org.opensearch.alerting.triggercondition.tokens.TriggerExpressionConstant
+import org.opensearch.alerting.triggercondition.tokens.TriggerExpressionOperator
+import org.opensearch.alerting.triggercondition.tokens.TriggerExpressionToken
+import java.util.Optional
+import java.util.Stack
+
+/**
+ * Solves the Trigger Expression using the Reverse Polish Notation (RPN) based solver
+ * @param polishNotation an array of expression tokens organized in the RPN order
+ */
+class TriggerExpressionRPNResolver(
+    private val polishNotation: ArrayList<ExpressionToken>
+) : TriggerExpressionResolver {
+
+    private val eqString by lazy {
+        val stringBuilder = StringBuilder()
+        for (expToken in polishNotation) {
+            when (expToken) {
+                is TriggerExpressionToken -> stringBuilder.append(expToken.value)
+                is TriggerExpressionOperator -> stringBuilder.append(expToken.value)
+                is TriggerExpressionConstant -> stringBuilder.append(expToken.type.ident)
+                else -> throw Exception()
+            }
+            stringBuilder.append(" ")
+        }
+        stringBuilder.toString()
+    }
+
+    override fun toString(): String = eqString
+
+    /**
+     * Evaluates the trigger expression expressed provided in form of the RPN token array.
+     * @param queryToDocIds Map to hold the resultant document id per query id
+     * @return evaluates the final set of document id
+     */
+    override fun evaluate(queryToDocIds: Map<DocLevelQuery, Set<String>>): Set<String> {
+        val tokenStack = Stack<Set<String>>()
+
+        val allDocIds = mutableSetOf<String>()
+        for (value in queryToDocIds.values) {
+            allDocIds.addAll(value)
+        }
+
+        for (expToken in polishNotation) {
+            when (expToken) {
+                is TriggerExpressionToken -> tokenStack.push(resolveQueryExpression(expToken.value, queryToDocIds))
+                is TriggerExpressionOperator -> {
+                    val right = tokenStack.pop()
+                    val expr = when (expToken) {
+                        TriggerExpressionOperator.AND -> TriggerExpression.And(tokenStack.pop(), right)
+                        TriggerExpressionOperator.OR -> TriggerExpression.Or(tokenStack.pop(), right)
+                        TriggerExpressionOperator.NOT -> TriggerExpression.Not(allDocIds, right)
+                        else -> throw IllegalArgumentException("No matching operator.")
+                    }
+                    tokenStack.push(expr.resolve())
+                }
+            }
+        }
+        return tokenStack.pop()
+    }
+
+    private fun resolveQueryExpression(queryExpString: String, queryToDocIds: Map<DocLevelQuery, Set<String>>): Set<String> {
+        if (!queryExpString.startsWith(TriggerExpressionConstant.ConstantType.QUERY.ident)) return emptySet()
+        val token = queryExpString.substringAfter(TriggerExpressionConstant.ConstantType.BRACKET_LEFT.ident)
+            .substringBefore(TriggerExpressionConstant.ConstantType.BRACKET_RIGHT.ident)
+        if (token.isEmpty()) return emptySet()
+
+        val tokens = token.split(TriggerExpressionConstant.ConstantType.EQUALS.ident)
+        if (tokens.isEmpty() || tokens.size != 2) return emptySet()
+
+        val identifier = tokens[0]
+        val value = tokens[1]
+        val documents = mutableSetOf<String>()
+        when (identifier) {
+            TriggerExpressionConstant.ConstantType.NAME.ident -> {
+                val key: Optional<DocLevelQuery> = queryToDocIds.keys.stream().filter { it.name == value }.findFirst()
+                if (key.isPresent) queryToDocIds[key.get()]?.let { doc -> documents.addAll(doc) }
+            }
+
+            TriggerExpressionConstant.ConstantType.ID.ident -> {
+                val key: Optional<DocLevelQuery> = queryToDocIds.keys.stream().filter { it.id == value }.findFirst()
+                if (key.isPresent) queryToDocIds[key.get()]?.let { doc -> documents.addAll(doc) }
+            }
+
+            // Iterate through all the queries with the same Tag
+            TriggerExpressionConstant.ConstantType.TAG.ident -> {
+                queryToDocIds.keys.stream().forEach {
+                    if (it.tags.contains(value)) queryToDocIds[it]?.let { it1 -> documents.addAll(it1) }
+                }
+            }
+        }
+        return documents
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/triggercondition/resolvers/TriggerExpressionResolver.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/triggercondition/resolvers/TriggerExpressionResolver.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.triggercondition.resolvers
+
+import org.opensearch.alerting.core.model.DocLevelQuery
+
+interface TriggerExpressionResolver {
+    fun evaluate(queryToDocIds: Map<DocLevelQuery, Set<String>>): Set<String>
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/triggercondition/tokens/ExpressionToken.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/triggercondition/tokens/ExpressionToken.kt
@@ -1,0 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.triggercondition.tokens
+
+interface ExpressionToken

--- a/alerting/src/main/kotlin/org/opensearch/alerting/triggercondition/tokens/TriggerExpressionConstant.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/triggercondition/tokens/TriggerExpressionConstant.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.triggercondition.tokens
+
+/**
+ * To define all the tokens which could be part of expression constant such as query[id=new_id], query[name=new_name],
+ * query[tag=new_tag]
+ */
+class TriggerExpressionConstant(val type: ConstantType) : ExpressionToken {
+
+    enum class ConstantType(val ident: String) {
+        QUERY("query"),
+
+        TAG("tag"),
+        NAME("name"),
+        ID("id"),
+
+        BRACKET_LEFT("["),
+        BRACKET_RIGHT("]"),
+
+        EQUALS("=")
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/triggercondition/tokens/TriggerExpressionOperator.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/triggercondition/tokens/TriggerExpressionOperator.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.triggercondition.tokens
+
+/**
+ * To define all the operators used in the trigger expression
+ */
+enum class TriggerExpressionOperator(val value: String, val precedence: Int, val rightAssociative: Boolean) : ExpressionToken {
+
+    AND("&&", 2, false),
+    OR("||", 2, false),
+
+    NOT("!", 3, true),
+
+    PAR_LEFT("(", 1, false),
+    PAR_RIGHT(")", 1, false)
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/triggercondition/tokens/TriggerExpressionToken.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/triggercondition/tokens/TriggerExpressionToken.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.triggercondition.tokens
+
+/**
+ * To define the tokens in Trigger expression such as query[tag=“sev1"] or query[name=“sev1"] or query[id=“sev1"]
+ */
+internal data class TriggerExpressionToken(val value: String) : ExpressionToken

--- a/alerting/src/test/kotlin/org/opensearch/alerting/triggeraction/TriggerExpressionParserTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/triggeraction/TriggerExpressionParserTests.kt
@@ -1,0 +1,71 @@
+package org.opensearch.alerting.triggeraction
+
+import org.junit.Assert
+import org.opensearch.alerting.triggercondition.parsers.TriggerExpressionParser
+import org.opensearch.test.OpenSearchTestCase
+
+class TriggerExpressionParserTests : OpenSearchTestCase() {
+
+    fun `test trigger expression posix parsing simple AND`() {
+        val eqString = "(query[name=sigma-123] && query[name=sigma-456])"
+        val equation = TriggerExpressionParser(eqString).parse()
+        Assert.assertEquals("query[name=sigma-123] query[name=sigma-456] && ", equation.toString())
+    }
+
+    fun `test trigger expression posix parsing multiple AND`() {
+        val eqString = "(query[name=sigma-123] && query[name=sigma-456]) && query[name=sigma-789]"
+        val equation = TriggerExpressionParser(eqString).parse()
+        Assert.assertEquals("query[name=sigma-123] query[name=sigma-456] && query[name=sigma-789] && ", equation.toString())
+    }
+
+    fun `test trigger expression posix parsing multiple AND with parenthesis`() {
+        val eqString = "(query[name=sigma-123] && query[name=sigma-456]) && (query[name=sigma-789] && query[name=id-2aw34])"
+        val equation = TriggerExpressionParser(eqString).parse()
+        Assert.assertEquals(
+            "query[name=sigma-123] query[name=sigma-456] && query[name=sigma-789] query[name=id-2aw34] && && ",
+            equation.toString()
+        )
+    }
+
+    fun `test trigger expression posix parsing simple OR`() {
+        val eqString = "(query[name=sigma-123] || query[name=sigma-456])"
+        val equation = TriggerExpressionParser(eqString).parse()
+        Assert.assertEquals("query[name=sigma-123] query[name=sigma-456] || ", equation.toString())
+    }
+
+    fun `test trigger expression posix parsing multiple OR`() {
+        val eqString = "(query[name=sigma-123] || query[name=sigma-456]) || query[name=sigma-789]"
+        val equation = TriggerExpressionParser(eqString).parse()
+        Assert.assertEquals("query[name=sigma-123] query[name=sigma-456] || query[name=sigma-789] || ", equation.toString())
+    }
+
+    fun `test trigger expression posix parsing multiple OR with parenthesis`() {
+        val eqString = "(query[name=sigma-123] || query[name=sigma-456]) || (query[name=sigma-789] || query[name=id-2aw34])"
+        val equation = TriggerExpressionParser(eqString).parse()
+        Assert.assertEquals(
+            "query[name=sigma-123] query[name=sigma-456] || query[name=sigma-789] query[name=id-2aw34] || || ",
+            equation.toString()
+        )
+    }
+
+    fun `test trigger expression posix parsing simple NOT`() {
+        val eqString = "(query[name=sigma-123] || !query[name=sigma-456])"
+        val equation = TriggerExpressionParser(eqString).parse()
+        Assert.assertEquals("query[name=sigma-123] query[name=sigma-456] ! || ", equation.toString())
+    }
+
+    fun `test trigger expression posix parsing multiple NOT`() {
+        val eqString = "(query[name=sigma-123] && !query[tag=tag-456]) && !(query[name=sigma-789])"
+        val equation = TriggerExpressionParser(eqString).parse()
+        Assert.assertEquals("query[name=sigma-123] query[tag=tag-456] ! && query[name=sigma-789] ! && ", equation.toString())
+    }
+
+    fun `test trigger expression posix parsing multiple operators with parenthesis`() {
+        val eqString = "(query[name=sigma-123] && query[tag=sev1]) || !(!query[name=sigma-789] || query[name=id-2aw34])"
+        val equation = TriggerExpressionParser(eqString).parse()
+        Assert.assertEquals(
+            "query[name=sigma-123] query[tag=sev1] && query[name=sigma-789] ! query[name=id-2aw34] || ! || ",
+            equation.toString()
+        )
+    }
+}

--- a/alerting/src/test/kotlin/org/opensearch/alerting/triggeraction/TriggerExpressionResolverTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/triggeraction/TriggerExpressionResolverTests.kt
@@ -1,0 +1,119 @@
+package org.opensearch.alerting.triggeraction
+
+import org.junit.Assert
+import org.opensearch.alerting.core.model.DocLevelQuery
+import org.opensearch.alerting.triggercondition.parsers.TriggerExpressionParser
+import org.opensearch.test.OpenSearchTestCase
+
+class TriggerExpressionResolverTests : OpenSearchTestCase() {
+
+    fun `test trigger expression evaluation simple AND`() {
+        val eqString = "(query[name=sigma-123] && query[name=sigma-456])"
+        val equation = TriggerExpressionParser(eqString).parse()
+        val queryToDocIds = mutableMapOf<DocLevelQuery, Set<String>>()
+        queryToDocIds[DocLevelQuery("", "sigma-123", "", emptyList())] = mutableSetOf("1", "2", "3")
+        queryToDocIds[DocLevelQuery("", "sigma-456", "", emptyList())] = mutableSetOf("1", "2", "3")
+        Assert.assertEquals("query[name=sigma-123] query[name=sigma-456] && ", equation.toString())
+        Assert.assertEquals(mutableSetOf("1", "2", "3"), equation.evaluate(queryToDocIds))
+    }
+
+    fun `test trigger expression evaluation simple AND scenario2`() {
+        val eqString = "(query[name=sigma-123] && query[id=id1456])"
+        val equation = TriggerExpressionParser(eqString).parse()
+        val queryToDocIds = mutableMapOf<DocLevelQuery, Set<String>>()
+        queryToDocIds[DocLevelQuery("", "sigma-123", "", emptyList())] = mutableSetOf("6", "3", "7")
+        queryToDocIds[DocLevelQuery("id1456", "", "", emptyList())] = mutableSetOf("1", "2", "3")
+        Assert.assertEquals("query[name=sigma-123] query[id=id1456] && ", equation.toString())
+        Assert.assertEquals(mutableSetOf("3"), equation.evaluate(queryToDocIds))
+    }
+
+    fun `test trigger expression evaluation simple AND scenario3`() {
+        val eqString = "(query[name=sigma-123] && query[tag=sev2])"
+        val equation = TriggerExpressionParser(eqString).parse()
+        val queryToDocIds = mutableMapOf<DocLevelQuery, Set<String>>()
+        queryToDocIds[DocLevelQuery("", "sigma-123", "", emptyList())] = mutableSetOf("6", "8", "7")
+        queryToDocIds[DocLevelQuery("", "", "", mutableListOf("tag=sev2"))] = mutableSetOf("1", "2", "3")
+        Assert.assertEquals("query[name=sigma-123] query[tag=sev2] && ", equation.toString())
+        Assert.assertEquals(emptySet<String>(), equation.evaluate(queryToDocIds))
+    }
+
+    fun `test trigger expression evaluation simple OR`() {
+        val eqString = "(query[name=sigma-123] || query[name=sigma-456])"
+        val equation = TriggerExpressionParser(eqString).parse()
+        val queryToDocIds = mutableMapOf<DocLevelQuery, Set<String>>()
+        queryToDocIds[DocLevelQuery("", "sigma-123", "", emptyList())] = mutableSetOf("1", "2", "3")
+        queryToDocIds[DocLevelQuery("", "sigma-456", "", emptyList())] = mutableSetOf("1", "2", "3")
+        Assert.assertEquals("query[name=sigma-123] query[name=sigma-456] || ", equation.toString())
+        Assert.assertEquals(mutableSetOf("1", "2", "3"), equation.evaluate(queryToDocIds))
+    }
+
+    fun `test trigger expression evaluation simple OR scenario2`() {
+        val eqString = "(query[name=sigma-123] || query[id=id1456])"
+        val equation = TriggerExpressionParser(eqString).parse()
+        val queryToDocIds = mutableMapOf<DocLevelQuery, Set<String>>()
+        queryToDocIds[DocLevelQuery("", "sigma-123", "", emptyList())] = mutableSetOf("6", "3", "7")
+        queryToDocIds[DocLevelQuery("id1456", "", "", emptyList())] = mutableSetOf("1", "2", "3")
+        Assert.assertEquals("query[name=sigma-123] query[id=id1456] || ", equation.toString())
+        Assert.assertEquals(mutableSetOf("6", "3", "7", "1", "2", "3"), equation.evaluate(queryToDocIds))
+    }
+
+    fun `test trigger expression evaluation simple OR scenario3`() {
+        val eqString = "(query[name=sigma-123] || query[tag=sev2])"
+        val equation = TriggerExpressionParser(eqString).parse()
+        val queryToDocIds = mutableMapOf<DocLevelQuery, Set<String>>()
+        queryToDocIds[DocLevelQuery("", "sigma-123", "", emptyList())] = mutableSetOf("6", "8", "7")
+        queryToDocIds[DocLevelQuery("", "", "", mutableListOf("tag=sev2"))] = emptySet()
+        Assert.assertEquals("query[name=sigma-123] query[tag=sev2] || ", equation.toString())
+        Assert.assertEquals(mutableSetOf("6", "8", "7"), equation.evaluate(queryToDocIds))
+    }
+
+    fun `test trigger expression evaluation simple NOT`() {
+        val eqString = "!(query[name=sigma-456])"
+        val equation = TriggerExpressionParser(eqString).parse()
+        val queryToDocIds = mutableMapOf<DocLevelQuery, Set<String>>()
+        queryToDocIds[DocLevelQuery("", "sigma-123", "", emptyList())] = mutableSetOf("1", "2", "3")
+        queryToDocIds[DocLevelQuery("", "sigma-456", "", emptyList())] = mutableSetOf("4", "5", "6")
+        Assert.assertEquals("query[name=sigma-456] ! ", equation.toString())
+        Assert.assertEquals(mutableSetOf("1", "2", "3"), equation.evaluate(queryToDocIds))
+    }
+
+    fun `test trigger expression evaluation AND with NOT`() {
+        val eqString = "(query[name=sigma-123] && !query[name=sigma-456])"
+        val equation = TriggerExpressionParser(eqString).parse()
+        val queryToDocIds = mutableMapOf<DocLevelQuery, Set<String>>()
+        queryToDocIds[DocLevelQuery("", "sigma-123", "", emptyList())] = mutableSetOf("1", "2", "3", "11")
+        queryToDocIds[DocLevelQuery("", "sigma-456", "", emptyList())] = mutableSetOf("3", "4", "5")
+        queryToDocIds[DocLevelQuery("id_new", "", "", emptyList())] = mutableSetOf("11", "12", "13")
+        Assert.assertEquals("query[name=sigma-123] query[name=sigma-456] ! && ", equation.toString())
+        Assert.assertEquals(mutableSetOf("1", "2", "11"), equation.evaluate(queryToDocIds))
+    }
+
+    fun `test trigger expression evaluation OR with NOT`() {
+        val eqString = "(query[name=sigma-123] || !query[id=id1456])"
+        val equation = TriggerExpressionParser(eqString).parse()
+        val queryToDocIds = mutableMapOf<DocLevelQuery, Set<String>>()
+        queryToDocIds[DocLevelQuery("", "sigma-123", "", emptyList())] = mutableSetOf("6", "3", "7")
+        queryToDocIds[DocLevelQuery("id1456", "", "", emptyList())] = mutableSetOf("11", "12", "15")
+        queryToDocIds[DocLevelQuery("id_new", "", "", emptyList())] = mutableSetOf("11", "12", "13")
+        Assert.assertEquals("query[name=sigma-123] query[id=id1456] ! || ", equation.toString())
+        Assert.assertEquals(mutableSetOf("6", "3", "7", "13"), equation.evaluate(queryToDocIds))
+    }
+
+    fun `test trigger expression evaluation with multiple operators with parenthesis`() {
+        val eqString = "(query[name=sigma-123] && query[tag=sev1]) || !(!query[name=sigma-789] || query[id=id-2aw34])"
+        val equation = TriggerExpressionParser(eqString).parse()
+
+        val queryToDocIds = mutableMapOf<DocLevelQuery, Set<String>>()
+        queryToDocIds[DocLevelQuery("", "sigma-123", "", emptyList())] = mutableSetOf("1", "2", "3")
+        queryToDocIds[DocLevelQuery("id_random1", "", "", mutableListOf("sev1"))] = mutableSetOf("2", "3", "4")
+        queryToDocIds[DocLevelQuery("", "sigma-789", "", emptyList())] = mutableSetOf("11", "12", "13")
+        queryToDocIds[DocLevelQuery("id-2aw34", "", "", emptyList())] = mutableSetOf("13", "14", "15")
+
+        Assert.assertEquals(
+            "query[name=sigma-123] query[tag=sev1] && query[name=sigma-789] ! query[id=id-2aw34] || ! || ",
+            equation.toString()
+        )
+
+        Assert.assertEquals(mutableSetOf("2", "3", "11", "12"), equation.evaluate(queryToDocIds))
+    }
+}


### PR DESCRIPTION
Add Trigger condition parser which parses the provided trigger condition expression in the Reverse Polish Notation and then 
resolves the final set of Document Ids which matches the given expression for Document Level Alerts.
 
 Users can configure the Trigger condition using the expression strings as below:
 

**Always True**
``
return true
``

**Always False**
``
return false
``

**Query Expressions**
```
* (query[name=sigma-123] && query[name=sigma-456]) || (!query[id=aert34df] && query[tag=sev2])
* query[tag=sev1]
* (query[name=sigma-123] && query[tag=sev2]) || (!query[tag=sev3] && query[id=dfd457iy] && query[tag=“sev1"])
```
Operartors supported are:
```
* (
* )
* &&
* ||
* !
```

Query Identifiers supported are:
```
* name ---> query[name=sigma-123]
* tag ---> query[tag=sev2]
* id ---> query[id=aert34df]
```


Signed-off-by: Saurabh Singh <sisurab@amazon.com>

*Issue #, if available:*

*Description of changes:*

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).