### PR TITLE
Model2 Approach to a Unified Common-Utils

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -81,7 +81,7 @@ configurations.testImplementation {
 dependencies {
     compileOnly "org.opensearch.plugin:opensearch-scripting-painless-spi:${versions.opensearch}"
     api "org.opensearch.plugin:percolator-client:${opensearch_version}"
-
+    api "org.opensearch:common-utils:${opensearch_build}"
     // OpenSearch Nanny state
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"

--- a/alerting/src/main/java/org/opensearch/alerting/action/ExecuteMonitorAction2.java
+++ b/alerting/src/main/java/org/opensearch/alerting/action/ExecuteMonitorAction2.java
@@ -1,0 +1,13 @@
+package org.opensearch.alerting.action;
+
+import org.opensearch.action.ActionType;
+
+public class ExecuteMonitorAction2 extends ActionType<org.opensearch.commons.model2.action.ExecuteMonitorResponse> {
+
+    public static final String NAME = "cluster:admin/opendistro/alerting/monitor/execute2";
+    public static final ExecuteMonitorAction2 INSTANCE = new ExecuteMonitorAction2(NAME);
+
+    private ExecuteMonitorAction2(final String name) {
+        super(name, org.opensearch.commons.model2.action.ExecuteMonitorResponse::new);
+    }
+}

--- a/alerting/src/main/java/org/opensearch/alerting/action/IndexMonitorAction2.java
+++ b/alerting/src/main/java/org/opensearch/alerting/action/IndexMonitorAction2.java
@@ -1,0 +1,13 @@
+package org.opensearch.alerting.action;
+
+import org.opensearch.action.ActionType;
+
+public class IndexMonitorAction2 extends ActionType<org.opensearch.commons.model2.action.IndexMonitorResponse> {
+
+    public static final String NAME = "cluster:admin/opendistro/alerting/monitor/write2";
+    public static final IndexMonitorAction2 INSTANCE = new IndexMonitorAction2(NAME);
+
+    private IndexMonitorAction2(final String name) {
+        super(name, org.opensearch.commons.model2.action.IndexMonitorResponse::new);
+    }
+}

--- a/alerting/src/main/java/org/opensearch/alerting/model/Model2ModelTranslator.java
+++ b/alerting/src/main/java/org/opensearch/alerting/model/Model2ModelTranslator.java
@@ -1,0 +1,55 @@
+package org.opensearch.alerting.model;
+
+import org.opensearch.alerting.core.model.IntervalSchedule;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+
+public class Model2ModelTranslator {
+    /*
+     override val id: String = NO_ID,
+    override val version: Long = NO_VERSION,
+    override val name: String,
+    override val enabled: Boolean,
+    override val schedule: Schedule,
+    override val lastUpdateTime: Instant,
+    override val enabledTime: Instant?,
+    // TODO: Check how this behaves during rolling upgrade/multi-version cluster
+    //  Can read/write and parsing break if it's done from an old -> new version of the plugin?
+    val monitorType: MonitorType,
+    val user: User?,
+    val schemaVersion: Int = NO_SCHEMA_VERSION,
+    val inputs: List<Input>,
+    val triggers: List<Trigger>,
+    val uiMetadata: Map<String, Any>
+     */
+    public static Monitor fromModel2(final org.opensearch.commons.model2.model.Monitor monitor2) {
+        return new Monitor(
+                monitor2.id, // id
+                monitor2.version, // version
+                monitor2.name, // name
+                true, // enabled
+                new IntervalSchedule(100, ChronoUnit.SECONDS, Instant.now()), // schedule
+                Instant.now(), // last update
+                Instant.now(), // enabled time
+                Monitor.MonitorType.valueOf(monitor2.monitor_type), // monitor type
+                null, // user
+                (int) monitor2.version, // schema version
+                List.of(), // inputs
+                List.of(), // triggers
+                Map.of()); // ui metadta
+    }
+
+    public static org.opensearch.commons.model2.model.Monitor toModel2(final Monitor monitor) {
+        return new org.opensearch.commons.model2.model.Monitor(
+                monitor.getId(),
+                monitor.getMonitorType().getValue(),
+                monitor.getVersion(),
+                monitor.getName(),
+                monitor.getLastUpdateTime().toEpochMilli(),
+                "milliseconds",
+                List.of()); // inputs
+    }
+}

--- a/alerting/src/main/java/org/opensearch/alerting/model/Model2ModelTranslator.java
+++ b/alerting/src/main/java/org/opensearch/alerting/model/Model2ModelTranslator.java
@@ -1,8 +1,10 @@
 package org.opensearch.alerting.model;
 
 import org.opensearch.alerting.core.model.IntervalSchedule;
+import org.opensearch.commons.model2.model.Schedule;
 
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
@@ -25,13 +27,16 @@ public class Model2ModelTranslator {
     val triggers: List<Trigger>,
     val uiMetadata: Map<String, Any>
      */
+
+
     public static Monitor fromModel2(final org.opensearch.commons.model2.model.Monitor monitor2) {
         return new Monitor(
                 monitor2.id, // id
                 monitor2.version, // version
                 monitor2.name, // name
                 true, // enabled
-                new IntervalSchedule(100, ChronoUnit.SECONDS, Instant.now()), // schedule
+                new IntervalSchedule(3, ChronoUnit.SECONDS, Instant.now()),
+                //TODO: monitor2.schedule.type.equals("cron") ? new CronSchedule(monitor2.schedule) : new IntervalSchedule(), // schedule
                 Instant.now(), // last update
                 Instant.now(), // enabled time
                 Monitor.MonitorType.valueOf(monitor2.monitor_type), // monitor type
@@ -47,6 +52,8 @@ public class Model2ModelTranslator {
                 monitor.getId(),
                 monitor.getMonitorType().getValue(),
                 monitor.getVersion(),
+                // TODO: align the Kotlin Schedule model with the Model2 Schedule model
+                new Schedule(monitor.getSchedule().getClass().getName(), ZoneId.systemDefault(), 100, ChronoUnit.SECONDS, "chrono"),
                 monitor.getName(),
                 monitor.getLastUpdateTime().toEpochMilli(),
                 "milliseconds",

--- a/alerting/src/main/java/org/opensearch/alerting/transport/TransportExecuteMonitorAction2.java
+++ b/alerting/src/main/java/org/opensearch/alerting/transport/TransportExecuteMonitorAction2.java
@@ -1,0 +1,69 @@
+package org.opensearch.alerting.transport;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.TransportAction;
+import org.opensearch.alerting.action.ExecuteMonitorAction2;
+import org.opensearch.alerting.model.Model2ModelTranslator;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.commons.model2.action.ExecuteMonitorRequest;
+import org.opensearch.commons.model2.action.ExecuteMonitorResponse;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+
+public class TransportExecuteMonitorAction2 extends TransportAction<ExecuteMonitorRequest, ExecuteMonitorResponse> {
+
+    private final Logger LOG = LogManager.getLogger(TransportExecuteMonitorAction2.class);
+
+
+    private final Client client;
+    private final ClusterService cluster;
+
+
+    @Inject
+    public TransportExecuteMonitorAction2(final TransportService transport,
+                                          final Client client,
+                                          final ActionFilters actionFilters,
+                                          final NamedXContentRegistry xContentRegistry,
+                                          final ClusterService clusterService,
+                                          final Settings settings) {
+        super(ExecuteMonitorAction2.NAME, actionFilters, transport.getTaskManager());
+
+        this.client = client;
+        this.cluster = clusterService;
+    }
+
+    // TODO: if you need to deserialize via XContent, note there is ModelSerializer.read(XContent,....)
+    @Override
+    protected void doExecute(final Task task, ExecuteMonitorRequest request, final ActionListener<ExecuteMonitorResponse> actionListener) {
+        try {
+            final org.opensearch.alerting.action.ExecuteMonitorRequest xRequest = new org.opensearch.alerting.action.ExecuteMonitorRequest(
+                    false,
+                    TimeValue.ZERO,
+                    null,
+                    Model2ModelTranslator.fromModel2(request.monitor));
+
+            this.client.execute(org.opensearch.alerting.action.ExecuteMonitorAction.Companion.getINSTANCE(), xRequest, new ActionListener<>() {
+                @Override
+                public void onResponse(final org.opensearch.alerting.action.ExecuteMonitorResponse response) {
+                    final ExecuteMonitorResponse xResponse = new ExecuteMonitorResponse(response.getMonitorRunResult().getMonitorName());
+                    actionListener.onResponse(xResponse);
+                }
+
+                @Override
+                public void onFailure(final Exception e) {
+                    actionListener.onFailure(e);
+                }
+            });
+        } catch (final Exception e) {
+            actionListener.onFailure(e);
+        }
+    }
+}

--- a/alerting/src/main/java/org/opensearch/alerting/transport/TransportExecuteMonitorAction2.java
+++ b/alerting/src/main/java/org/opensearch/alerting/transport/TransportExecuteMonitorAction2.java
@@ -50,18 +50,9 @@ public class TransportExecuteMonitorAction2 extends TransportAction<ExecuteMonit
                     null,
                     Model2ModelTranslator.fromModel2(request.monitor));
 
-            this.client.execute(org.opensearch.alerting.action.ExecuteMonitorAction.Companion.getINSTANCE(), xRequest, new ActionListener<>() {
-                @Override
-                public void onResponse(final org.opensearch.alerting.action.ExecuteMonitorResponse response) {
-                    final ExecuteMonitorResponse xResponse = new ExecuteMonitorResponse(response.getMonitorRunResult().getMonitorName());
-                    actionListener.onResponse(xResponse);
-                }
-
-                @Override
-                public void onFailure(final Exception e) {
-                    actionListener.onFailure(e);
-                }
-            });
+            this.client.execute(org.opensearch.alerting.action.ExecuteMonitorAction.Companion.getINSTANCE(), xRequest,
+                    ActionListener.map(actionListener, response ->
+                            new ExecuteMonitorResponse(response.getMonitorRunResult().getMonitorName())));
         } catch (final Exception e) {
             actionListener.onFailure(e);
         }

--- a/alerting/src/main/java/org/opensearch/alerting/transport/TransportIndexMonitorAction2.java
+++ b/alerting/src/main/java/org/opensearch/alerting/transport/TransportIndexMonitorAction2.java
@@ -1,0 +1,75 @@
+package org.opensearch.alerting.transport;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.TransportAction;
+import org.opensearch.alerting.action.IndexMonitorAction;
+import org.opensearch.alerting.action.IndexMonitorAction2;
+import org.opensearch.alerting.model.Model2ModelTranslator;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.commons.model2.action.IndexMonitorRequest;
+import org.opensearch.commons.model2.action.IndexMonitorResponse;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+
+public class TransportIndexMonitorAction2 extends TransportAction<IndexMonitorRequest, IndexMonitorResponse> {
+
+    private final Logger LOG = LogManager.getLogger(TransportIndexMonitorAction.class);
+
+    private final Client client;
+    private final ClusterService cluster;
+
+
+    @Inject
+    public TransportIndexMonitorAction2(final TransportService transport,
+                                        final Client client,
+                                        final ActionFilters actionFilters,
+                                        final NamedXContentRegistry xContentRegistry,
+                                        final ClusterService clusterService,
+                                        final Settings settings) {
+        super(IndexMonitorAction2.NAME, actionFilters, transport.getTaskManager());
+
+        this.client = client;
+        this.cluster = clusterService;
+    }
+
+    @Override
+    protected void doExecute(final Task task, IndexMonitorRequest request, final ActionListener<IndexMonitorResponse> actionListener) {
+        try {
+            final org.opensearch.alerting.action.IndexMonitorRequest xRequest = new org.opensearch.alerting.action.IndexMonitorRequest(
+                    request.monitorId,
+                    request.seqNo,
+                    request.primaryTerm,
+                    request.refreshPolicy,
+                    request.method,
+                    Model2ModelTranslator.fromModel2(request.monitor));
+
+            this.client.execute(IndexMonitorAction.Companion.getINSTANCE(), xRequest, new ActionListener<>() {
+                @Override
+                public void onResponse(final org.opensearch.alerting.action.IndexMonitorResponse response) {
+                    final IndexMonitorResponse xResponse = new IndexMonitorResponse(
+                            response.getId(),
+                            response.getVersion(),
+                            response.getSeqNo(),
+                            response.getVersion(),
+                            response.getStatus(),
+                            Model2ModelTranslator.toModel2(response.getMonitor()));
+                    actionListener.onResponse(xResponse);
+                }
+
+                @Override
+                public void onFailure(final Exception e) {
+                    actionListener.onFailure(e);
+                }
+            });
+        } catch (final Exception e) {
+            actionListener.onFailure(e);
+        }
+    }
+}

--- a/alerting/src/main/java/org/opensearch/alerting/transport/TransportIndexMonitorAction2.java
+++ b/alerting/src/main/java/org/opensearch/alerting/transport/TransportIndexMonitorAction2.java
@@ -5,7 +5,6 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.TransportAction;
-import org.opensearch.alerting.action.IndexMonitorAction;
 import org.opensearch.alerting.action.IndexMonitorAction2;
 import org.opensearch.alerting.model.Model2ModelTranslator;
 import org.opensearch.client.Client;
@@ -50,24 +49,15 @@ public class TransportIndexMonitorAction2 extends TransportAction<IndexMonitorRe
                     request.method,
                     Model2ModelTranslator.fromModel2(request.monitor));
 
-            this.client.execute(IndexMonitorAction.Companion.getINSTANCE(), xRequest, new ActionListener<>() {
-                @Override
-                public void onResponse(final org.opensearch.alerting.action.IndexMonitorResponse response) {
-                    final IndexMonitorResponse xResponse = new IndexMonitorResponse(
-                            response.getId(),
-                            response.getVersion(),
-                            response.getSeqNo(),
-                            response.getVersion(),
-                            response.getStatus(),
-                            Model2ModelTranslator.toModel2(response.getMonitor()));
-                    actionListener.onResponse(xResponse);
-                }
-
-                @Override
-                public void onFailure(final Exception e) {
-                    actionListener.onFailure(e);
-                }
-            });
+            this.client.execute(org.opensearch.alerting.action.IndexMonitorAction.Companion.getINSTANCE(), xRequest,
+                    ActionListener.map(actionListener,
+                            response -> new IndexMonitorResponse(
+                                    response.getId(),
+                                    response.getVersion(),
+                                    response.getSeqNo(),
+                                    response.getVersion(),
+                                    response.getStatus(),
+                                    Model2ModelTranslator.toModel2(response.getMonitor()))));
         } catch (final Exception e) {
             actionListener.onFailure(e);
         }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -17,6 +17,7 @@ import org.opensearch.alerting.action.GetEmailGroupAction
 import org.opensearch.alerting.action.GetFindingsAction
 import org.opensearch.alerting.action.GetMonitorAction
 import org.opensearch.alerting.action.IndexMonitorAction
+import org.opensearch.alerting.action.IndexMonitorAction2
 import org.opensearch.alerting.action.SearchEmailAccountAction
 import org.opensearch.alerting.action.SearchEmailGroupAction
 import org.opensearch.alerting.action.SearchMonitorAction
@@ -66,6 +67,7 @@ import org.opensearch.alerting.transport.TransportGetEmailGroupAction
 import org.opensearch.alerting.transport.TransportGetFindingsSearchAction
 import org.opensearch.alerting.transport.TransportGetMonitorAction
 import org.opensearch.alerting.transport.TransportIndexMonitorAction
+import org.opensearch.alerting.transport.TransportIndexMonitorAction2
 import org.opensearch.alerting.transport.TransportSearchEmailAccountAction
 import org.opensearch.alerting.transport.TransportSearchEmailGroupAction
 import org.opensearch.alerting.transport.TransportSearchMonitorAction
@@ -184,8 +186,9 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             ActionPlugin.ActionHandler(SearchEmailGroupAction.INSTANCE, TransportSearchEmailGroupAction::class.java),
             ActionPlugin.ActionHandler(GetDestinationsAction.INSTANCE, TransportGetDestinationsAction::class.java),
             ActionPlugin.ActionHandler(GetAlertsAction.INSTANCE, TransportGetAlertsAction::class.java),
-            ActionPlugin.ActionHandler(GetFindingsAction.INSTANCE, TransportGetFindingsSearchAction::class.java)
-
+            ActionPlugin.ActionHandler(GetFindingsAction.INSTANCE, TransportGetFindingsSearchAction::class.java),
+                // sap<->alerting bridge actions
+            ActionPlugin.ActionHandler(IndexMonitorAction2.INSTANCE,TransportIndexMonitorAction2::class.java)
         )
     }
 
