### PR TITLE
Improve error messaging on exceptions from notification channel retrieval and fix bug

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/AlertingConfigAccessor.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/AlertingConfigAccessor.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.withContext
 import org.opensearch.action.get.GetRequest
 import org.opensearch.action.get.GetResponse
 import org.opensearch.alerting.core.model.ScheduledJob
-import org.opensearch.alerting.model.destination.Destination
 import org.opensearch.alerting.model.destination.email.EmailAccount
 import org.opensearch.alerting.model.destination.email.EmailGroup
 import org.opensearch.alerting.opensearchapi.suspendUntil
@@ -29,18 +28,6 @@ import org.opensearch.index.IndexNotFoundException
  */
 class AlertingConfigAccessor {
     companion object {
-
-        suspend fun getMonitorInfo(client: Client, xContentRegistry: NamedXContentRegistry, monitorId: String): Monitor {
-            val jobSource = getAlertingConfigDocumentSource(client, "Monitor", monitorId)
-            return withContext(Dispatchers.IO) {
-                val xcp = XContentHelper.createParser(
-                    xContentRegistry, LoggingDeprecationHandler.INSTANCE,
-                    jobSource, XContentType.JSON
-                )
-                val monitor = Monitor.parse(xcp)
-                monitor
-            }
-        }
 
         suspend fun getMonitorMetadata(client: Client, xContentRegistry: NamedXContentRegistry, metadataId: String): MonitorMetadata? {
             return try {
@@ -61,18 +48,6 @@ class AlertingConfigAccessor {
                 if (e.message?.equals("no such index [.opendistro-alerting-config]") == true) {
                     return null
                 } else throw e
-            }
-        }
-
-        suspend fun getDestinationInfo(client: Client, xContentRegistry: NamedXContentRegistry, destinationId: String): Destination {
-            val jobSource = getAlertingConfigDocumentSource(client, "Destination", destinationId)
-            return withContext(Dispatchers.IO) {
-                val xcp = XContentHelper.createParser(
-                    xContentRegistry, LoggingDeprecationHandler.INSTANCE,
-                    jobSource, XContentType.JSON
-                )
-                val destination = Destination.parseWithType(xcp)
-                destination
             }
         }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
@@ -23,7 +23,6 @@ import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.settings.DestinationSettings
 import org.opensearch.client.Client
 import org.opensearch.common.settings.Settings
-import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentFactory
 
@@ -123,26 +122,6 @@ fun defaultToPerExecutionAction(
     }
 
     return false
-}
-
-// TODO: Check if this can be more generic such that TransportIndexMonitorAction class can use this. Also see if this should be refactored
-// to another class. Include tests for this as well.
-suspend fun updateMonitor(client: Client, xContentRegistry: NamedXContentRegistry, settings: Settings, monitor: Monitor): IndexResponse {
-    /*val currentMonitor = AlertingConfigAccessor.getMonitorInfo(client, xContentRegistry, monitor.id)
-
-    var updateMonitor = monitor
-    // If both are enabled, use the current existing monitor enabled time, otherwise the next execution will be
-    // incorrect.
-    if (monitor.enabled && currentMonitor.enabled)
-        updateMonitor = monitor.copy(enabledTime = currentMonitor.enabledTime)*/
-
-    val indexRequest = IndexRequest(ScheduledJob.SCHEDULED_JOBS_INDEX)
-        .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-        .source(monitor.toXContentWithUser(XContentFactory.jsonBuilder(), ToXContent.MapParams(mapOf("with_type" to "true"))))
-        .id(monitor.id)
-        .timeout(AlertingSettings.INDEX_TIMEOUT.get(settings))
-
-    return client.suspendUntil { client.index(indexRequest, it) }
 }
 
 suspend fun updateMonitorMetadata(client: Client, settings: Settings, monitorMetadata: MonitorMetadata): IndexResponse {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/NotificationApiUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/NotificationApiUtils.kt
@@ -6,6 +6,7 @@
 package org.opensearch.alerting.util.destinationmigration
 
 import org.apache.logging.log4j.LogManager
+import org.opensearch.OpenSearchSecurityException
 import org.opensearch.OpenSearchStatusException
 import org.opensearch.action.bulk.BackoffPolicy
 import org.opensearch.alerting.model.destination.Destination
@@ -48,6 +49,8 @@ class NotificationApiUtils {
             return try {
                 val res: GetNotificationConfigResponse = getNotificationConfig(client, GetNotificationConfigRequest(setOf(id)))
                 res.searchResult.objectList.firstOrNull()
+            } catch (e: OpenSearchSecurityException) {
+                throw e
             } catch (e: OpenSearchStatusException) {
                 if (e.status() == RestStatus.NOT_FOUND) {
                     logger.debug("Notification config [$id] was not found")


### PR DESCRIPTION
Signed-off-by: Ashish Agrawal <ashisagr@amazon.com>

*Issue #, if available:*
N/A
*Description of changes:*
  - Improve error messaging on exceptions from notification channel retrieval
  - Use GetDestinations Transport action instead of directly accessing alerting config index for legacy destinations
 
*CheckList:*
[X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).