### PR TITLE
Backport: Fix UnsupportedOperation error while alert categorization in BucketLe…

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt
@@ -93,8 +93,8 @@ class AlertService(
             (
                 foundAlerts[trigger.id]?.mapNotNull { alert ->
                     alert.aggregationResultBucket?.let { it.getBucketKeysHash() to alert }
-                }?.toMap() ?: mutableMapOf()
-                ) as MutableMap<String, Alert>
+                }?.toMap()?.toMutableMap() ?: mutableMapOf()
+                )
         }
     }
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertServiceTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertServiceTests.kt
@@ -177,6 +177,30 @@ class AlertServiceTests : OpenSearchTestCase() {
         assertAlertsExistForBucketKeys(listOf(listOf("a")), completedAlerts)
     }
 
+    fun `test getting categorized alerts for bucket-level monitor with de-duped alerts size 1`() {
+        val trigger = randomBucketLevelTrigger()
+        val monitor = randomBucketLevelMonitor(triggers = listOf(trigger))
+
+        val currentAlerts = createCurrentAlertsFromBucketKeys(
+            monitor, trigger,
+            listOf(
+                listOf("a")
+            )
+        )
+        val aggResultBuckets = createAggregationResultBucketsFromBucketKeys(
+            listOf(
+                listOf("a"),
+            )
+        )
+
+        val categorizedAlerts = alertService.getCategorizedAlertsForBucketLevelMonitor(monitor, trigger, currentAlerts, aggResultBuckets)
+        // Completed Alerts are what remains in currentAlerts after categorization
+        val completedAlerts = currentAlerts.values.toList()
+        assertAlertsExistForBucketKeys(listOf(listOf("a")), categorizedAlerts[AlertCategory.DEDUPED] ?: error("Deduped alerts not found"))
+        assertAlertsExistForBucketKeys(emptyList(), categorizedAlerts[AlertCategory.NEW] ?: error("New alerts found"))
+        assertAlertsExistForBucketKeys(emptyList(), completedAlerts)
+    }
+
     private fun createCurrentAlertsFromBucketKeys(
         monitor: Monitor,
         trigger: BucketLevelTrigger,
@@ -189,7 +213,7 @@ class AlertServiceTests : OpenSearchTestCase() {
                 actionExecutionResults = listOf(randomActionExecutionResult()), aggregationResultBucket = aggResultBucket
             )
             aggResultBucket.getBucketKeysHash() to alert
-        }.toMap() as MutableMap<String, Alert>
+        }.toMap().toMutableMap()
     }
 
     private fun createAggregationResultBucketsFromBucketKeys(bucketKeysList: List<List<String>>): List<AggregationResultBucket> {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertServiceTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertServiceTests.kt
@@ -189,7 +189,7 @@ class AlertServiceTests : OpenSearchTestCase() {
         )
         val aggResultBuckets = createAggregationResultBucketsFromBucketKeys(
             listOf(
-                listOf("a"),
+                listOf("a")
             )
         )
 


### PR DESCRIPTION
…vel monitor (#428)

* Fix UnsupportedOperation error while alert categorization in BucketLevel monitor

Signed-off-by: Rishabh Kumar Maurya <rishabhmaurya05@gmail.com>

* Added UT for the failure scenario

Signed-off-by: Rishabh Kumar Maurya <rishabhmaurya05@gmail.com>
(cherry picked from commit 8737e6d1b779280e8c98dd2f361a279b07932ad7)
Signed-off-by: Rishabh Kumar Maurya <rishabhmaurya05@gmail.com>

*Issue #, if available:*

*Description of changes:*

*CheckList:*
[ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).