@@ -197,7 +200,9 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             QueryLevelTrigger.XCONTENT_REGISTRY,
             BucketLevelTrigger.XCONTENT_REGISTRY,
             ClusterMetricsInput.XCONTENT_REGISTRY,
-            DocumentLevelTrigger.XCONTENT_REGISTRY
+            DocumentLevelTrigger.XCONTENT_REGISTRY,
+                // sap<->alerting bridge actions
+            org.opensearch.commons.model2.model.Monitor.XCONTENT_REGISTRY
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -7,20 +7,7 @@ package org.opensearch.alerting
 
 import org.opensearch.action.ActionRequest
 import org.opensearch.action.ActionResponse
-import org.opensearch.alerting.action.AcknowledgeAlertAction
-import org.opensearch.alerting.action.DeleteMonitorAction
-import org.opensearch.alerting.action.ExecuteMonitorAction
-import org.opensearch.alerting.action.GetAlertsAction
-import org.opensearch.alerting.action.GetDestinationsAction
-import org.opensearch.alerting.action.GetEmailAccountAction
-import org.opensearch.alerting.action.GetEmailGroupAction
-import org.opensearch.alerting.action.GetFindingsAction
-import org.opensearch.alerting.action.GetMonitorAction
-import org.opensearch.alerting.action.IndexMonitorAction
-import org.opensearch.alerting.action.IndexMonitorAction2
-import org.opensearch.alerting.action.SearchEmailAccountAction
-import org.opensearch.alerting.action.SearchEmailGroupAction
-import org.opensearch.alerting.action.SearchMonitorAction
+import org.opensearch.alerting.action.*
 import org.opensearch.alerting.aggregation.bucketselectorext.BucketSelectorExtAggregationBuilder
 import org.opensearch.alerting.alerts.AlertIndices
 import org.opensearch.alerting.core.JobSweeper
