### PR TITLE
Deprecate the Master nomenclature in 2.3

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
@@ -150,7 +150,7 @@ class AlertIndices(
 
     @Volatile private var requestTimeout = AlertingSettings.REQUEST_TIMEOUT.get(settings)
 
-    @Volatile private var isMaster = false
+    @Volatile private var isClusterManager = false
 
     // for JobsMonitor to report
     var lastRolloverTime: TimeValue? = null
@@ -192,12 +192,12 @@ class AlertIndices(
     }
 
     override fun clusterChanged(event: ClusterChangedEvent) {
-        // Instead of using a LocalNodeMasterListener to track master changes, this service will
+        // Instead of using a LocalNodeClusterManagerListener to track master changes, this service will
         // track them here to avoid conditions where master listener events run after other
         // listeners that depend on what happened in the master listener
-        if (this.isMaster != event.localNodeMaster()) {
-            this.isMaster = event.localNodeMaster()
-            if (this.isMaster) {
+        if (this.isClusterManager != event.localNodeClusterManager()) {
+            this.isClusterManager = event.localNodeClusterManager()
+            if (this.isClusterManager) {
                 onMaster()
             } else {
                 offMaster()

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/DestinationMigrationCoordinator.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/DestinationMigrationCoordinator.kt
@@ -52,7 +52,7 @@ class DestinationMigrationCoordinator(
             DestinationMigrationUtilService.finishFlag = false
         }
         if (
-            event.localNodeMaster() &&
+            event.localNodeClusterManager() &&
             !runningLock &&
             (scheduledMigration == null || scheduledMigration!!.isCancelled)
         ) {
@@ -62,7 +62,7 @@ class DestinationMigrationCoordinator(
             } finally {
                 runningLock = false
             }
-        } else if (!event.localNodeMaster()) {
+        } else if (!event.localNodeClusterManager()) {
             scheduledMigration?.cancel()
         }
     }


### PR DESCRIPTION
Signed-off-by: Subhobrata Dey <sbcd90@gmail.com>

*Issue #, if available:*
[Deprecate the "Master" nomenclature](https://github.com/opensearch-project/alerting/issues/320)

*Description of changes:*
this replaces the deprecated api `localNodeMaster` to `localNodeClusterManager`.

*CheckList:*
[X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).