### PR TITLE
Fix minor bugs and pass in user context when retrieving user's notification channels

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/BucketLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/BucketLevelMonitorRunner.kt
@@ -5,7 +5,6 @@
 
 package org.opensearch.alerting
 
-import kotlinx.coroutines.runBlocking
 import org.apache.logging.log4j.LogManager
 import org.opensearch.alerting.model.ActionRunResult
 import org.opensearch.alerting.model.Alert
@@ -18,6 +17,7 @@ import org.opensearch.alerting.model.action.AlertCategory
 import org.opensearch.alerting.model.action.PerAlertActionScope
 import org.opensearch.alerting.model.action.PerExecutionActionScope
 import org.opensearch.alerting.opensearchapi.InjectorContextElement
+import org.opensearch.alerting.opensearchapi.withClosableContext
 import org.opensearch.alerting.script.BucketLevelTriggerExecutionContext
 import org.opensearch.alerting.util.defaultToPerExecutionAction
 import org.opensearch.alerting.util.getActionExecutionPolicy
@@ -80,7 +80,7 @@ object BucketLevelMonitorRunner : MonitorRunner() {
             //  If a setting is imposed that limits buckets that can be processed for Bucket-Level Monitors, we'd need to iterate over
             //  the buckets until we hit that threshold. In that case, we'd want to exit the execution without creating any alerts since the
             //  buckets we iterate over before hitting the limit is not deterministic. Is there a better way to fail faster in this case?
-            runBlocking(InjectorContextElement(monitor.id, monitorCtx.settings!!, monitorCtx.threadPool!!.threadContext, roles)) {
+            withClosableContext(InjectorContextElement(monitor.id, monitorCtx.settings!!, monitorCtx.threadPool!!.threadContext, roles)) {
                 // Storing the first page of results in the case of pagination input results to prevent empty results
                 // in the final output of monitorResult which occurs when all pages have been exhausted.
                 // If it's favorable to return the last page, will need to check how to accomplish that with multiple aggregation paths

--- a/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
@@ -164,9 +164,10 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
                     matchedQueriesForDocs.forEach { hit ->
                         val (id, query) = Pair(
                             hit.id.replace("_${indexName}_${monitor.id}", ""),
-                            ((hit.sourceAsMap["query"] as HashMap<*, *>)["query_string"] as HashMap<*, *>)["query"]
+                            ((hit.sourceAsMap["query"] as HashMap<*, *>)["query_string"] as HashMap<*, *>)["query"].toString()
+                                .replace("_${indexName}_${monitor.id}", "")
                         )
-                        val docLevelQuery = DocLevelQuery(id, id, query.toString())
+                        val docLevelQuery = DocLevelQuery(id, id, query.toString().replace("_${indexName}_${monitor.id}", ""))
 
                         val docIndices = hit.field("_percolator_document_slot").values.map { it.toString().toInt() }
                         docIndices.forEach { idx ->
@@ -271,7 +272,7 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
                     triggerResult.actionResultsMap.getOrPut(alert.id) { mutableMapOf() }
                     triggerResult.actionResultsMap[alert.id]?.set(action.id, actionResults)
                 }
-            } else {
+            } else if (alerts.isNotEmpty()) {
                 val actionResults = this.runAction(action, actionCtx, monitorCtx, dryrun)
                 for (alert in alerts) {
                     triggerResult.actionResultsMap.getOrPut(alert.id) { mutableMapOf() }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
@@ -167,7 +167,7 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
                             ((hit.sourceAsMap["query"] as HashMap<*, *>)["query_string"] as HashMap<*, *>)["query"].toString()
                                 .replace("_${indexName}_${monitor.id}", "")
                         )
-                        val docLevelQuery = DocLevelQuery(id, id, query.toString().replace("_${indexName}_${monitor.id}", ""))
+                        val docLevelQuery = DocLevelQuery(id, id, query)
 
                         val docIndices = hit.field("_percolator_document_slot").values.map { it.toString().toInt() }
                         docIndices.forEach { idx ->
@@ -268,12 +268,12 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
             val actionExecutionScope = action.getActionExecutionPolicy(monitor)!!.actionExecutionScope
             if (actionExecutionScope is PerAlertActionScope && !shouldDefaultToPerExecution) {
                 for (alert in alerts) {
-                    val actionResults = this.runAction(action, actionCtx.copy(alert = alert), monitorCtx, dryrun)
+                    val actionResults = this.runAction(action, actionCtx.copy(alerts = listOf(alert)), monitorCtx, dryrun)
                     triggerResult.actionResultsMap.getOrPut(alert.id) { mutableMapOf() }
                     triggerResult.actionResultsMap[alert.id]?.set(action.id, actionResults)
                 }
             } else if (alerts.isNotEmpty()) {
-                val actionResults = this.runAction(action, actionCtx, monitorCtx, dryrun)
+                val actionResults = this.runAction(action, actionCtx.copy(alerts = alerts), monitorCtx, dryrun)
                 for (alert in alerts) {
                     triggerResult.actionResultsMap.getOrPut(alert.id) { mutableMapOf() }
                     triggerResult.actionResultsMap[alert.id]?.set(action.id, actionResults)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
@@ -68,6 +68,7 @@ abstract class MonitorRunner {
                         ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT,
                         userStr
                     )
+                    // TODO: investigate if "withContext" can be replaced with "withClosableContext" and not have side effects
                     withContext(Dispatchers.IO) {
                         actionOutput[Action.MESSAGE_ID] = getConfigAndSendNotification(
                             action,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/QueryLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/QueryLevelMonitorRunner.kt
@@ -5,7 +5,6 @@
 
 package org.opensearch.alerting
 
-import kotlinx.coroutines.runBlocking
 import org.apache.logging.log4j.LogManager
 import org.opensearch.alerting.model.Alert
 import org.opensearch.alerting.model.Monitor
@@ -13,6 +12,7 @@ import org.opensearch.alerting.model.MonitorRunResult
 import org.opensearch.alerting.model.QueryLevelTrigger
 import org.opensearch.alerting.model.QueryLevelTriggerRunResult
 import org.opensearch.alerting.opensearchapi.InjectorContextElement
+import org.opensearch.alerting.opensearchapi.withClosableContext
 import org.opensearch.alerting.script.QueryLevelTriggerExecutionContext
 import org.opensearch.alerting.util.isADMonitor
 import java.time.Instant
@@ -46,7 +46,7 @@ object QueryLevelMonitorRunner : MonitorRunner() {
             return monitorResult.copy(error = e)
         }
         if (!isADMonitor(monitor)) {
-            runBlocking(InjectorContextElement(monitor.id, monitorCtx.settings!!, monitorCtx.threadPool!!.threadContext, roles)) {
+            withClosableContext(InjectorContextElement(monitor.id, monitorCtx.settings!!, monitorCtx.threadPool!!.threadContext, roles)) {
                 monitorResult = monitorResult.copy(
                     inputResults = monitorCtx.inputService!!.collectInputResults(monitor, periodStart, periodEnd)
                 )

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/Alert.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/Alert.kt
@@ -370,7 +370,9 @@ data class Alert(
             STATE_FIELD to state.toString(),
             // Converting bucket keys to comma separated String to avoid manipulation in Action mustache templates
             BUCKET_KEYS to aggregationResultBucket?.bucketKeys?.joinToString(","),
-            PARENTS_BUCKET_PATH to aggregationResultBucket?.parentBucketPath
+            PARENTS_BUCKET_PATH to aggregationResultBucket?.parentBucketPath,
+            FINDING_IDS to findingIds.joinToString(","),
+            RELATED_DOC_IDS to relatedDocIds.joinToString(",")
         )
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/DocumentLevelTrigger.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/DocumentLevelTrigger.kt
@@ -68,7 +68,9 @@ data class DocumentLevelTrigger(
     /** Returns a representation of the trigger suitable for passing into painless and mustache scripts. */
     fun asTemplateArg(): Map<String, Any> {
         return mapOf(
-            ID_FIELD to id, NAME_FIELD to name, SEVERITY_FIELD to severity,
+            ID_FIELD to id,
+            NAME_FIELD to name,
+            SEVERITY_FIELD to severity,
             ACTIONS_FIELD to actions.map { it.asTemplateArg() }
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/script/DocumentLevelTriggerExecutionContext.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/script/DocumentLevelTriggerExecutionContext.kt
@@ -16,7 +16,7 @@ data class DocumentLevelTriggerExecutionContext(
     override val results: List<Map<String, Any>>,
     override val periodStart: Instant,
     override val periodEnd: Instant,
-    val alert: Alert? = null,
+    val alerts: List<Alert> = listOf(),
     val triggeredDocs: List<String>,
     val relatedFindings: List<String>,
     override val error: Exception? = null
@@ -25,10 +25,10 @@ data class DocumentLevelTriggerExecutionContext(
     constructor(
         monitor: Monitor,
         trigger: DocumentLevelTrigger,
-        alert: Alert? = null
+        alerts: List<Alert> = listOf()
     ) : this(
         monitor, trigger, emptyList(), Instant.now(), Instant.now(),
-        alert, emptyList(), emptyList(), null
+        alerts, emptyList(), emptyList(), null
     )
 
     /**
@@ -38,7 +38,7 @@ data class DocumentLevelTriggerExecutionContext(
     override fun asTemplateArg(): Map<String, Any?> {
         val tempArg = super.asTemplateArg().toMutableMap()
         tempArg["trigger"] = trigger.asTemplateArg()
-        tempArg["alert"] = alert?.asTemplateArg()
+        tempArg["alerts"] = alerts.map { it.asTemplateArg() }
         return tempArg
     }
 }

--- a/alerting/src/main/resources/org/opensearch/alerting/org.opensearch.alerting.txt
+++ b/alerting/src/main/resources/org/opensearch/alerting/org.opensearch.alerting.txt
@@ -31,16 +31,6 @@ class org.opensearch.alerting.script.QueryLevelTriggerExecutionContext {
     Exception getError()
 }
 
-class org.opensearch.alerting.script.DocumentLevelTriggerExecutionContext {
-    Monitor getMonitor()
-    DocumentLevelTrigger getTrigger()
-    List getResults()
-    java.time.Instant getPeriodStart()
-    java.time.Instant getPeriodEnd()
-    Alert getAlert()
-    Exception getError()
-}
-
 class org.opensearch.alerting.model.Monitor {
     String getId()
     long getVersion()
@@ -49,13 +39,6 @@ class org.opensearch.alerting.model.Monitor {
 }
 
 class org.opensearch.alerting.model.QueryLevelTrigger {
-    String getId()
-    String getName()
-    String getSeverity()
-    List getActions()
-}
-
-class org.opensearch.alerting.model.DocumentLevelTrigger {
     String getId()
     String getName()
     String getSeverity()

--- a/alerting/src/test/kotlin/org/opensearch/alerting/DocumentMonitorRunnerIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/DocumentMonitorRunnerIT.kt
@@ -5,6 +5,8 @@
 
 package org.opensearch.alerting
 
+import org.opensearch.alerting.alerts.AlertIndices.Companion.ALL_ALERT_INDEX_PATTERN
+import org.opensearch.alerting.alerts.AlertIndices.Companion.ALL_FINDING_INDEX_PATTERN
 import org.opensearch.alerting.core.model.DocLevelMonitorInput
 import org.opensearch.alerting.core.model.DocLevelQuery
 import org.opensearch.alerting.model.action.ActionExecutionPolicy
@@ -329,8 +331,16 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
 
         indexDoc(testIndex, "1", testDoc)
         indexDoc(testIndex2, "5", testDoc)
+        executeMonitor(monitor.id)
+
+        // clear previous findings and alerts
+        deleteIndex(ALL_FINDING_INDEX_PATTERN)
+        deleteIndex(ALL_ALERT_INDEX_PATTERN)
+
         val testIndex3 = createTestIndex("test3")
         indexDoc(testIndex3, "10", testDoc)
+        indexDoc(testIndex, "14", testDoc)
+        indexDoc(testIndex2, "51", testDoc)
 
         val response = executeMonitor(monitor.id)
 
@@ -342,7 +352,7 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
         @Suppress("UNCHECKED_CAST")
         val matchingDocsToQuery = searchResult[docQuery.id] as List<String>
         assertEquals("Incorrect search result", 3, matchingDocsToQuery.size)
-        assertTrue("Incorrect search result", matchingDocsToQuery.containsAll(listOf("1|$testIndex", "5|$testIndex2", "10|$testIndex3")))
+        assertTrue("Incorrect search result", matchingDocsToQuery.containsAll(listOf("14|$testIndex", "51|$testIndex2", "10|$testIndex3")))
 
         val alerts = searchAlertsWithFilter(monitor)
         assertEquals("Alert saved for test monitor", 3, alerts.size)
@@ -350,9 +360,19 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
         // TODO: modify findings such that there is a finding per document, so this test will need to be modified
         val findings = searchFindings(monitor)
         assertEquals("Findings saved for test monitor", 3, findings.size)
-        assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("1"))
-        assertTrue("Findings saved for test monitor", findings[1].relatedDocIds.contains("5"))
-        assertTrue("Findings saved for test monitor", findings[2].relatedDocIds.contains("10"))
+        assertTrue(
+            "Findings saved for test monitor expected 14 instead of ${findings[0].relatedDocIds}",
+            findings[0].relatedDocIds.contains("14")
+        )
+        assertTrue(
+            "Findings saved for test monitor expected 51 instead of ${findings[1].relatedDocIds}",
+            findings[1].relatedDocIds.contains("51")
+        )
+        assertTrue(
+            "Findings saved for test monitor expected 10 instead of ${findings[2].relatedDocIds}",
+            findings[2].relatedDocIds.contains("10")
+        )
+        assertEquals("Findings saved for test monitor", 3, findings.size)
     }
 
     fun `test document-level monitor when alias only has write index with 0 docs`() {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/DocumentMonitorRunnerIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/DocumentMonitorRunnerIT.kt
@@ -132,7 +132,6 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
         val alerts = searchAlertsWithFilter(monitor)
         assertEquals("Alert saved for test monitor", 2, alerts.size)
 
-        // TODO: modify findings such that there is a finding per document, so this test will need to be modified
         val findings = searchFindings(monitor)
         assertEquals("Findings saved for test monitor", 2, findings.size)
         assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("1"))
@@ -199,7 +198,6 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
         val alerts = searchAlertsWithFilter(monitor)
         assertEquals("Alert saved for test monitor", 2, alerts.size)
 
-        // TODO: modify findings such that there is a finding per document, so this test will need to be modified
         val findings = searchFindings(monitor)
         assertEquals("Findings saved for test monitor", 2, findings.size)
         assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("1"))
@@ -263,7 +261,6 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
         val alerts = searchAlertsWithFilter(monitor)
         assertEquals("Alert saved for test monitor", 2, alerts.size)
 
-        // TODO: modify findings such that there is a finding per document, so this test will need to be modified
         val findings = searchFindings(monitor)
         assertEquals("Findings saved for test monitor", 2, findings.size)
         assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("1"))
@@ -305,7 +302,6 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
         val alerts = searchAlertsWithFilter(monitor)
         assertEquals("Alert saved for test monitor", 2, alerts.size)
 
-        // TODO: modify findings such that there is a finding per document, so this test will need to be modified
         val findings = searchFindings(monitor)
         assertEquals("Findings saved for test monitor", 2, findings.size)
         assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("1"))
@@ -333,6 +329,20 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
         indexDoc(testIndex2, "5", testDoc)
         executeMonitor(monitor.id)
 
+        var alerts = searchAlertsWithFilter(monitor)
+        assertEquals("Alert saved for test monitor", 2, alerts.size)
+
+        var findings = searchFindings(monitor)
+        assertEquals("Findings saved for test monitor", 2, findings.size)
+        assertTrue(
+            "Findings saved for test monitor expected 1 instead of ${findings[0].relatedDocIds}",
+            findings[0].relatedDocIds.contains("1")
+        )
+        assertTrue(
+            "Findings saved for test monitor expected 51 instead of ${findings[1].relatedDocIds}",
+            findings[1].relatedDocIds.contains("5")
+        )
+
         // clear previous findings and alerts
         deleteIndex(ALL_FINDING_INDEX_PATTERN)
         deleteIndex(ALL_ALERT_INDEX_PATTERN)
@@ -354,11 +364,10 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
         assertEquals("Incorrect search result", 3, matchingDocsToQuery.size)
         assertTrue("Incorrect search result", matchingDocsToQuery.containsAll(listOf("14|$testIndex", "51|$testIndex2", "10|$testIndex3")))
 
-        val alerts = searchAlertsWithFilter(monitor)
+        alerts = searchAlertsWithFilter(monitor)
         assertEquals("Alert saved for test monitor", 3, alerts.size)
 
-        // TODO: modify findings such that there is a finding per document, so this test will need to be modified
-        val findings = searchFindings(monitor)
+        findings = searchFindings(monitor)
         assertEquals("Findings saved for test monitor", 3, findings.size)
         assertTrue(
             "Findings saved for test monitor expected 14 instead of ${findings[0].relatedDocIds}",
@@ -372,7 +381,6 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
             "Findings saved for test monitor expected 10 instead of ${findings[2].relatedDocIds}",
             findings[2].relatedDocIds.contains("10")
         )
-        assertEquals("Findings saved for test monitor", 3, findings.size)
     }
 
     fun `test document-level monitor when alias only has write index with 0 docs`() {

--- a/core/src/main/kotlin/org/opensearch/alerting/core/model/DocLevelQuery.kt
+++ b/core/src/main/kotlin/org/opensearch/alerting/core/model/DocLevelQuery.kt
@@ -16,9 +16,10 @@ import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 import java.io.IOException
 import java.lang.IllegalArgumentException
+import java.util.UUID
 
 data class DocLevelQuery(
-    val id: String = NO_ID,
+    val id: String = UUID.randomUUID().toString(),
     val name: String,
     val query: String,
     val tags: List<String> = mutableListOf()
@@ -77,7 +78,7 @@ data class DocLevelQuery(
 
         @JvmStatic @Throws(IOException::class)
         fun parse(xcp: XContentParser): DocLevelQuery {
-            var id: String = NO_ID
+            var id: String = UUID.randomUUID().toString()
             lateinit var query: String
             lateinit var name: String
             val tags: MutableList<String> = mutableListOf()


### PR DESCRIPTION
Signed-off-by: Ashish Agrawal <ashisagr@amazon.com>

*Issue #, if available:*
N/A
*Description of changes:*
- Fix Minor bugs
  - Pass in user context when retrieving user's notification channels
  - Fix action execution for DocLevel monitors where actions are to run per trigger execution
  - Fix bug that did not generate all the alerts for monitors with multiple indices in Document Level Monitors
  - Add Findings ID and document ID to action template
*CheckList:*
[X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).