@@ -57,20 +44,7 @@ import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.settings.DestinationSettings
 import org.opensearch.alerting.settings.LegacyOpenDistroAlertingSettings
 import org.opensearch.alerting.settings.LegacyOpenDistroDestinationSettings
-import org.opensearch.alerting.transport.TransportAcknowledgeAlertAction
-import org.opensearch.alerting.transport.TransportDeleteMonitorAction
-import org.opensearch.alerting.transport.TransportExecuteMonitorAction
-import org.opensearch.alerting.transport.TransportGetAlertsAction
-import org.opensearch.alerting.transport.TransportGetDestinationsAction
-import org.opensearch.alerting.transport.TransportGetEmailAccountAction
-import org.opensearch.alerting.transport.TransportGetEmailGroupAction
-import org.opensearch.alerting.transport.TransportGetFindingsSearchAction
-import org.opensearch.alerting.transport.TransportGetMonitorAction
-import org.opensearch.alerting.transport.TransportIndexMonitorAction
-import org.opensearch.alerting.transport.TransportIndexMonitorAction2
-import org.opensearch.alerting.transport.TransportSearchEmailAccountAction
-import org.opensearch.alerting.transport.TransportSearchEmailGroupAction
-import org.opensearch.alerting.transport.TransportSearchMonitorAction
+import org.opensearch.alerting.transport.*
 import org.opensearch.alerting.util.DocLevelMonitorQueries
 import org.opensearch.alerting.util.destinationmigration.DestinationMigrationCoordinator
 import org.opensearch.client.Client
