### PR TITLE
Adds support for fetching alerts from custom alert index in Get Alerts transport layer

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/action/GetAlertsRequest.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/action/GetAlertsRequest.kt
@@ -17,17 +17,20 @@ class GetAlertsRequest : ActionRequest {
     val severityLevel: String
     val alertState: String
     val monitorId: String?
+    val alertIndex: String?
 
     constructor(
         table: Table,
         severityLevel: String,
         alertState: String,
-        monitorId: String?
+        monitorId: String?,
+        alertIndex: String?,
     ) : super() {
         this.table = table
         this.severityLevel = severityLevel
         this.alertState = alertState
         this.monitorId = monitorId
+        this.alertIndex = alertIndex
     }
 
     @Throws(IOException::class)
@@ -35,7 +38,8 @@ class GetAlertsRequest : ActionRequest {
         table = Table.readFrom(sin),
         severityLevel = sin.readString(),
         alertState = sin.readString(),
-        monitorId = sin.readOptionalString()
+        monitorId = sin.readOptionalString(),
+        alertIndex = sin.readOptionalString()
     )
 
     override fun validate(): ActionRequestValidationException? {
@@ -48,5 +52,6 @@ class GetAlertsRequest : ActionRequest {
         out.writeString(severityLevel)
         out.writeString(alertState)
         out.writeOptionalString(monitorId)
+        out.writeOptionalString(alertIndex)
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetAlertsAction.kt
@@ -66,7 +66,7 @@ class RestGetAlertsAction : BaseRestHandler() {
             searchString
         )
 
-        val getAlertsRequest = GetAlertsRequest(table, severityLevel, alertState, monitorId)
+        val getAlertsRequest = GetAlertsRequest(table, severityLevel, alertState, monitorId, null)
         return RestChannelConsumer {
                 channel ->
             client.execute(GetAlertsAction.INSTANCE, getAlertsRequest, RestToXContentListener(channel))

--- a/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
@@ -64,6 +64,7 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
                 .get()
             fail()
         } catch (e: Exception) {
+            Assert.assertTrue(e.message!!.contains("IndexNotFoundException"))
         }
     }
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/action/GetAlertsRequestTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/action/GetAlertsRequestTests.kt
@@ -16,7 +16,7 @@ class GetAlertsRequestTests : OpenSearchTestCase() {
 
         val table = Table("asc", "sortString", null, 1, 0, "")
 
-        val req = GetAlertsRequest(table, "1", "active", null)
+        val req = GetAlertsRequest(table, "1", "active", null, null)
         assertNotNull(req)
 
         val out = BytesStreamOutput()
@@ -33,7 +33,7 @@ class GetAlertsRequestTests : OpenSearchTestCase() {
     fun `test get alerts request with filter`() {
 
         val table = Table("asc", "sortString", null, 1, 0, "")
-        val req = GetAlertsRequest(table, "1", "active", null)
+        val req = GetAlertsRequest(table, "1", "active", null, null)
         assertNotNull(req)
 
         val out = BytesStreamOutput()
@@ -50,7 +50,7 @@ class GetAlertsRequestTests : OpenSearchTestCase() {
     fun `test validate returns null`() {
         val table = Table("asc", "sortString", null, 1, 0, "")
 
-        val req = GetAlertsRequest(table, "1", "active", null)
+        val req = GetAlertsRequest(table, "1", "active", null, null)
         assertNotNull(req)
         assertNull(req.validate())
     }


### PR DESCRIPTION
Adds support for fetching alerts from custom alert index in Get Alerts transport layer

Signed-off-by: Surya Sashank Nistala <snistala@amazon.com>

Related Issues:
#562 #522 