### PR TITLE
Skipping destination migration if alerting index is not initialized

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -234,7 +234,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
         docLevelMonitorQueries = DocLevelMonitorQueries(client.admin(), clusterService)
         scheduler = JobScheduler(threadPool, runner)
         sweeper = JobSweeper(environment.settings(), client, clusterService, threadPool, xContentRegistry, scheduler, ALERTING_JOB_TYPES)
-        destinationMigrationCoordinator = DestinationMigrationCoordinator(client, clusterService, threadPool, alertIndices)
+        destinationMigrationCoordinator = DestinationMigrationCoordinator(client, clusterService, threadPool, scheduledJobIndices)
         this.threadPool = threadPool
         this.clusterService = clusterService
         return listOf(sweeper, scheduler, runner, scheduledJobIndices, docLevelMonitorQueries, destinationMigrationCoordinator)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -234,7 +234,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
         docLevelMonitorQueries = DocLevelMonitorQueries(client.admin(), clusterService)
         scheduler = JobScheduler(threadPool, runner)
         sweeper = JobSweeper(environment.settings(), client, clusterService, threadPool, xContentRegistry, scheduler, ALERTING_JOB_TYPES)
-        destinationMigrationCoordinator = DestinationMigrationCoordinator(client, clusterService, threadPool)
+        destinationMigrationCoordinator = DestinationMigrationCoordinator(client, clusterService, threadPool, alertIndices)
         this.threadPool = threadPool
         this.clusterService = clusterService
         return listOf(sweeper, scheduler, runner, scheduledJobIndices, docLevelMonitorQueries, destinationMigrationCoordinator)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
@@ -230,6 +230,10 @@ class AlertIndices(
         return alertIndexInitialized && alertHistoryIndexInitialized
     }
 
+    fun isAlertIndexInitialized(): Boolean {
+        return alertIndexInitialized
+    }
+
     fun isAlertHistoryEnabled(): Boolean = alertHistoryEnabled
 
     fun isFindingHistoryEnabled(): Boolean = findingHistoryEnabled

--- a/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
@@ -230,10 +230,6 @@ class AlertIndices(
         return alertIndexInitialized && alertHistoryIndexInitialized
     }
 
-    fun isAlertIndexInitialized(): Boolean {
-        return alertIndexInitialized
-    }
-
     fun isAlertHistoryEnabled(): Boolean = alertHistoryEnabled
 
     fun isFindingHistoryEnabled(): Boolean = findingHistoryEnabled

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/DestinationMigrationCoordinator.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/DestinationMigrationCoordinator.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.apache.logging.log4j.LogManager
-import org.opensearch.alerting.alerts.AlertIndices
+import org.opensearch.alerting.core.ScheduledJobIndices
 import org.opensearch.client.Client
 import org.opensearch.client.node.NodeClient
 import org.opensearch.cluster.ClusterChangedEvent
