### PR TITLE
Implemented unit test that matches execution time across different time zones.

### DIFF
--- a/core/src/test/kotlin/org/opensearch/alerting/core/model/ScheduleTest.kt
+++ b/core/src/test/kotlin/org/opensearch/alerting/core/model/ScheduleTest.kt
@@ -301,6 +301,16 @@ class ScheduleTest : XContentTestBase {
         assertTrue(intervalSchedule.runningOnTime(null))
     }
 
+    @Test
+    fun `execution time matches across different time zones`() {
+        val pdtClockCronSchedule = CronSchedule("* * * * *", ZoneId.systemDefault())
+        val utcClockCronSchedule = CronSchedule("* * * * *", ZoneId.systemDefault())
+        val instant = Instant.ofEpochSecond(1539615226L)
+        val pdtNextExecution = pdtClockCronSchedule.getExpectedNextExecutionTime(instant.atZone(ZoneId.of("America/Los_Angeles")).toInstant(), null)
+        val utcNextExecution = utcClockCronSchedule.getExpectedNextExecutionTime(instant.atZone(ZoneId.of("UTC")).toInstant(), null)
+        assertEquals(pdtNextExecution, utcNextExecution)
+    }
+
     private fun createTestIntervalSchedule(): IntervalSchedule {
         val testInstance = Instant.ofEpochSecond(1539715678L)
         val enabledTime = Instant.ofEpochSecond(1539615146L)


### PR DESCRIPTION
Signed-off-by: AWSHurneyt <hurneyt@amazon.com>

*Issue #, if available:*
Implemented unit test that matches execution time across different time zones.

*Description of changes:*

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).