@@ -188,7 +162,8 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             ActionPlugin.ActionHandler(GetAlertsAction.INSTANCE, TransportGetAlertsAction::class.java),
             ActionPlugin.ActionHandler(GetFindingsAction.INSTANCE, TransportGetFindingsSearchAction::class.java),
                 // sap<->alerting bridge actions
-            ActionPlugin.ActionHandler(IndexMonitorAction2.INSTANCE,TransportIndexMonitorAction2::class.java)
+            ActionPlugin.ActionHandler(org.opensearch.commons.model2.action.IndexMonitorAction.ALERTING_BRIDGE_INSTANCE,TransportIndexMonitorAction2::class.java),
+            ActionPlugin.ActionHandler(ExecuteMonitorAction2.INSTANCE, TransportExecuteMonitorAction2::class.java)
         )
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 buildscript {
     apply from: 'build-tools/repositories.gradle'
 
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.2.0-SNAPSHOT")
-        buildVersionQualifier = System.getProperty("build.version_qualifier", "")
+        opensearch_version = System.getProperty("opensearch.version", "2.2.0")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        // 2.2.0-SNAPSHOT -> 2.2.0.0-SNAPSHOT
+        buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'
         plugin_no_snapshot = opensearch_build
@@ -21,9 +21,9 @@ buildscript {
         if (isSnapshot) {
             opensearch_build += "-SNAPSHOT"
         }
-        opensearch_no_snapshot = opensearch_version.replace("-SNAPSHOT","")
-        common_utils_version = System.getProperty("common_utils.version", opensearch_build)
+        opensearch_no_snapshot = opensearch_version.replace("-SNAPSHOT", "")
         kotlin_version = '1.6.10'
+        common_utils_version = System.getProperty("common_utils.version", opensearch_build)
     }
 
     repositories {
@@ -47,7 +47,7 @@ apply plugin: 'base'
 apply plugin: 'jacoco'
 apply from: 'build-tools/merged-coverage.gradle'
 
-configurations {
+/*configurations {
     ktlint
 }
 
@@ -57,23 +57,23 @@ dependencies {
             attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
         }
     }
-}
+}*/
 
-task ktlint(type: JavaExec, group: "verification") {
-    description = "Check Kotlin code style."
-    main = "com.pinterest.ktlint.Main"
-    classpath = configurations.ktlint
-    args "alerting/**/*.kt", "elastic-api/**/*.kt", "core/**/*.kt"
-}
+//task ktlint(type: JavaExec, group: "verification") {
+//    description = "Check Kotlin code style."
+//    main = "com.pinterest.ktlint.Main"
+//    classpath = configurations.ktlint
+//    args "alerting/**/*.kt", "elastic-api/**/*.kt", "core/**/*.kt"
+//}
 
-task ktlintFormat(type: JavaExec, group: "formatting") {
-    description = "Fix Kotlin code style deviations."
-    main = "com.pinterest.ktlint.Main"
-    classpath = configurations.ktlint
-    args "-F", "alerting/**/*.kt", "elastic-api/**/*.kt", "core/**/*.kt"
-}
+//task ktlintFormat(type: JavaExec, group: "formatting") {
+//    description = "Fix Kotlin code style deviations."
+//    main = "com.pinterest.ktlint.Main"
+//    classpath = configurations.ktlint
+//    args "-F", "alerting/**/*.kt", "elastic-api/**/*.kt", "core/**/*.kt"
+//}
 
-check.dependsOn ktlint
+//check.dependsOn ktlint
 
 allprojects {
     group = "org.opensearch"
@@ -86,7 +86,7 @@ allprojects {
     }
     plugins.withId('org.jetbrains.kotlin.jvm') {
         compileKotlin.kotlinOptions.jvmTarget = compileTestKotlin.kotlinOptions.jvmTarget = JavaVersion.VERSION_11
-        compileKotlin.dependsOn ktlint
+        // ompileKotlin.dependsOn ktlint
     }
     tasks.withType(AbstractArchiveTask).configureEach {
         preserveFileTimestamps = false


### PR DESCRIPTION
This is related to ISSUE-10 of security analytics. It's the best push I have that uses a simpler Model infrastructure based on public fields and reflection. It also incorporates the notion of redirecting existing actions to a intermediate "translator action" (@getsaurabh02 idea). 

This is a 3 part PR across common-utils, alerting, and security analytics. All under the same `model2/` branch.

*CheckList:*
[X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).