### PR TITLE
Support multiple input indices for document level monitors

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
@@ -363,11 +363,6 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
         if (monitor.inputs[0].name() != DocLevelMonitorInput.DOC_LEVEL_INPUT_FIELD) {
             throw IOException("Invalid input with document-level-monitor.")
         }
-
-        val docLevelMonitorInput = monitor.inputs[0] as DocLevelMonitorInput
-        if (docLevelMonitorInput.indices.size > 1) {
-            throw IOException("Only one index is supported with document-level-monitor.")
-        }
     }
 
     suspend fun createRunContext(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
@@ -115,15 +115,13 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
 
         try {
             val indexCreationTimeMap = mutableMapOf<String, Long>()
-            for (index in inputIndices) {
-                val getIndexRequest = GetIndexRequest().indices(index)
-                val getIndexResponse: GetIndexResponse = monitorCtx.client!!.suspendUntil {
-                    monitorCtx.client!!.admin().indices().getIndex(getIndexRequest, it)
-                }
-                val indices = getIndexResponse.indices()
-                indices.forEach { index ->
-                    indexCreationTimeMap[index] = getIndexResponse.settings.get(index).getAsLong("index.creation_date", 0L)
-                }
+            val getIndexRequest = GetIndexRequest().indices(*inputIndices.toTypedArray())
+            val getIndexResponse: GetIndexResponse = monitorCtx.client!!.suspendUntil {
+                monitorCtx.client!!.admin().indices().getIndex(getIndexRequest, it)
+            }
+            val indices = getIndexResponse.indices()
+            indices.forEach { index ->
+                indexCreationTimeMap[index] = getIndexResponse.settings.get(index).getAsLong("index.creation_date", 0L)
             }
 
             // cleanup old indices that are not monitored anymore from the same monitor

--- a/alerting/src/test/kotlin/org/opensearch/alerting/DocumentMonitorRunnerIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/DocumentMonitorRunnerIT.kt
@@ -579,7 +579,7 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
         }
     }
 
-    fun `test document-level monitor with multiple input indices `() {
+    fun `test document-level monitor with multiple input indices`() {
 
         val testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now().truncatedTo(MILLIS))
         val testDoc = """{
@@ -600,8 +600,8 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
             triggers = listOf(randomDocumentLevelTrigger(condition = ALWAYS_RUN, actions = listOf(action)))
         )
 
-        indexDoc(testIndex1, "11", testDoc)
-        indexDoc(testIndex2, "17", testDoc)
+        indexDoc(testIndex1, "1", testDoc)
+        indexDoc(testIndex2, "5", testDoc)
 
         val response = executeMonitor(monitor, params = DRYRUN_MONITOR)
 


### PR DESCRIPTION
Signed-off-by: Angie Zhang <langelzh@amazon.com>

*Issue #, if available:* #474

*Description of changes:* Support multiple indices as input for Document level monitors

*CheckList:*
[ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).