### PR TITLE
Deprecate the Master nomenclature in 2.0

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
@@ -56,7 +56,7 @@ import java.time.Instant
  * date based index. The frequency of rolling over indices is controlled by the `opendistro.alerting.alert_rollover_period` setting.
  *
  * These indexes are created when first used and are then rolled over every `alert_rollover_period`. The rollover is
- * initiated on the master node to ensure only a single node tries to roll it over.  Once we have a curator functionality
+ * initiated on the cluster manager node to ensure only a single node tries to roll it over.  Once we have a curator functionality
  * in Scheduled Jobs we can migrate to using that to rollover the index.
  */
 // TODO: reafactor to make a generic version of this class for finding and alerts

--- a/core/src/main/kotlin/org/opensearch/alerting/core/JobSweeper.kt
+++ b/core/src/main/kotlin/org/opensearch/alerting/core/JobSweeper.kt
@@ -138,7 +138,7 @@ class JobSweeper(
      * the cluster, a replica is added, removed or promoted to primary).
      *
      * This callback won't be invoked concurrently since cluster state changes are applied serially to the node
-     * in the order they occur on the master. However we can't block this callback for the duration of a full sweep so
+     * in the order they occur on the cluster manager. However we can't block this callback for the duration of a full sweep so
      * we perform the sweep in the background in a single threaded executor [fullSweepExecutor].
      */
     override fun clusterChanged(event: ClusterChangedEvent) {


### PR DESCRIPTION
Signed-off-by: Subhobrata Dey <sbcd90@gmail.com>

*Issue #, if available:*
[Deprecate the "Master" nomenclature](https://github.com/opensearch-project/alerting/issues/320)

*Description of changes:*
Replace the terminology "master" with "cluster manager".

*CheckList:*
[X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).