### PR TITLE
Add support for reproducible builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,10 @@ allprojects {
         compileKotlin.kotlinOptions.jvmTarget = compileTestKotlin.kotlinOptions.jvmTarget = JavaVersion.VERSION_11
         compileKotlin.dependsOn ktlint
     }
+    tasks.withType(AbstractArchiveTask).configureEach {
+        preserveFileTimestamps = false
+        reproducibleFileOrder = true
+    }
 }
 
 evaluationDependsOnChildren()


### PR DESCRIPTION
*Issue #, if available:*

*Add support for reproducible builds*
As per gradle [docs] add support to remove timestamps and package with same order which is required from
[reproducible] builds

[docs]: https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives
[reproducible]: https://reproducible-builds.org/

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).