### PR TITLE
Refactored backwards compatibility tests to point to the OpenSearch 1.1.0.0 zip following deprecation of ODFE.

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -183,7 +183,7 @@ testClusters.integTest {
 }
 
 testClusters.integTest.nodes.each { node ->
-    node.setting("opendistro.destination.host.deny_list", "[\"10.0.0.0/8\", \"127.0.0.1\"]")
+    node.setting("plugins.destination.host.deny_list", "[\"10.0.0.0/8\", \"127.0.0.1\"]")
 }
 
 integTest {
@@ -247,17 +247,17 @@ task integTestRemote(type: RestIntegTestTask) {
 }
 integTestRemote.enabled = System.getProperty("tests.rest.cluster") != null
 
-String bwcVersion = "1.13.1.0"
+String bwcVersion = "1.1.0.0"
 String baseName = "alertingBwcCluster"
 String bwcFilePath = "src/test/resources/bwc"
-String bwcOpenDistroPlugin = "opendistro-alerting-" + bwcVersion + ".zip"
-String bwcRemoteFile = 'https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/opendistro-alerting/' + bwcOpenDistroPlugin
+String bwcOpenSearchPlugin = "opensearch-alerting-" + bwcVersion + ".zip"
+String bwcRemoteFile = 'https://ci.opensearch.org/ci/dbc/bundle-build/1.1.0/20210930/linux/x64/builds/opensearch/plugins/' + bwcOpenSearchPlugin
 
 2.times {i ->
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-            versions = ["7.10.2","2.1.0-SNAPSHOT"]
+            versions = ["1.1.0", "2.1.0-SNAPSHOT"]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>(){
                 @Override
@@ -270,7 +270,7 @@ String bwcRemoteFile = 'https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elastics
                             if (!dir.exists()) {
                                 dir.mkdirs()
                             }
-                            File f = new File(dir, bwcOpenDistroPlugin)
+                            File f = new File(dir, bwcOpenSearchPlugin)
                             if (!f.exists()) {
                                 new URL(bwcRemoteFile).withInputStream{ ins -> f.withOutputStream{ it << ins }}
                             }


### PR DESCRIPTION
Signed-off-by: AWSHurneyt <hurneyt@amazon.com>

*Issue #, if available:*
https://github.com/opensearch-project/alerting/issues/498

*Description of changes:*
Refactored backwards compatibility tests to point to the OpenSearch 1.1.0.0 zip following deprecation of ODFE.

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).