### PR TITLE
Fix minor bugs and support per alert action execution for Document Level Monitors

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt
@@ -22,7 +22,6 @@ import org.opensearch.alerting.model.ActionRunResult
 import org.opensearch.alerting.model.AggregationResultBucket
 import org.opensearch.alerting.model.Alert
 import org.opensearch.alerting.model.BucketLevelTrigger
-import org.opensearch.alerting.model.DocumentLevelTriggerRunResult
 import org.opensearch.alerting.model.Monitor
 import org.opensearch.alerting.model.QueryLevelTriggerRunResult
 import org.opensearch.alerting.model.Trigger
@@ -47,6 +46,7 @@ import org.opensearch.index.query.QueryBuilders
 import org.opensearch.rest.RestStatus
 import org.opensearch.search.builder.SearchSourceBuilder
 import java.time.Instant
+import java.util.UUID
 
 /** Service that handles CRUD operations for alerts */
 class AlertService(
@@ -173,21 +173,15 @@ class AlertService(
         findings: List<String>,
         relatedDocIds: List<String>,
         ctx: DocumentLevelTriggerExecutionContext,
-        result: DocumentLevelTriggerRunResult,
         alertError: AlertError?
     ): Alert {
         val currentTime = Instant.now()
 
-        val actionExecutionResults = result.actionResults.map {
-            ActionExecutionResult(it.key, it.value.executionTime, if (it.value.throttled) 1 else 0)
-        }
-
         val alertState = if (alertError == null) Alert.State.ACTIVE else Alert.State.ERROR
         return Alert(
-            monitor = ctx.monitor, trigger = ctx.trigger, startTime = currentTime,
+            id = UUID.randomUUID().toString(), monitor = ctx.monitor, trigger = ctx.trigger, startTime = currentTime,
             lastNotificationTime = currentTime, state = alertState, errorMessage = alertError?.message,
-            actionExecutionResults = actionExecutionResults, schemaVersion = IndexUtils.alertIndexSchemaVersion,
-            findingIds = findings, relatedDocIds = relatedDocIds
+            schemaVersion = IndexUtils.alertIndexSchemaVersion, findingIds = findings, relatedDocIds = relatedDocIds
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -228,6 +228,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             .registerInputService(InputService(client, scriptService, namedWriteableRegistry, xContentRegistry))
             .registerTriggerService(TriggerService(scriptService))
             .registerAlertService(AlertService(client, xContentRegistry, alertIndices))
+            .registerDocLevelMonitorQueries(DocLevelMonitorQueries(client, clusterService))
             .registerConsumers()
             .registerDestinationSettings()
         scheduledJobIndices = ScheduledJobIndices(client.admin(), clusterService)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
@@ -6,8 +6,8 @@
 package org.opensearch.alerting
 
 import org.apache.logging.log4j.LogManager
-import org.opensearch.action.admin.indices.alias.get.GetAliasesRequest
-import org.opensearch.action.admin.indices.alias.get.GetAliasesResponse
+import org.opensearch.action.admin.indices.get.GetIndexRequest
+import org.opensearch.action.admin.indices.get.GetIndexResponse
 import org.opensearch.action.index.IndexRequest
 import org.opensearch.action.index.IndexResponse
 import org.opensearch.action.search.SearchAction
@@ -18,7 +18,9 @@ import org.opensearch.alerting.alerts.AlertIndices.Companion.FINDING_HISTORY_WRI
 import org.opensearch.alerting.core.model.DocLevelMonitorInput
 import org.opensearch.alerting.core.model.DocLevelQuery
 import org.opensearch.alerting.core.model.ScheduledJob
+import org.opensearch.alerting.model.ActionExecutionResult
 import org.opensearch.alerting.model.Alert
+import org.opensearch.alerting.model.AlertingConfigAccessor.Companion.getMonitorMetadata
 import org.opensearch.alerting.model.DocumentExecutionContext
 import org.opensearch.alerting.model.DocumentLevelTrigger
 import org.opensearch.alerting.model.DocumentLevelTriggerRunResult
@@ -26,11 +28,14 @@ import org.opensearch.alerting.model.Finding
 import org.opensearch.alerting.model.InputRunResults
 import org.opensearch.alerting.model.Monitor
 import org.opensearch.alerting.model.MonitorRunResult
+import org.opensearch.alerting.model.action.PerAlertActionScope
 import org.opensearch.alerting.opensearchapi.string
 import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.script.DocumentLevelTriggerExecutionContext
 import org.opensearch.alerting.util.AlertingException
-import org.opensearch.alerting.util.updateMonitor
+import org.opensearch.alerting.util.defaultToPerExecutionAction
+import org.opensearch.alerting.util.getActionExecutionPolicy
+import org.opensearch.alerting.util.updateMonitorMetadata
 import org.opensearch.client.Client
 import org.opensearch.cluster.routing.ShardRouting
 import org.opensearch.cluster.service.ClusterService
@@ -78,41 +83,55 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
         try {
             validate(monitor)
         } catch (e: Exception) {
-            logger.info("Failed to start Document-level-monitor. Error: ${e.message}")
+            logger.error("Failed to start Document-level-monitor. Error: ${e.message}")
             return monitorResult.copy(error = AlertingException.wrap(e))
         }
+
+        monitorCtx.docLevelMonitorQueries!!.initDocLevelQueryIndex()
+        monitorCtx.docLevelMonitorQueries!!.indexDocLevelQueries(
+            monitor = monitor,
+            monitorId = monitor.id,
+            indexTimeout = monitorCtx.indexTimeout!!
+        )
 
         val docLevelMonitorInput = monitor.inputs[0] as DocLevelMonitorInput
         val index = docLevelMonitorInput.indices[0]
         val queries: List<DocLevelQuery> = docLevelMonitorInput.queries
 
+        var monitorMetadata = getMonitorMetadata(monitorCtx.client!!, monitorCtx.xContentRegistry!!, "${monitor.id}-metadata")
+        if (monitorMetadata == null) {
+            monitorMetadata = createMonitorMetadata(monitor.id)
+        }
+
         val isTempMonitor = dryrun || monitor.id == Monitor.NO_ID
-        val lastRunContext = if (monitor.lastRunContext.isNullOrEmpty()) mutableMapOf()
-        else monitor.lastRunContext.toMutableMap() as MutableMap<String, MutableMap<String, Any>>
+        val lastRunContext = if (monitorMetadata.lastRunContext.isNullOrEmpty()) mutableMapOf()
+        else monitorMetadata.lastRunContext.toMutableMap() as MutableMap<String, MutableMap<String, Any>>
+
         val updatedLastRunContext = lastRunContext.toMutableMap()
 
         val queryToDocIds = mutableMapOf<DocLevelQuery, MutableSet<String>>()
+        val inputRunResults = mutableMapOf<String, MutableSet<String>>()
         val docsToQueries = mutableMapOf<String, MutableList<String>>()
-        val idQueryMap = mutableMapOf<String, DocLevelQuery>()
 
         try {
-            val getAliasesRequest = GetAliasesRequest(index)
-            val getAliasesResponse: GetAliasesResponse = monitorCtx.client!!.suspendUntil {
-                monitorCtx.client!!.admin().indices().getAliases(getAliasesRequest, it)
+            val getIndexRequest = GetIndexRequest().indices(index)
+            val getIndexResponse: GetIndexResponse = monitorCtx.client!!.suspendUntil {
+                monitorCtx.client!!.admin().indices().getIndex(getIndexRequest, it)
             }
-            val aliasIndices = getAliasesResponse.aliases.keys().map { it.value }
+            val indices = getIndexResponse.indices()
 
-            val isAlias = aliasIndices.isNotEmpty()
-            logger.debug("index, $index, is an alias index: $isAlias")
-
-            // If the input index is an alias, creating a list of all indices associated with that alias;
-            // else creating a list containing the single index input
-            val indices = if (isAlias) getAliasesResponse.aliases.keys().map { it.value } else listOf(index)
+            // cleanup old indices that are not monitored anymore from the same monitor
+            for (ind in updatedLastRunContext.keys) {
+                if (!indices.contains(ind)) {
+                    updatedLastRunContext.remove(ind)
+                }
+            }
 
             indices.forEach { indexName ->
                 // Prepare lastRunContext for each index
                 val indexLastRunContext = lastRunContext.getOrPut(indexName) {
-                    createRunContext(monitorCtx.clusterService!!, monitorCtx.client!!, indexName)
+                    val indexCreatedRecently = createdRecently(monitor, indexName, periodStart, periodEnd, getIndexResponse)
+                    createRunContext(monitorCtx.clusterService!!, monitorCtx.client!!, indexName, indexCreatedRecently)
                 }
 
                 // Prepare updatedLastRunContext for each index
@@ -152,17 +171,9 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
                         val docIndices = hit.field("_percolator_document_slot").values.map { it.toString().toInt() }
                         docIndices.forEach { idx ->
                             val docIndex = "${matchingDocs[idx].first}|$indexName"
-                            if (queryToDocIds.containsKey(docLevelQuery)) {
-                                queryToDocIds[docLevelQuery]?.add(docIndex)
-                            } else {
-                                queryToDocIds[docLevelQuery] = mutableSetOf(docIndex)
-                            }
-
-                            if (docsToQueries.containsKey(docIndex)) {
-                                docsToQueries[docIndex]?.add(id)
-                            } else {
-                                docsToQueries[docIndex] = mutableListOf(id)
-                            }
+                            queryToDocIds.getOrPut(docLevelQuery) { mutableSetOf() }.add(docIndex)
+                            inputRunResults.getOrPut(docLevelQuery.id) { mutableSetOf() }.add(docIndex)
+                            docsToQueries.getOrPut(docIndex) { mutableListOf() }.add(id)
                         }
                     }
                 }
@@ -173,12 +184,9 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
             return monitorResult.copy(error = alertingException, inputResults = InputRunResults(emptyList(), alertingException))
         }
 
-        val queryInputResults = queryToDocIds.mapKeys { it.key.id }
-        monitorResult = monitorResult.copy(inputResults = InputRunResults(listOf(queryInputResults)))
-        val queryIds = queries.map {
-            idQueryMap[it.id] = it
-            it.id
-        }
+        monitorResult = monitorResult.copy(inputResults = InputRunResults(listOf(inputRunResults)))
+
+        val idQueryMap: Map<String, DocLevelQuery> = queries.associateBy { it.id }
 
         val triggerResults = mutableMapOf<String, DocumentLevelTriggerRunResult>()
         monitor.triggers.forEach {
@@ -196,13 +204,7 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
 
         // Don't update monitor if this is a test monitor
         if (!isTempMonitor) {
-
-            // TODO: Check for race condition against the update monitor api
-            // This does the update at the end in case of errors and makes sure all the queries are executed
-            val updatedMonitor = monitor.copy(lastRunContext = updatedLastRunContext)
-            // note: update has to called in serial for shards of a given index.
-            // make sure this is just updated for the specific query or at the end of all the queries
-            updateMonitor(monitorCtx.client!!, monitorCtx.xContentRegistry!!, monitorCtx.settings!!, updatedMonitor)
+            updateMonitorMetadata(monitorCtx.client!!, monitorCtx.settings!!, monitorMetadata.copy(lastRunContext = updatedLastRunContext))
         }
 
         // TODO: Update the Document as part of the Trigger and return back the trigger action result
@@ -222,23 +224,17 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
         val triggerCtx = DocumentLevelTriggerExecutionContext(monitor, trigger)
         val triggerResult = monitorCtx.triggerService!!.runDocLevelTrigger(monitor, trigger, queryToDocIds)
 
-        logger.info("trigger results")
-        logger.info(triggerResult.triggeredDocs.toString())
-
         val findings = mutableListOf<String>()
         val findingDocPairs = mutableListOf<Pair<String, String>>()
 
         // TODO: Implement throttling for findings
-        if (!dryrun && monitor.id != Monitor.NO_ID) {
-            docsToQueries.forEach {
-                val triggeredQueries = it.value.map { queryId -> idQueryMap[queryId]!! }
-                val findingId = createFindings(monitor, monitorCtx, triggeredQueries, it.key)
+        docsToQueries.forEach {
+            val triggeredQueries = it.value.map { queryId -> idQueryMap[queryId]!! }
+            val findingId = createFindings(monitor, monitorCtx, triggeredQueries, it.key, !dryrun && monitor.id != Monitor.NO_ID)
+            findings.add(findingId)
 
-                findings.add(findingId)
-
-                if (triggerResult.triggeredDocs.contains(it.key)) {
-                    findingDocPairs.add(Pair(findingId, it.key))
-                }
+            if (triggerResult.triggeredDocs.contains(it.key)) {
+                findingDocPairs.add(Pair(findingId, it.key))
             }
         }
 
@@ -248,25 +244,53 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
             error = monitorResult.error ?: triggerResult.error
         )
 
-        for (action in trigger.actions) {
-            triggerResult.actionResults[action.id] = this.runAction(action, actionCtx, monitorCtx, dryrun)
+        val alerts = mutableListOf<Alert>()
+        findingDocPairs.forEach {
+            val alert = monitorCtx.alertService!!.composeDocLevelAlert(
+                listOf(it.first),
+                listOf(it.second),
+                triggerCtx,
+                monitorResult.alertError() ?: triggerResult.alertError()
+            )
+            alerts.add(alert)
         }
 
-        // TODO: Implement throttling for alerts
+        val shouldDefaultToPerExecution = defaultToPerExecutionAction(
+            monitorCtx.maxActionableAlertCount,
+            monitorId = monitor.id,
+            triggerId = trigger.id,
+            totalActionableAlertCount = alerts.size,
+            monitorOrTriggerError = actionCtx.error
+        )
+
+        for (action in trigger.actions) {
+            val actionExecutionScope = action.getActionExecutionPolicy(monitor)!!.actionExecutionScope
+            if (actionExecutionScope is PerAlertActionScope && !shouldDefaultToPerExecution) {
+                for (alert in alerts) {
+                    val actionResults = this.runAction(action, actionCtx.copy(alert = alert), monitorCtx, dryrun)
+                    triggerResult.actionResultsMap.getOrPut(alert.id) { mutableMapOf() }
+                    triggerResult.actionResultsMap[alert.id]?.set(action.id, actionResults)
+                }
+            } else {
+                val actionResults = this.runAction(action, actionCtx, monitorCtx, dryrun)
+                for (alert in alerts) {
+                    triggerResult.actionResultsMap.getOrPut(alert.id) { mutableMapOf() }
+                    triggerResult.actionResultsMap[alert.id]?.set(action.id, actionResults)
+                }
+            }
+        }
+
         // Alerts are saved after the actions since if there are failures in the actions, they can be stated in the alert
         if (!dryrun && monitor.id != Monitor.NO_ID) {
-            val alerts = mutableListOf<Alert>()
-            findingDocPairs.forEach {
-                val alert = monitorCtx.alertService!!.composeDocLevelAlert(
-                    listOf(it.first),
-                    listOf(it.second),
-                    triggerCtx,
-                    triggerResult,
-                    monitorResult.alertError() ?: triggerResult.alertError()
-                )
-                alerts.add(alert)
+            val updatedAlerts = alerts.map { alert ->
+                val actionResults = triggerResult.actionResultsMap.getOrDefault(alert.id, emptyMap())
+                val actionExecutionResults = actionResults.values.map { actionRunResult ->
+                    ActionExecutionResult(actionRunResult.actionId, actionRunResult.executionTime, if (actionRunResult.throttled) 1 else 0)
+                }
+                alert.copy(actionExecutionResults = actionExecutionResults)
             }
-            monitorCtx.retryPolicy?.let { monitorCtx.alertService!!.saveAlerts(alerts, it) }
+
+            monitorCtx.retryPolicy?.let { monitorCtx.alertService!!.saveAlerts(updatedAlerts, it) }
         }
         return triggerResult
     }
@@ -275,7 +299,8 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
         monitor: Monitor,
         monitorCtx: MonitorRunnerExecutionContext,
         docLevelQueries: List<DocLevelQuery>,
-        matchingDocId: String
+        matchingDocId: String,
+        shouldCreateFinding: Boolean
     ): String {
         // Before the "|" is the doc id and after the "|" is the index
         val docIndex = matchingDocId.split("|")
@@ -293,14 +318,16 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
         val findingStr = finding.toXContent(XContentBuilder.builder(XContentType.JSON.xContent()), ToXContent.EMPTY_PARAMS).string()
         logger.debug("Findings: $findingStr")
 
-        val indexRequest = IndexRequest(FINDING_HISTORY_WRITE_INDEX)
-            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-            .source(findingStr, XContentType.JSON)
-            .id(finding.id)
-            .routing(finding.id)
+        if (shouldCreateFinding) {
+            val indexRequest = IndexRequest(FINDING_HISTORY_WRITE_INDEX)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                .source(findingStr, XContentType.JSON)
+                .id(finding.id)
+                .routing(finding.id)
 
-        val indexResponse: IndexResponse = monitorCtx.client!!.suspendUntil {
-            monitorCtx.client!!.index(indexRequest, it)
+            monitorCtx.client!!.suspendUntil<Client, IndexResponse> {
+                monitorCtx.client!!.index(indexRequest, it)
+            }
         }
         return finding.id
     }
@@ -335,7 +362,12 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
         }
     }
 
-    suspend fun createRunContext(clusterService: ClusterService, client: Client, index: String): HashMap<String, Any> {
+    suspend fun createRunContext(
+        clusterService: ClusterService,
+        client: Client,
+        index: String,
+        createdRecently: Boolean = false
+    ): HashMap<String, Any> {
         val lastRunContext = HashMap<String, Any>()
         lastRunContext["index"] = index
         val count = getShardsCount(clusterService, index)
@@ -343,10 +375,23 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
 
         for (i: Int in 0 until count) {
             val shard = i.toString()
-            val maxSeqNo: Long = getMaxSeqNo(client, index, shard)
+            val maxSeqNo: Long = if (createdRecently) -1L else getMaxSeqNo(client, index, shard)
             lastRunContext[shard] = maxSeqNo
         }
         return lastRunContext
+    }
+
+    // Checks if the index was created from the last execution run or when the monitor was last updated to ensure that
+    // new index is monitored from the beginning of that index
+    private fun createdRecently(
+        monitor: Monitor,
+        index: String,
+        periodStart: Instant,
+        periodEnd: Instant,
+        getIndexResponse: GetIndexResponse
+    ): Boolean {
+        val lastExecutionTime = if (periodStart == periodEnd) monitor.lastUpdateTime else periodStart
+        return getIndexResponse.settings.get(index).getAsLong("index.creation_date", 0L) > lastExecutionTime.toEpochMilli()
     }
 
     /**
@@ -391,10 +436,8 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
         for (i: Int in 0 until count) {
             val shard = i.toString()
             try {
-                logger.info("Monitor execution for shard: $shard")
                 val maxSeqNo: Long = docExecutionCtx.updatedLastRunContext[shard].toString().toLong()
                 val prevSeqNo = docExecutionCtx.lastRunContext[shard].toString().toLongOrNull()
-                logger.info("prevSeq: $prevSeqNo, maxSeq: $maxSeqNo")
 
                 val hits: SearchHits = searchShard(
                     monitorCtx,
@@ -404,13 +447,12 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
                     maxSeqNo,
                     null
                 )
-                logger.info("Search hits for shard_$shard is: ${hits.hits.size}")
 
                 if (hits.hits.isNotEmpty()) {
                     matchingDocs.addAll(getAllDocs(hits, index, monitor.id))
                 }
             } catch (e: Exception) {
-                logger.info("Failed to run for shard $shard. Error: ${e.message}")
+                logger.warn("Failed to run for shard $shard. Error: ${e.message}")
             }
         }
         return matchingDocs
@@ -443,7 +485,6 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
                     .query(boolQueryBuilder)
                     .size(10000) // fixme: make this configurable.
             )
-        logger.info("Request: $request")
         val response: SearchResponse = monitorCtx.client!!.suspendUntil { monitorCtx.client!!.search(request, it) }
         if (response.status() !== RestStatus.OK) {
             throw IOException("Failed to search shard: $shard")

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.withContext
 import org.opensearch.alerting.model.ActionRunResult
 import org.opensearch.alerting.model.AlertingConfigAccessor
 import org.opensearch.alerting.model.Monitor
+import org.opensearch.alerting.model.MonitorMetadata
 import org.opensearch.alerting.model.MonitorRunResult
 import org.opensearch.alerting.model.action.Action
 import org.opensearch.alerting.model.destination.Destination
@@ -140,5 +141,9 @@ abstract class MonitorRunner {
         }
 
         return NotificationActionConfigs(destination, channel)
+    }
+
+    protected fun createMonitorMetadata(monitorId: String): MonitorMetadata {
+        return MonitorMetadata("$monitorId-metadata", monitorId, emptyList(), emptyMap())
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunnerExecutionContext.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunnerExecutionContext.kt
@@ -11,9 +11,11 @@ import org.opensearch.alerting.model.destination.DestinationContextFactory
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.settings.DestinationSettings
 import org.opensearch.alerting.settings.LegacyOpenDistroDestinationSettings
+import org.opensearch.alerting.util.DocLevelMonitorQueries
 import org.opensearch.client.Client
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.settings.Settings
+import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.script.ScriptService
 import org.opensearch.threadpool.ThreadPool
@@ -30,6 +32,7 @@ data class MonitorRunnerExecutionContext(
     var inputService: InputService? = null,
     var triggerService: TriggerService? = null,
     var alertService: AlertService? = null,
+    var docLevelMonitorQueries: DocLevelMonitorQueries? = null,
 
     @Volatile var retryPolicy: BackoffPolicy? = null,
     @Volatile var moveAlertsRetryPolicy: BackoffPolicy? = null,
@@ -40,5 +43,6 @@ data class MonitorRunnerExecutionContext(
     @Volatile var destinationSettings: Map<String, DestinationSettings.Companion.SecureDestinationSettings>? = null,
     @Volatile var destinationContextFactory: DestinationContextFactory? = null,
 
-    @Volatile var maxActionableAlertCount: Long = AlertingSettings.DEFAULT_MAX_ACTIONABLE_ALERT_COUNT
+    @Volatile var maxActionableAlertCount: Long = AlertingSettings.DEFAULT_MAX_ACTIONABLE_ALERT_COUNT,
+    @Volatile var indexTimeout: TimeValue? = null
 )

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/Alert.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/Alert.kt
@@ -108,6 +108,7 @@ data class Alert(
     )
 
     constructor(
+        id: String = NO_ID,
         monitor: Monitor,
         trigger: DocumentLevelTrigger,
         findingIds: List<String>,
@@ -120,7 +121,7 @@ data class Alert(
         actionExecutionResults: List<ActionExecutionResult> = mutableListOf(),
         schemaVersion: Int = NO_SCHEMA_VERSION
     ) : this(
-        monitorId = monitor.id, monitorName = monitor.name, monitorVersion = monitor.version, monitorUser = monitor.user,
+        id = id, monitorId = monitor.id, monitorName = monitor.name, monitorVersion = monitor.version, monitorUser = monitor.user,
         triggerId = trigger.id, triggerName = trigger.name, state = state, startTime = startTime,
         lastNotificationTime = lastNotificationTime, errorMessage = errorMessage, errorHistory = errorHistory,
         severity = trigger.severity, actionExecutionResults = actionExecutionResults, schemaVersion = schemaVersion,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/DocumentLevelTriggerRunResult.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/DocumentLevelTriggerRunResult.kt
@@ -5,20 +5,18 @@
 
 package org.opensearch.alerting.model
 
-import org.opensearch.alerting.alerts.AlertError
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.StreamOutput
 import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.script.ScriptException
 import java.io.IOException
-import java.time.Instant
 
 data class DocumentLevelTriggerRunResult(
     override var triggerName: String,
     var triggeredDocs: List<String>,
     override var error: Exception?,
-    var actionResults: MutableMap<String, ActionRunResult> = mutableMapOf()
+    var actionResultsMap: MutableMap<String, MutableMap<String, ActionRunResult>> = mutableMapOf()
 ) : TriggerRunResult(triggerName, error) {
 
     @Throws(IOException::class)
@@ -27,33 +25,21 @@ data class DocumentLevelTriggerRunResult(
         triggerName = sin.readString(),
         error = sin.readException(),
         triggeredDocs = sin.readStringList(),
-        actionResults = sin.readMap() as MutableMap<String, ActionRunResult>
+        actionResultsMap = sin.readMap() as MutableMap<String, MutableMap<String, ActionRunResult>>
     )
-
-    override fun alertError(): AlertError? {
-        if (error != null) {
-            return AlertError(Instant.now(), "Failed evaluating trigger:\n${error!!.userErrorMessage()}")
-        }
-        for (actionResult in actionResults.values) {
-            if (actionResult.error != null) {
-                return AlertError(Instant.now(), "Failed running action:\n${actionResult.error.userErrorMessage()}")
-            }
-        }
-        return null
-    }
 
     override fun internalXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         if (error is ScriptException) error = Exception((error as ScriptException).toJsonString(), error)
         return builder
             .field("triggeredDocs", triggeredDocs as List<String>)
-            .field("action_results", actionResults as Map<String, ActionRunResult>)
+            .field("action_results", actionResultsMap as Map<String, Any>)
     }
 
     @Throws(IOException::class)
     override fun writeTo(out: StreamOutput) {
         super.writeTo(out)
         out.writeStringCollection(triggeredDocs)
-        out.writeMap(actionResults as Map<String, ActionRunResult>)
+        out.writeMap(actionResultsMap as Map<String, Any>)
     }
 
     companion object {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/Monitor.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/Monitor.kt
@@ -55,7 +55,6 @@ data class Monitor(
     val schemaVersion: Int = NO_SCHEMA_VERSION,
     val inputs: List<Input>,
     val triggers: List<Trigger>,
-    val lastRunContext: Map<String, Any>,
     val uiMetadata: Map<String, Any>
 ) : ScheduledJob {
 
@@ -113,7 +112,6 @@ data class Monitor(
         schemaVersion = sin.readInt(),
         inputs = sin.readList((Input)::readFrom),
         triggers = sin.readList((Trigger)::readFrom),
-        lastRunContext = suppressWarning(sin.readMap()),
         uiMetadata = suppressWarning(sin.readMap())
     )
 
@@ -161,7 +159,6 @@ data class Monitor(
             .field(INPUTS_FIELD, inputs.toTypedArray())
             .field(TRIGGERS_FIELD, triggers.toTypedArray())
             .optionalTimeField(LAST_UPDATE_TIME_FIELD, lastUpdateTime)
-        if (lastRunContext.isNotEmpty()) builder.field(LAST_RUN_CONTEXT_FIELD, lastRunContext)
         if (uiMetadata.isNotEmpty()) builder.field(UI_METADATA_FIELD, uiMetadata)
         if (params.paramAsBoolean("with_type", false)) builder.endObject()
         return builder.endObject()
@@ -204,7 +201,6 @@ data class Monitor(
             }
             it.writeTo(out)
         }
-        out.writeMap(lastRunContext)
         out.writeMap(uiMetadata)
     }
 
@@ -222,7 +218,6 @@ data class Monitor(
         const val NO_VERSION = 1L
         const val INPUTS_FIELD = "inputs"
         const val LAST_UPDATE_TIME_FIELD = "last_update_time"
-        const val LAST_RUN_CONTEXT_FIELD = "last_run_context"
         const val UI_METADATA_FIELD = "ui_metadata"
         const val ENABLED_TIME_FIELD = "enabled_time"
 
@@ -245,7 +240,6 @@ data class Monitor(
             var schedule: Schedule? = null
             var lastUpdateTime: Instant? = null
             var enabledTime: Instant? = null
-            var lastRunContext: Map<String, Any> = mapOf()
             var uiMetadata: Map<String, Any> = mapOf()
             var enabled = true
             var schemaVersion = NO_SCHEMA_VERSION
@@ -287,7 +281,6 @@ data class Monitor(
                     }
                     ENABLED_TIME_FIELD -> enabledTime = xcp.instant()
                     LAST_UPDATE_TIME_FIELD -> lastUpdateTime = xcp.instant()
-                    LAST_RUN_CONTEXT_FIELD -> lastRunContext = xcp.map()
                     UI_METADATA_FIELD -> uiMetadata = xcp.map()
                     else -> {
                         xcp.skipChildren()
@@ -313,7 +306,6 @@ data class Monitor(
                 schemaVersion,
                 inputs.toList(),
                 triggers.toList(),
-                lastRunContext,
                 uiMetadata
             )
         }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/MonitorMetadata.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/MonitorMetadata.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.model
+
+import org.opensearch.alerting.opensearchapi.instant
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.common.io.stream.Writeable
+import org.opensearch.common.xcontent.ToXContent
+import org.opensearch.common.xcontent.XContentBuilder
+import org.opensearch.common.xcontent.XContentParser
+import org.opensearch.common.xcontent.XContentParserUtils
+import java.io.IOException
+import java.time.Instant
+
+data class MonitorMetadata(
+    val id: String,
+    val monitorId: String,
+    val lastActionExecutionTimes: List<ActionExecutionTime>,
+    val lastRunContext: Map<String, Any>
+) : Writeable, ToXContent {
+
+    @Throws(IOException::class)
+    constructor(sin: StreamInput) : this(
+        id = sin.readString(),
+        monitorId = sin.readString(),
+        lastActionExecutionTimes = sin.readList(ActionExecutionTime::readFrom),
+        lastRunContext = Monitor.suppressWarning(sin.readMap())
+    )
+
+    override fun writeTo(out: StreamOutput) {
+        out.writeString(id)
+        out.writeString(monitorId)
+        out.writeCollection(lastActionExecutionTimes)
+        out.writeMap(lastRunContext)
+    }
+
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        builder.startObject()
+        if (params.paramAsBoolean("with_type", false)) builder.startObject(METADATA)
+        builder.field(MONITOR_ID_FIELD, monitorId)
+            .field(LAST_ACTION_EXECUTION_FIELD, lastActionExecutionTimes.toTypedArray())
+        if (lastRunContext.isNotEmpty()) builder.field(LAST_RUN_CONTEXT_FIELD, lastRunContext)
+        if (params.paramAsBoolean("with_type", false)) builder.endObject()
+        return builder.endObject()
+    }
+
+    companion object {
+        const val METADATA = "metadata"
+        const val MONITOR_ID_FIELD = "monitor_id"
+        const val LAST_ACTION_EXECUTION_FIELD = "last_action_execution_times"
+        const val LAST_RUN_CONTEXT_FIELD = "last_run_context"
+
+        @JvmStatic @JvmOverloads
+        @Throws(IOException::class)
+        fun parse(xcp: XContentParser): MonitorMetadata {
+            lateinit var monitorId: String
+            val lastActionExecutionTimes = mutableListOf<ActionExecutionTime>()
+            var lastRunContext: Map<String, Any> = mapOf()
+
+            XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
+            while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
+                val fieldName = xcp.currentName()
+                xcp.nextToken()
+
+                when (fieldName) {
+                    MONITOR_ID_FIELD -> monitorId = xcp.text()
+                    LAST_ACTION_EXECUTION_FIELD -> {
+                        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, xcp.currentToken(), xcp)
+                        while (xcp.nextToken() != XContentParser.Token.END_ARRAY) {
+                            lastActionExecutionTimes.add(ActionExecutionTime.parse(xcp))
+                        }
+                    }
+                    LAST_RUN_CONTEXT_FIELD -> lastRunContext = xcp.map()
+                }
+            }
+
+            return MonitorMetadata(
+                "$monitorId-metadata",
+                monitorId = monitorId,
+                lastActionExecutionTimes = lastActionExecutionTimes,
+                lastRunContext = lastRunContext
+            )
+        }
+
+        @JvmStatic
+        @Throws(IOException::class)
+        fun readFrom(sin: StreamInput): MonitorMetadata {
+            return MonitorMetadata(sin)
+        }
+    }
+}
+
+/**
+ * A value object containing action execution time.
+ */
+data class ActionExecutionTime(
+    val actionId: String,
+    val executionTime: Instant
+) : Writeable, ToXContent {
+
+    @Throws(IOException::class)
+    constructor(sin: StreamInput) : this(
+        sin.readString(), // actionId
+        sin.readInstant(), // executionTime
+    )
+
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        return builder.startObject()
+            .field(ACTION_ID_FIELD, actionId)
+            .field(EXECUTION_TIME_FIELD, executionTime)
+            .endObject()
+    }
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        out.writeString(actionId)
+        out.writeInstant(executionTime)
+    }
+
+    companion object {
+        const val ACTION_ID_FIELD = "action_id"
+        const val EXECUTION_TIME_FIELD = "execution_time"
+
+        @JvmStatic
+        @Throws(IOException::class)
+        fun parse(xcp: XContentParser): ActionExecutionTime {
+            lateinit var actionId: String
+            lateinit var executionTime: Instant
+
+            XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
+            while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
+                val fieldName = xcp.currentName()
+                xcp.nextToken()
+
+                when (fieldName) {
+                    ACTION_ID_FIELD -> actionId = xcp.text()
+                    EXECUTION_TIME_FIELD -> executionTime = xcp.instant()!!
+                }
+            }
+
+            return ActionExecutionTime(
+                actionId,
+                executionTime
+            )
+        }
+
+        @JvmStatic
+        @Throws(IOException::class)
+        fun readFrom(sin: StreamInput): ActionExecutionTime {
+            return ActionExecutionTime(sin)
+        }
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/action/ActionExecutionPolicy.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/action/ActionExecutionPolicy.kt
@@ -85,5 +85,18 @@ data class ActionExecutionPolicy(
             )
             return ActionExecutionPolicy(actionExecutionScope = defaultActionExecutionScope)
         }
+
+        /**
+         * The default [ActionExecutionPolicy] configuration for Document-Level Monitors.
+         *
+         * If Query-Level Monitors integrate the use of [ActionExecutionPolicy] then a separate default configuration
+         * will need to be made depending on the desired behavior.
+         */
+        fun getDefaultConfigurationForDocumentLevelMonitor(): ActionExecutionPolicy {
+            val defaultActionExecutionScope = PerAlertActionScope(
+                actionableAlerts = setOf(AlertCategory.DEDUPED, AlertCategory.NEW)
+            )
+            return ActionExecutionPolicy(actionExecutionScope = defaultActionExecutionScope)
+        }
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
@@ -140,11 +140,40 @@ class TransportDeleteMonitorAction @Inject constructor(
                         if (clusterState.routingTable.hasIndex(ScheduledJob.DOC_LEVEL_QUERIES_INDEX)) {
                             deleteDocLevelMonitorQueries()
                         }
+                        deleteMetadata()
+
                         actionListener.onResponse(response)
                     }
 
                     override fun onFailure(t: Exception) {
                         actionListener.onFailure(AlertingException.wrap(t))
+                    }
+                }
+            )
+        }
+
+        private fun deleteMetadata() {
+            val getRequest = GetRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, monitorId)
+            client.get(
+                getRequest,
+                object : ActionListener<GetResponse> {
+                    override fun onResponse(response: GetResponse) {
+                        if (response.isExists) {
+                            val deleteMetadataRequest = DeleteRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, "$monitorId")
+                                .setRefreshPolicy(deleteRequest.refreshPolicy)
+                            client.delete(
+                                deleteMetadataRequest,
+                                object : ActionListener<DeleteResponse> {
+                                    override fun onResponse(response: DeleteResponse) {
+                                    }
+
+                                    override fun onFailure(t: Exception) {
+                                    }
+                                }
+                            )
+                        }
+                    }
+                    override fun onFailure(t: Exception) {
                     }
                 }
             )

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
@@ -130,7 +130,6 @@ class TransportExecuteMonitorAction @Inject constructor(
                                 log.info("Central Percolation index ${ScheduledJob.DOC_LEVEL_QUERIES_INDEX} created")
                             }
                             docLevelMonitorQueries.indexDocLevelQueries(
-                                client,
                                 monitor,
                                 monitor.id,
                                 WriteRequest.RefreshPolicy.IMMEDIATE,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
@@ -5,6 +5,7 @@
 
 package org.opensearch.alerting.util
 
+import org.apache.logging.log4j.LogManager
 import org.opensearch.action.index.IndexRequest
 import org.opensearch.action.index.IndexResponse
 import org.opensearch.action.support.WriteRequest
@@ -12,8 +13,10 @@ import org.opensearch.alerting.core.model.ScheduledJob
 import org.opensearch.alerting.model.AggregationResultBucket
 import org.opensearch.alerting.model.BucketLevelTriggerRunResult
 import org.opensearch.alerting.model.Monitor
+import org.opensearch.alerting.model.MonitorMetadata
 import org.opensearch.alerting.model.action.Action
 import org.opensearch.alerting.model.action.ActionExecutionPolicy
+import org.opensearch.alerting.model.action.ActionExecutionScope
 import org.opensearch.alerting.model.destination.Destination
 import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.settings.AlertingSettings
@@ -23,6 +26,8 @@ import org.opensearch.common.settings.Settings
 import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentFactory
+
+private val logger = LogManager.getLogger("AlertingUtils")
 
 /**
  * RFC 5322 compliant pattern matching: https://www.ietf.org/rfc/rfc5322.txt
@@ -64,6 +69,8 @@ fun Action.getActionExecutionPolicy(monitor: Monitor): ActionExecutionPolicy? {
     // the parse.
     return this.actionExecutionPolicy ?: if (monitor.isBucketLevelMonitor()) {
         ActionExecutionPolicy.getDefaultConfigurationForBucketLevelMonitor()
+    } else if (monitor.isDocLevelMonitor()) {
+        ActionExecutionPolicy.getDefaultConfigurationForDocumentLevelMonitor()
     } else {
         null
     }
@@ -85,6 +92,39 @@ fun BucketLevelTriggerRunResult.getCombinedTriggerRunResult(
     return this.copy(aggregationResultBuckets = mergedAggregationResultBuckets, actionResultsMap = mergedActionResultsMap, error = error)
 }
 
+fun defaultToPerExecutionAction(
+    maxActionableAlertCount: Long,
+    monitorId: String,
+    triggerId: String,
+    totalActionableAlertCount: Int,
+    monitorOrTriggerError: Exception?
+): Boolean {
+    // If the monitorId or triggerResult has an error, then also default to PER_EXECUTION to communicate the error
+    if (monitorOrTriggerError != null) {
+        logger.debug(
+            "Trigger [$triggerId] in monitor [$monitorId] encountered an error. Defaulting to " +
+                "[${ActionExecutionScope.Type.PER_EXECUTION}] for action execution to communicate error."
+        )
+        return true
+    }
+
+    // If the MAX_ACTIONABLE_ALERT_COUNT is set to -1, consider it unbounded and proceed regardless of actionable Alert count
+    if (maxActionableAlertCount < 0) return false
+
+    // If the total number of Alerts to execute Actions on exceeds the MAX_ACTIONABLE_ALERT_COUNT setting then default to
+    // PER_EXECUTION for less intrusive Actions
+    if (totalActionableAlertCount > maxActionableAlertCount) {
+        logger.debug(
+            "The total actionable alerts for trigger [$triggerId] in monitor [$monitorId] is [$totalActionableAlertCount] " +
+                "which exceeds the maximum of [$maxActionableAlertCount]. " +
+                "Defaulting to [${ActionExecutionScope.Type.PER_EXECUTION}] for action execution."
+        )
+        return true
+    }
+
+    return false
+}
+
 // TODO: Check if this can be more generic such that TransportIndexMonitorAction class can use this. Also see if this should be refactored
 // to another class. Include tests for this as well.
 suspend fun updateMonitor(client: Client, xContentRegistry: NamedXContentRegistry, settings: Settings, monitor: Monitor): IndexResponse {
@@ -100,6 +140,16 @@ suspend fun updateMonitor(client: Client, xContentRegistry: NamedXContentRegistr
         .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
         .source(monitor.toXContentWithUser(XContentFactory.jsonBuilder(), ToXContent.MapParams(mapOf("with_type" to "true"))))
         .id(monitor.id)
+        .timeout(AlertingSettings.INDEX_TIMEOUT.get(settings))
+
+    return client.suspendUntil { client.index(indexRequest, it) }
+}
+
+suspend fun updateMonitorMetadata(client: Client, settings: Settings, monitorMetadata: MonitorMetadata): IndexResponse {
+    val indexRequest = IndexRequest(ScheduledJob.SCHEDULED_JOBS_INDEX)
+        .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+        .source(monitorMetadata.toXContent(XContentFactory.jsonBuilder(), ToXContent.MapParams(mapOf("with_type" to "true"))))
+        .id(monitorMetadata.id)
         .timeout(AlertingSettings.INDEX_TIMEOUT.get(settings))
 
     return client.suspendUntil { client.index(indexRequest, it) }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
@@ -7,10 +7,10 @@ package org.opensearch.alerting.util
 
 import org.apache.logging.log4j.LogManager
 import org.opensearch.ResourceAlreadyExistsException
-import org.opensearch.action.admin.indices.alias.get.GetAliasesRequest
-import org.opensearch.action.admin.indices.alias.get.GetAliasesResponse
 import org.opensearch.action.admin.indices.create.CreateIndexRequest
 import org.opensearch.action.admin.indices.create.CreateIndexResponse
+import org.opensearch.action.admin.indices.get.GetIndexRequest
+import org.opensearch.action.admin.indices.get.GetIndexResponse
 import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest
 import org.opensearch.action.bulk.BulkRequest
 import org.opensearch.action.bulk.BulkResponse
@@ -65,10 +65,9 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
     }
 
     suspend fun indexDocLevelQueries(
-        queryClient: Client,
         monitor: Monitor,
         monitorId: String,
-        refreshPolicy: RefreshPolicy,
+        refreshPolicy: RefreshPolicy = RefreshPolicy.IMMEDIATE,
         indexTimeout: TimeValue
     ) {
         val docLevelMonitorInput = monitor.inputs[0] as DocLevelMonitorInput
@@ -77,13 +76,11 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
 
         val clusterState = clusterService.state()
 
-        val getAliasesRequest = GetAliasesRequest(index)
-        val getAliasesResponse: GetAliasesResponse = queryClient.suspendUntil {
-            queryClient.admin().indices().getAliases(getAliasesRequest, it)
+        val getIndexRequest = GetIndexRequest().indices(index)
+        val getIndexResponse: GetIndexResponse = client.suspendUntil {
+            client.admin().indices().getIndex(getIndexRequest, it)
         }
-        val aliasIndices = getAliasesResponse.aliases?.keys()?.map { it.value }
-        val isAlias = aliasIndices != null && aliasIndices.isNotEmpty()
-        val indices = if (isAlias) aliasIndices else listOf(index)
+        val indices = getIndexResponse.indices()
 
         indices?.forEach { indexName ->
             if (clusterState.routingTable.hasIndex(indexName)) {
@@ -106,8 +103,8 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
 
                     val updateMappingRequest = PutMappingRequest(ScheduledJob.DOC_LEVEL_QUERIES_INDEX)
                     updateMappingRequest.source(mapOf<String, Any>("properties" to updatedProperties))
-                    val updateMappingResponse: AcknowledgedResponse = queryClient.suspendUntil {
-                        queryClient.admin().indices().putMapping(updateMappingRequest, it)
+                    val updateMappingResponse: AcknowledgedResponse = client.suspendUntil {
+                        client.admin().indices().putMapping(updateMappingRequest, it)
                     }
 
                     if (updateMappingResponse.isAcknowledged) {
@@ -129,8 +126,8 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
                             indexRequests.add(indexRequest)
                         }
                         if (indexRequests.isNotEmpty()) {
-                            val bulkResponse: BulkResponse = queryClient.suspendUntil {
-                                queryClient.bulk(
+                            val bulkResponse: BulkResponse = client.suspendUntil {
+                                client.bulk(
                                     BulkRequest().setRefreshPolicy(refreshPolicy).timeout(indexTimeout).add(indexRequests), it
                                 )
                             }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/ADTestHelpers.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/ADTestHelpers.kt
@@ -496,7 +496,7 @@ fun randomADMonitor(
     return Monitor(
         name = name, monitorType = Monitor.MonitorType.QUERY_LEVEL_MONITOR, enabled = enabled, inputs = inputs,
         schedule = schedule, triggers = triggers, enabledTime = enabledTime, lastUpdateTime = lastUpdateTime,
-        user = user, lastRunContext = mapOf(), uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf()
+        user = user, uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf()
     )
 }
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/DocumentMonitorRunnerIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/DocumentMonitorRunnerIT.kt
@@ -7,6 +7,10 @@ package org.opensearch.alerting
 
 import org.opensearch.alerting.core.model.DocLevelMonitorInput
 import org.opensearch.alerting.core.model.DocLevelQuery
+import org.opensearch.alerting.model.action.ActionExecutionPolicy
+import org.opensearch.alerting.model.action.AlertCategory
+import org.opensearch.alerting.model.action.PerAlertActionScope
+import org.opensearch.alerting.model.action.PerExecutionActionScope
 import org.opensearch.client.Response
 import org.opensearch.client.ResponseException
 import org.opensearch.script.Script
@@ -47,10 +51,13 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
 
         for (triggerResult in output.objectMap("trigger_results").values) {
             assertEquals(1, triggerResult.objectMap("action_results").values.size)
-            for (actionResult in triggerResult.objectMap("action_results").values) {
-                @Suppress("UNCHECKED_CAST") val actionOutput = actionResult["output"] as Map<String, String>
-                assertEquals("Hello ${monitor.name}", actionOutput["subject"])
-                assertEquals("Hello ${monitor.name}", actionOutput["message"])
+            for (alertActionResult in triggerResult.objectMap("action_results").values) {
+                for (actionResult in alertActionResult.values) {
+                    @Suppress("UNCHECKED_CAST") val actionOutput = (actionResult as Map<String, Map<String, String>>)["output"]
+                        as Map<String, String>
+                    assertEquals("Hello ${monitor.name}", actionOutput["subject"])
+                    assertEquals("Hello ${monitor.name}", actionOutput["message"])
+                }
             }
         }
 
@@ -130,13 +137,231 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
         assertTrue("Findings saved for test monitor", findings[1].relatedDocIds.contains("5"))
     }
 
+    fun `test execute monitor generates alerts and findings with per alert execution for actions`() {
+        val testIndex = createTestIndex()
+        val testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now().truncatedTo(MILLIS))
+        val testDoc = """{
+            "message" : "This is an error from IAD region",
+            "test_strict_date_time" : "$testTime",
+            "test_field" : "us-west-2"
+        }"""
+
+        val docQuery = DocLevelQuery(query = "test_field:\"us-west-2\"", name = "3")
+        val docLevelInput = DocLevelMonitorInput("description", listOf(testIndex), listOf(docQuery))
+
+        val alertCategories = AlertCategory.values()
+        val actionExecutionScope = PerAlertActionScope(
+            actionableAlerts = (1..randomInt(alertCategories.size)).map { alertCategories[it - 1] }.toSet()
+        )
+        val actionExecutionPolicy = ActionExecutionPolicy(actionExecutionScope)
+        val actions = (0..randomInt(10)).map {
+            randomActionWithPolicy(
+                template = randomTemplateScript("Hello {{ctx.monitor.name}}"),
+                destinationId = createDestination().id,
+                actionExecutionPolicy = actionExecutionPolicy
+            )
+        }
+
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN, actions = actions)
+        val monitor = createMonitor(randomDocumentLevelMonitor(inputs = listOf(docLevelInput), triggers = listOf(trigger)))
+        assertNotNull(monitor.id)
+
+        indexDoc(testIndex, "1", testDoc)
+        indexDoc(testIndex, "5", testDoc)
+
+        val response = executeMonitor(monitor.id)
+
+        val output = entityAsMap(response)
+
+        assertEquals(monitor.name, output["monitor_name"])
+        @Suppress("UNCHECKED_CAST")
+        val searchResult = (output.objectMap("input_results")["results"] as List<Map<String, Any>>).first()
+        @Suppress("UNCHECKED_CAST")
+        val matchingDocsToQuery = searchResult[docQuery.id] as List<String>
+        assertEquals("Incorrect search result", 2, matchingDocsToQuery.size)
+        assertTrue("Incorrect search result", matchingDocsToQuery.containsAll(listOf("1|$testIndex", "5|$testIndex")))
+
+        for (triggerResult in output.objectMap("trigger_results").values) {
+            assertEquals(2, triggerResult.objectMap("action_results").values.size)
+            for (alertActionResult in triggerResult.objectMap("action_results").values) {
+                assertEquals(actions.size, alertActionResult.values.size)
+                for (actionResult in alertActionResult.values) {
+                    @Suppress("UNCHECKED_CAST") val actionOutput = (actionResult as Map<String, Map<String, String>>)["output"]
+                        as Map<String, String>
+                    assertEquals("Hello ${monitor.name}", actionOutput["subject"])
+                    assertEquals("Hello ${monitor.name}", actionOutput["message"])
+                }
+            }
+        }
+
+        val alerts = searchAlertsWithFilter(monitor)
+        assertEquals("Alert saved for test monitor", 2, alerts.size)
+
+        // TODO: modify findings such that there is a finding per document, so this test will need to be modified
+        val findings = searchFindings(monitor)
+        assertEquals("Findings saved for test monitor", 2, findings.size)
+        assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("1"))
+        assertTrue("Findings saved for test monitor", findings[1].relatedDocIds.contains("5"))
+    }
+
+    fun `test execute monitor generates alerts and findings with per trigger execution for actions`() {
+        val testIndex = createTestIndex()
+        val testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now().truncatedTo(MILLIS))
+        val testDoc = """{
+            "message" : "This is an error from IAD region",
+            "test_strict_date_time" : "$testTime",
+            "test_field" : "us-west-2"
+        }"""
+
+        val docQuery = DocLevelQuery(query = "test_field:\"us-west-2\"", name = "3")
+        val docLevelInput = DocLevelMonitorInput("description", listOf(testIndex), listOf(docQuery))
+
+        val actionExecutionScope = PerExecutionActionScope()
+        val actionExecutionPolicy = ActionExecutionPolicy(actionExecutionScope)
+        val actions = (0..randomInt(10)).map {
+            randomActionWithPolicy(
+                template = randomTemplateScript("Hello {{ctx.monitor.name}}"),
+                destinationId = createDestination().id,
+                actionExecutionPolicy = actionExecutionPolicy
+            )
+        }
+
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN, actions = actions)
+        val monitor = createMonitor(randomDocumentLevelMonitor(inputs = listOf(docLevelInput), triggers = listOf(trigger)))
+        assertNotNull(monitor.id)
+
+        indexDoc(testIndex, "1", testDoc)
+        indexDoc(testIndex, "5", testDoc)
+
+        val response = executeMonitor(monitor.id)
+
+        val output = entityAsMap(response)
+
+        assertEquals(monitor.name, output["monitor_name"])
+        @Suppress("UNCHECKED_CAST")
+        val searchResult = (output.objectMap("input_results")["results"] as List<Map<String, Any>>).first()
+        @Suppress("UNCHECKED_CAST")
+        val matchingDocsToQuery = searchResult[docQuery.id] as List<String>
+        assertEquals("Incorrect search result", 2, matchingDocsToQuery.size)
+        assertTrue("Incorrect search result", matchingDocsToQuery.containsAll(listOf("1|$testIndex", "5|$testIndex")))
+
+        for (triggerResult in output.objectMap("trigger_results").values) {
+            assertEquals(2, triggerResult.objectMap("action_results").values.size)
+            for (alertActionResult in triggerResult.objectMap("action_results").values) {
+                assertEquals(actions.size, alertActionResult.values.size)
+                for (actionResult in alertActionResult.values) {
+                    @Suppress("UNCHECKED_CAST") val actionOutput = (actionResult as Map<String, Map<String, String>>)["output"]
+                        as Map<String, String>
+                    assertEquals("Hello ${monitor.name}", actionOutput["subject"])
+                    assertEquals("Hello ${monitor.name}", actionOutput["message"])
+                }
+            }
+        }
+
+        val alerts = searchAlertsWithFilter(monitor)
+        assertEquals("Alert saved for test monitor", 2, alerts.size)
+
+        // TODO: modify findings such that there is a finding per document, so this test will need to be modified
+        val findings = searchFindings(monitor)
+        assertEquals("Findings saved for test monitor", 2, findings.size)
+        assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("1"))
+        assertTrue("Findings saved for test monitor", findings[1].relatedDocIds.contains("5"))
+    }
+
+    fun `test execute monitor with wildcard index that generates alerts and findings`() {
+        val testIndex = createTestIndex("test1")
+        val testIndex2 = createTestIndex("test2")
+        val testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now().truncatedTo(MILLIS))
+        val testDoc = """{
+            "message" : "This is an error from IAD region",
+            "test_strict_date_time" : "$testTime",
+            "test_field" : "us-west-2"
+        }"""
+
+        val docQuery = DocLevelQuery(query = "test_field:\"us-west-2\"", name = "3")
+        val docLevelInput = DocLevelMonitorInput("description", listOf("test*"), listOf(docQuery))
+
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val monitor = createMonitor(randomDocumentLevelMonitor(inputs = listOf(docLevelInput), triggers = listOf(trigger)))
+        assertNotNull(monitor.id)
+
+        indexDoc(testIndex, "1", testDoc)
+        indexDoc(testIndex2, "5", testDoc)
+
+        val response = executeMonitor(monitor.id)
+
+        val output = entityAsMap(response)
+
+        assertEquals(monitor.name, output["monitor_name"])
+        @Suppress("UNCHECKED_CAST")
+        val searchResult = (output.objectMap("input_results")["results"] as List<Map<String, Any>>).first()
+        @Suppress("UNCHECKED_CAST")
+        val matchingDocsToQuery = searchResult[docQuery.id] as List<String>
+        assertEquals("Incorrect search result", 2, matchingDocsToQuery.size)
+        assertTrue("Incorrect search result", matchingDocsToQuery.containsAll(listOf("1|$testIndex", "5|$testIndex2")))
+
+        val alerts = searchAlertsWithFilter(monitor)
+        assertEquals("Alert saved for test monitor", 2, alerts.size)
+
+        // TODO: modify findings such that there is a finding per document, so this test will need to be modified
+        val findings = searchFindings(monitor)
+        assertEquals("Findings saved for test monitor", 2, findings.size)
+        assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("1"))
+        assertTrue("Findings saved for test monitor", findings[1].relatedDocIds.contains("5"))
+    }
+
+    fun `test execute monitor with new index added after first execution that generates alerts and findings`() {
+        val testIndex = createTestIndex("test1")
+        val testIndex2 = createTestIndex("test2")
+        val testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now().truncatedTo(MILLIS))
+        val testDoc = """{
+            "message" : "This is an error from IAD region",
+            "test_strict_date_time" : "$testTime",
+            "test_field" : "us-west-2"
+        }"""
+
+        val docQuery = DocLevelQuery(query = "test_field:\"us-west-2\"", name = "3")
+        val docLevelInput = DocLevelMonitorInput("description", listOf("test*"), listOf(docQuery))
+
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val monitor = createMonitor(randomDocumentLevelMonitor(inputs = listOf(docLevelInput), triggers = listOf(trigger)))
+        assertNotNull(monitor.id)
+
+        indexDoc(testIndex, "1", testDoc)
+        indexDoc(testIndex2, "5", testDoc)
+        val testIndex3 = createTestIndex("test3")
+        indexDoc(testIndex3, "10", testDoc)
+
+        val response = executeMonitor(monitor.id)
+
+        val output = entityAsMap(response)
+
+        assertEquals(monitor.name, output["monitor_name"])
+        @Suppress("UNCHECKED_CAST")
+        val searchResult = (output.objectMap("input_results")["results"] as List<Map<String, Any>>).first()
+        @Suppress("UNCHECKED_CAST")
+        val matchingDocsToQuery = searchResult[docQuery.id] as List<String>
+        assertEquals("Incorrect search result", 3, matchingDocsToQuery.size)
+        assertTrue("Incorrect search result", matchingDocsToQuery.containsAll(listOf("1|$testIndex", "5|$testIndex2", "10|$testIndex3")))
+
+        val alerts = searchAlertsWithFilter(monitor)
+        assertEquals("Alert saved for test monitor", 3, alerts.size)
+
+        // TODO: modify findings such that there is a finding per document, so this test will need to be modified
+        val findings = searchFindings(monitor)
+        assertEquals("Findings saved for test monitor", 3, findings.size)
+        assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("1"))
+        assertTrue("Findings saved for test monitor", findings[1].relatedDocIds.contains("5"))
+        assertTrue("Findings saved for test monitor", findings[2].relatedDocIds.contains("10"))
+    }
+
     fun `test document-level monitor when alias only has write index with 0 docs`() {
         // Monitor should execute, but create 0 findings.
         val alias = createTestAlias(includeWriteIndex = true)
         val aliasIndex = alias.keys.first()
         val query = randomDocLevelQuery(tags = listOf())
         val input = randomDocLevelMonitorInput(indices = listOf(aliasIndex), queries = listOf(query))
-        val trigger = randomDocLevelTrigger(condition = Script("params${query.id}"))
+        val trigger = randomDocumentLevelTrigger(condition = Script("query[id=\"${query.id}\"]"))
         val monitor = createMonitor(randomDocumentLevelMonitor(enabled = false, inputs = listOf(input), triggers = listOf(trigger)))
 
         val response: Response
@@ -175,7 +400,7 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
         val indices = alias[aliasIndex]?.keys?.toList() as List<String>
         val query = randomDocLevelQuery(tags = listOf())
         val input = randomDocLevelMonitorInput(indices = listOf(aliasIndex), queries = listOf(query))
-        val trigger = randomDocLevelTrigger(condition = Script("params${query.id}"))
+        val trigger = randomDocumentLevelTrigger(condition = Script("query[id=\"${query.id}\"]"))
 
         val preExistingDocIds = mutableSetOf<String>()
         indices.forEach { index ->
@@ -216,7 +441,7 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
         val indices = alias[aliasIndex]?.keys?.toList() as List<String>
         val query = randomDocLevelQuery(tags = listOf())
         val input = randomDocLevelMonitorInput(indices = listOf(aliasIndex), queries = listOf(query))
-        val trigger = randomDocLevelTrigger(condition = Script("params${query.id}"))
+        val trigger = randomDocumentLevelTrigger(condition = Script("query[id=\"${query.id}\"]"))
 
         val preExistingDocIds = mutableSetOf<String>()
         indices.forEach { index ->
@@ -270,7 +495,7 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
         val indices = alias[aliasIndex]?.keys?.toList() as List<String>
         val query = randomDocLevelQuery(tags = listOf())
         val input = randomDocLevelMonitorInput(indices = listOf(aliasIndex), queries = listOf(query))
-        val trigger = randomDocLevelTrigger(condition = Script("params${query.id}"))
+        val trigger = randomDocumentLevelTrigger(condition = Script("query[id=\"${query.id}\"]"))
 
         val preExistingDocIds = mutableSetOf<String>()
         indices.forEach { index ->

--- a/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
@@ -88,7 +88,7 @@ fun randomQueryLevelMonitor(
     return Monitor(
         name = name, monitorType = Monitor.MonitorType.QUERY_LEVEL_MONITOR, enabled = enabled, inputs = inputs,
         schedule = schedule, triggers = triggers, enabledTime = enabledTime, lastUpdateTime = lastUpdateTime, user = user,
-        lastRunContext = mapOf(), uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf()
+        uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf()
     )
 }
 
@@ -106,7 +106,7 @@ fun randomQueryLevelMonitorWithoutUser(
     return Monitor(
         name = name, monitorType = Monitor.MonitorType.QUERY_LEVEL_MONITOR, enabled = enabled, inputs = inputs,
         schedule = schedule, triggers = triggers, enabledTime = enabledTime, lastUpdateTime = lastUpdateTime, user = null,
-        lastRunContext = mapOf(), uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf()
+        uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf()
     )
 }
 
@@ -130,7 +130,7 @@ fun randomBucketLevelMonitor(
     return Monitor(
         name = name, monitorType = Monitor.MonitorType.BUCKET_LEVEL_MONITOR, enabled = enabled, inputs = inputs,
         schedule = schedule, triggers = triggers, enabledTime = enabledTime, lastUpdateTime = lastUpdateTime, user = user,
-        lastRunContext = mapOf(), uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf()
+        uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf()
     )
 }
 
@@ -148,7 +148,7 @@ fun randomClusterMetricsMonitor(
     return Monitor(
         name = name, monitorType = Monitor.MonitorType.CLUSTER_METRICS_MONITOR, enabled = enabled, inputs = inputs,
         schedule = schedule, triggers = triggers, enabledTime = enabledTime, lastUpdateTime = lastUpdateTime, user = user,
-        lastRunContext = mapOf(), uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf()
+        uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf()
     )
 }
 
@@ -166,7 +166,7 @@ fun randomDocumentLevelMonitor(
     return Monitor(
         name = name, monitorType = Monitor.MonitorType.DOC_LEVEL_MONITOR, enabled = enabled, inputs = inputs,
         schedule = schedule, triggers = triggers, enabledTime = enabledTime, lastUpdateTime = lastUpdateTime, user = user,
-        lastRunContext = mapOf(), uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf()
+        uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf()
     )
 }
 
@@ -241,23 +241,6 @@ fun randomBucketSelectorScript(
     params: Map<String, String> = mutableMapOf("avg" to "10")
 ): Script {
     return Script(Script.DEFAULT_SCRIPT_TYPE, Script.DEFAULT_SCRIPT_LANG, idOrCode, emptyMap<String, String>(), params)
-}
-
-fun randomDocLevelTrigger(
-    id: String = UUIDs.base64UUID(),
-    name: String = OpenSearchRestTestCase.randomAlphaOfLength(10),
-    severity: String = "1",
-    condition: Script = randomScript(),
-    actions: List<Action> = mutableListOf(),
-    destinationId: String = ""
-): DocumentLevelTrigger {
-    return DocumentLevelTrigger(
-        id = id,
-        name = name,
-        severity = severity,
-        condition = condition,
-        actions = if (actions.isEmpty()) (0..randomInt(10)).map { randomAction(destinationId = destinationId) } else actions
-    )
 }
 
 fun randomEmailAccount(
@@ -527,7 +510,12 @@ fun randomDocumentLevelTriggerRunResult(): DocumentLevelTriggerRunResult {
     val map = mutableMapOf<String, ActionRunResult>()
     map.plus(Pair("key1", randomActionRunResult()))
     map.plus(Pair("key2", randomActionRunResult()))
-    return DocumentLevelTriggerRunResult("trigger-name", mutableListOf(UUIDs.randomBase64UUID().toString()), null, map)
+    return DocumentLevelTriggerRunResult(
+        "trigger-name",
+        mutableListOf(UUIDs.randomBase64UUID().toString()),
+        null,
+        mutableMapOf(Pair("alertId", map))
+    )
 }
 
 fun randomActionRunResult(): ActionRunResult {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/action/GetMonitorResponseTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/action/GetMonitorResponseTests.kt
@@ -49,7 +49,6 @@ class GetMonitorResponseTests : OpenSearchTestCase() {
             schemaVersion = 0,
             inputs = mutableListOf(),
             triggers = mutableListOf(),
-            lastRunContext = mutableMapOf(),
             uiMetadata = mutableMapOf()
         )
         val req = GetMonitorResponse("1234", 1L, 2L, 0L, RestStatus.OK, monitor)

--- a/alerting/src/test/kotlin/org/opensearch/alerting/action/IndexMonitorResponseTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/action/IndexMonitorResponseTests.kt
@@ -35,7 +35,6 @@ class IndexMonitorResponseTests : OpenSearchTestCase() {
             schemaVersion = 0,
             inputs = mutableListOf(),
             triggers = mutableListOf(),
-            lastRunContext = mutableMapOf(),
             uiMetadata = mutableMapOf()
         )
         val req = IndexMonitorResponse("1234", 1L, 2L, 0L, RestStatus.OK, monitor)

--- a/alerting/src/test/kotlin/org/opensearch/alerting/model/DocLevelMonitorInputTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/model/DocLevelMonitorInputTests.kt
@@ -14,9 +14,10 @@ import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.test.OpenSearchTestCase
+import java.lang.IllegalArgumentException
 
 class DocLevelMonitorInputTests : OpenSearchTestCase() {
-    fun `testing DocLevelQuery asTemplateArgs`() {
+    fun `test DocLevelQuery asTemplateArgs`() {
         // GIVEN
         val query = randomDocLevelQuery()
 
@@ -30,7 +31,34 @@ class DocLevelMonitorInputTests : OpenSearchTestCase() {
         assertEquals("Template args 'tags' field does not match:", templateArgs[DocLevelQuery.TAGS_FIELD], query.tags)
     }
 
-    fun `testing DocLevelMonitorInput asTemplateArgs`() {
+    fun `test create Doc Level Query with invalid characters for name`() {
+        val badString = "query with space"
+        try {
+            randomDocLevelQuery(name = badString)
+            fail("Expecting an illegal argument exception")
+        } catch (e: IllegalArgumentException) {
+            assertEquals(
+                "They query name or tag, $badString, contains an invalid character: [' ','[',']','{','}','(',')']",
+                e.message
+            )
+        }
+    }
+
+    @Throws(IllegalArgumentException::class)
+    fun `test create Doc Level Query with invalid characters for tags`() {
+        val badString = "[(){}]"
+        try {
+            randomDocLevelQuery(tags = listOf(badString))
+            fail("Expecting an illegal argument exception")
+        } catch (e: IllegalArgumentException) {
+            assertEquals(
+                "They query name or tag, $badString, contains an invalid character: [' ','[',']','{','}','(',')']",
+                e.message
+            )
+        }
+    }
+
+    fun `test DocLevelMonitorInput asTemplateArgs`() {
         // GIVEN
         val input = randomDocLevelMonitorInput()
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/model/WriteableTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/model/WriteableTests.kt
@@ -17,8 +17,8 @@ import org.opensearch.alerting.randomActionRunResult
 import org.opensearch.alerting.randomBucketLevelMonitorRunResult
 import org.opensearch.alerting.randomBucketLevelTrigger
 import org.opensearch.alerting.randomBucketLevelTriggerRunResult
-import org.opensearch.alerting.randomDocLevelTrigger
 import org.opensearch.alerting.randomDocumentLevelMonitorRunResult
+import org.opensearch.alerting.randomDocumentLevelTrigger
 import org.opensearch.alerting.randomDocumentLevelTriggerRunResult
 import org.opensearch.alerting.randomEmailAccount
 import org.opensearch.alerting.randomEmailGroup
@@ -111,7 +111,7 @@ class WriteableTests : OpenSearchTestCase() {
     }
 
     fun `test doc-level trigger as stream`() {
-        val trigger = randomDocLevelTrigger()
+        val trigger = randomDocumentLevelTrigger()
         val out = BytesStreamOutput()
         trigger.writeTo(out)
         val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)

--- a/alerting/src/test/kotlin/org/opensearch/alerting/model/XContentTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/model/XContentTests.kt
@@ -33,6 +33,7 @@ import org.opensearch.alerting.randomUserEmpty
 import org.opensearch.alerting.toJsonString
 import org.opensearch.alerting.toJsonStringWithUser
 import org.opensearch.common.xcontent.ToXContent
+import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.commons.authuser.User
 import org.opensearch.index.query.QueryBuilders
 import org.opensearch.search.builder.SearchSourceBuilder
@@ -379,5 +380,12 @@ class XContentTests : OpenSearchTestCase() {
         val actionExecutionPolicyString = actionExecutionPolicy.toXContent(builder(), ToXContent.EMPTY_PARAMS).string()
         val parsedActionExecutionPolicy = ActionExecutionPolicy.parse(parser(actionExecutionPolicyString))
         assertEquals("Round tripping ActionExecutionPolicy doesn't work", actionExecutionPolicy, parsedActionExecutionPolicy)
+    }
+
+    fun `test MonitorMetadata`() {
+        val monitorMetadata = MonitorMetadata("monitorId-metadata", "monitorId", emptyList(), emptyMap())
+        val monitorMetadataString = monitorMetadata.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS).string()
+        val parsedMonitorMetadata = MonitorMetadata.parse(parser(monitorMetadataString))
+        assertEquals("Round tripping MonitorMetadata doesn't work", monitorMetadata, parsedMonitorMetadata)
     }
 }

--- a/core/src/main/resources/mappings/scheduled-jobs.json
+++ b/core/src/main/resources/mappings/scheduled-jobs.json
@@ -244,10 +244,6 @@
             }
           }
         },
-        "last_run_context": {
-          "type": "object",
-          "enabled": false
-        },
         "ui_metadata": {
           "type": "object",
           "enabled": false
@@ -444,6 +440,29 @@
               "type": "text"
             }
           }
+        }
+      }
+    },
+    "metadata" : {
+      "properties": {
+        "monitor_id": {
+          "type": "keyword"
+        },
+        "last_action_execution_times": {
+          "type": "nested",
+          "properties": {
+            "action_id": {
+              "type": "keyword"
+            },
+            "execution_time": {
+              "type": "date",
+              "format": "strict_date_time||epoch_millis"
+            }
+          }
+        },
+        "last_run_context": {
+          "type": "object",
+          "enabled": false
         }
       }
     }


### PR DESCRIPTION
Fix minor bugs and support per alert action execution for Document Level Monitors (#441)

* Fix minor bugs as well as support per alert action execution for DocLevelMonitors

Signed-off-by: Ashish Agrawal <ashisagr@amazon.com>

*Issue #, if available:*
N/A
*Description of changes:*
- backport #441
- 
*CheckList:*
[X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).