@@ -26,7 +26,7 @@ class DestinationMigrationCoordinator(
     private val client: Client,
     private val clusterService: ClusterService,
     private val threadPool: ThreadPool,
-    private val alertIndices: AlertIndices
+    private val scheduledJobIndices: ScheduledJobIndices
 ) : ClusterStateListener, CoroutineScope, LifecycleListener() {
 
     private val logger = LogManager.getLogger(javaClass)
@@ -68,8 +68,8 @@ class DestinationMigrationCoordinator(
     }
 
     private fun initMigrateDestinations() {
-        if (!alertIndices.isAlertIndexInitialized()) {
-            logger.debug("Alerting index is not initialized")
+        if (!scheduledJobIndices.scheduledJobIndexExists()) {
+            logger.debug("Alerting config index is not initialized")
             scheduledMigration?.cancel()
             return
         }


### PR DESCRIPTION
Signed-off-by: Ravi Thaluru <thalurur@users.noreply.github.com>

*Issue #, if available:*
N/A

*Description of changes:*
Keep seeing following errors on cluster - skipping Destination migration if alert index is not initialized
```
[2022-04-20T20:04:42,752][ERROR][o.o.a.u.d.DestinationMigrationCoordinator] [dev-dsk-rthaluru-2b-5db44ff7.us-west-2.amazon.com] Failed to migrate destination data
org.opensearch.index.IndexNotFoundException: no such index [.opendistro-alerting-config]
        at org.opensearch.cluster.metadata.IndexNameExpressionResolver$WildcardExpressionResolver.indexNotFoundException(IndexNameExpressionResolver.java:1055) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.cluster.metadata.IndexNameExpressionResolver$WildcardExpressionResolver.innerResolve(IndexNameExpressionResolver.java:992) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.cluster.metadata.IndexNameExpressionResolver$WildcardExpressionResolver.resolve(IndexNameExpressionResolver.java:948) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.cluster.metadata.IndexNameExpressionResolver.concreteIndices(IndexNameExpressionResolver.java:252) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.cluster.metadata.IndexNameExpressionResolver.concreteIndices(IndexNameExpressionResolver.java:228) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.action.search.TransportSearchAction.resolveLocalIndices(TransportSearchAction.java:872) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.action.search.TransportSearchAction.executeSearch(TransportSearchAction.java:913) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.action.search.TransportSearchAction.executeLocalSearch(TransportSearchAction.java:757) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.action.search.TransportSearchAction.lambda$executeRequest$3(TransportSearchAction.java:398) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.action.ActionListener$1.onResponse(ActionListener.java:78) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.index.query.Rewriteable.rewriteAndFetch(Rewriteable.java:136) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.index.query.Rewriteable.rewriteAndFetch(Rewriteable.java:101) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.action.search.TransportSearchAction.executeRequest(TransportSearchAction.java:487) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.action.search.TransportSearchAction.doExecute(TransportSearchAction.java:277) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.action.search.TransportSearchAction.doExecute(TransportSearchAction.java:120) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:194) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.indexmanagement.rollup.actionfilter.FieldCapsFilter.apply(FieldCapsFilter.kt:118) ~[?:?]
        at org.opensearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:192) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.performanceanalyzer.action.PerformanceAnalyzerActionFilter.apply(PerformanceAnalyzerActionFilter.java:78) ~[?:?]
        at org.opensearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:192) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.security.filter.SecurityFilter.apply0(SecurityFilter.java:272) ~[?:?]
        at org.opensearch.security.filter.SecurityFilter.apply(SecurityFilter.java:157) ~[?:?]
        at org.opensearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:192) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.action.support.TransportAction.execute(TransportAction.java:169) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.action.support.TransportAction.execute(TransportAction.java:97) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.client.node.NodeClient.executeLocally(NodeClient.java:108) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.client.node.NodeClient.doExecute(NodeClient.java:95) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.client.support.AbstractClient.execute(AbstractClient.java:425) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.client.support.AbstractClient.search(AbstractClient.java:556) ~[opensearch-2.0.0-rc1.jar:2.0.0-rc1]
        at org.opensearch.alerting.util.destinationmigration.DestinationMigrationUtilService$Companion$retrieveDestinationsToMigrate$response$1.invoke(DestinationMigrationUtilService.kt:161) ~[opensearch-alerting-2.0.0.0-rc1.jar:2.0.0.0-rc1]
        at org.opensearch.alerting.util.destinationmigration.DestinationMigrationUtilService$Companion$retrieveDestinationsToMigrate$response$1.invoke(DestinationMigrationUtilService.kt:161) ~[opensearch-alerting-2.0.0.0-rc1.jar:2.0.0.0-rc1]
        at org.opensearch.alerting.opensearchapi.OpenSearchExtensionsKt.suspendUntil(OpenSearchExtensions.kt:189) ~[alerting-core-2.0.0.0-rc1.jar:?]
        at org.opensearch.alerting.util.destinationmigration.DestinationMigrationUtilService$Companion.retrieveDestinationsToMigrate(DestinationMigrationUtilService.kt:161) ~[opensearch-alerting-2.0.0.0-rc1.jar:2.0.0.0-rc1]
        at org.opensearch.alerting.util.destinationmigration.DestinationMigrationUtilService$Companion.migrateDestinations(DestinationMigrationUtilService.kt:67) ~[opensearch-alerting-2.0.0.0-rc1.jar:2.0.0.0-rc1]
        at org.opensearch.alerting.util.destinationmigration.DestinationMigrationCoordinator$initMigrateDestinations$scheduledJob$1$1.invokeSuspend(DestinationMigrationCoordinator.kt:89) [opensearch-alerting-2.0.0.0-rc1.jar:2.0.0.0-rc1]
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33) [kotlin-stdlib-1.6.10.jar:1.6.10-release-923(1.6.10)]
        at kotlinx.coroutines.DispatchedTask.run(Dispatched.kt:233) [kotlinx-coroutines-core-1.1.1.jar:?]
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:594) [kotlinx-coroutines-core-1.1.1.jar:?]
        at kotlinx.coroutines.scheduling.CoroutineScheduler.access$runSafely(CoroutineScheduler.kt:60) [kotlinx-coroutines-core-1.1.1.jar:?]
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:742) [kotlinx-coroutines-core-1.1.1.jar:?]
```

*CheckList:*
[X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).