### PR TITLE
Fix UnsupportedOperation error while alert categorization in BucketLevel monitor

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt
@@ -95,8 +95,8 @@ class AlertService(
             (
                 foundAlerts[trigger.id]?.mapNotNull { alert ->
                     alert.aggregationResultBucket?.let { it.getBucketKeysHash() to alert }
-                }?.toMap() ?: mutableMapOf()
-                ) as MutableMap<String, Alert>
+                }?.toMap()?.toMutableMap() ?: mutableMapOf()
+                )
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opensearch-project/alerting/issues/254
*Description of changes:*
`toMap()`  has special implementation when size is 1 and returns a readOnly map, which causes trouble later in the code while modifying this map. Explicitly converting it to a `MutableMap`
```
public fun <K, V> Iterable<Pair<K, V>>.toMap(): Map<K, V> {
    if (this is Collection) {
        return when (size) {
            0 -> emptyMap()
            1 -> mapOf(if (this is List) this[0] else iterator().next())
            else -> toMap(LinkedHashMap<K, V>(mapCapacity(size)))
        }
    }
    return toMap(LinkedHashMap<K, V>()).optimizeReadOnlyMap()
}
```

*CheckList:*
[ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).