### PR TITLE
Bumping 2.x branch version from 2.1.0 to 2.2.0.

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     implementation "com.github.seancfoley:ipaddress:5.3.3"
 
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
-    testImplementation "org.mockito:mockito-core:4.3.1"
+    testImplementation "org.mockito:mockito-core:4.6.1"
 }
 
 javadoc.enabled = false // turn off javadoc as it barfs on Kotlin code
@@ -257,7 +257,7 @@ String bwcRemoteFile = 'https://ci.opensearch.org/ci/dbc/bundle-build/1.1.0/2021
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-            versions = ["1.1.0", "2.1.0-SNAPSHOT"]
+            versions = ["1.1.0", "2.2.0-SNAPSHOT"]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>(){
                 @Override

--- a/build.gradle
+++ b/build.gradle
@@ -7,10 +7,10 @@ buildscript {
     apply from: 'build-tools/repositories.gradle'
 
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.1.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.2.0-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        // 2.1.0-SNAPSHOT -> 2.1.0.0-SNAPSHOT
+        // 2.2.0-SNAPSHOT -> 2.2.0.0-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'
         plugin_no_snapshot = opensearch_build


### PR DESCRIPTION
Signed-off-by: AWSHurneyt <hurneyt@amazon.com>

*Issue #, if available:*
https://github.com/opensearch-project/alerting/issues/498

*Description of changes:*
1. Bumping `2.x` branch version from `2.1.0` to `2.2.0`. This change is dependent on https://github.com/opensearch-project/notifications/pull/493.
2. Bumped `mockito-core` version from `4.3.1` to `4.6.1`.

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).