### PR TITLE
Replace Forum link in Alerting plugin README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![codecov](https://codecov.io/gh/opensearch-project/alerting/branch/main/graph/badge.svg)](https://codecov.io/gh/opensearch-project/alerting)
 [![Documentation](https://img.shields.io/badge/api-reference-blue.svg)](https://opensearch.org/docs/latest/monitoring-plugins/alerting/api/)
 [![Chat](https://img.shields.io/badge/chat-on%20forums-blue)](https://forum.opensearch.org/c/plugins/alerting/7)
-[![PRs welcome!](https://img.shields.io/badge/PRs-welcome!-success)]
+![PRs welcome!](https://img.shields.io/badge/PRs-welcome!-success)
 
 <img src="https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_default.svg" height="64px"/>
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Test Workflow](https://github.com/opensearch-project/alerting/workflows/Test%20Workflow/badge.svg)](https://github.com/opensearch-project/alerting/actions)
 [![codecov](https://codecov.io/gh/opensearch-project/alerting/branch/main/graph/badge.svg)](https://codecov.io/gh/opensearch-project/alerting)
 [![Documentation](https://img.shields.io/badge/api-reference-blue.svg)](https://opensearch.org/docs/latest/monitoring-plugins/alerting/api/)
-[![Chat](https://img.shields.io/badge/chat-on%20forums-blue)](https://discuss.opendistrocommunity.dev/c/alerting/)
-![PRs welcome!](https://img.shields.io/badge/PRs-welcome!-success)
+[![Chat](https://img.shields.io/badge/chat-on%20forums-blue)](https://forum.opensearch.org/c/plugins/alerting/7)
+[![PRs welcome!](https://img.shields.io/badge/PRs-welcome!-success)]
 
 <img src="https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_default.svg" height="64px"/>
 


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

*Description of changes*
Replace the link to Forum discussion in the README.md file so that it points to the OpenSearch forum rather than the defunct Open Distro forum.

*CheckList:*
This fixes the issue for the Alerting plugin in [#921](https://github.com/opensearch-project/documentation-website/issues/921).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).