### PR TITLE
GetFindingsAction new optional parameters

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/action/GetFindingsRequest.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/action/GetFindingsRequest.kt
@@ -15,19 +15,27 @@ import java.io.IOException
 class GetFindingsRequest : ActionRequest {
     val findingId: String?
     val table: Table
+    val monitorId: String?
+    val findingIndexName: String?
 
     constructor(
         findingId: String?,
-        table: Table
+        table: Table,
+        monitorId: String?,
+        findingIndexName: String?
     ) : super() {
         this.findingId = findingId
         this.table = table
+        this.monitorId = monitorId
+        this.findingIndexName = findingIndexName
     }
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         findingId = sin.readOptionalString(),
-        table = Table.readFrom(sin)
+        table = Table.readFrom(sin),
+        monitorId = sin.readOptionalString(),
+        findingIndexName = sin.readOptionalString()
     )
 
     override fun validate(): ActionRequestValidationException? {
@@ -38,5 +46,7 @@ class GetFindingsRequest : ActionRequest {
     override fun writeTo(out: StreamOutput) {
         out.writeOptionalString(findingId)
         table.writeTo(out)
+        out.writeOptionalString(monitorId)
+        out.writeOptionalString(findingIndexName)
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/action/GetFindingsRequest.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/action/GetFindingsRequest.kt
@@ -16,7 +16,7 @@ class GetFindingsRequest : ActionRequest {
     val findingId: String?
     val table: Table
     val monitorId: String?
-    val findingIndexName: String?
+    val findingIndex: String?
 
     constructor(
         findingId: String?,
@@ -27,7 +27,7 @@ class GetFindingsRequest : ActionRequest {
         this.findingId = findingId
         this.table = table
         this.monitorId = monitorId
-        this.findingIndexName = findingIndexName
+        this.findingIndex = findingIndexName
     }
 
     @Throws(IOException::class)
@@ -47,6 +47,6 @@ class GetFindingsRequest : ActionRequest {
         out.writeOptionalString(findingId)
         table.writeTo(out)
         out.writeOptionalString(monitorId)
-        out.writeOptionalString(findingIndexName)
+        out.writeOptionalString(findingIndex)
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/action/GetFindingsRequest.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/action/GetFindingsRequest.kt
@@ -21,8 +21,8 @@ class GetFindingsRequest : ActionRequest {
     constructor(
         findingId: String?,
         table: Table,
-        monitorId: String?,
-        findingIndexName: String?
+        monitorId: String? = null,
+        findingIndexName: String? = null
     ) : super() {
         this.findingId = findingId
         this.table = table

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetFindingsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetFindingsAction.kt
@@ -45,8 +45,7 @@ class RestGetFindingsAction : BaseRestHandler() {
         val size = request.paramAsInt("size", 20)
         val startIndex = request.paramAsInt("startIndex", 0)
         val searchString = request.param("searchString", "")
-        val monitorId = request.param("monitorId", null)
-        val findingIndexName = request.param("findingIndexName", null)
+
         val table = Table(
             sortOrder,
             sortString,
@@ -58,9 +57,7 @@ class RestGetFindingsAction : BaseRestHandler() {
 
         val getFindingsSearchRequest = GetFindingsRequest(
             findingID,
-            table,
-            monitorId,
-            findingIndexName
+            table
         )
         return RestChannelConsumer {
                 channel ->

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetFindingsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetFindingsAction.kt
@@ -45,7 +45,8 @@ class RestGetFindingsAction : BaseRestHandler() {
         val size = request.paramAsInt("size", 20)
         val startIndex = request.paramAsInt("startIndex", 0)
         val searchString = request.param("searchString", "")
-
+        val monitorId = request.param("monitorId", null)
+        val findingIndexName = request.param("findingIndexName", null)
         val table = Table(
             sortOrder,
             sortString,
@@ -57,7 +58,9 @@ class RestGetFindingsAction : BaseRestHandler() {
 
         val getFindingsSearchRequest = GetFindingsRequest(
             findingID,
-            table
+            table,
+            monitorId,
+            findingIndexName
         )
         return RestChannelConsumer {
                 channel ->

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetFindingsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetFindingsAction.kt
@@ -130,6 +130,8 @@ class TransportGetFindingsSearchAction @Inject constructor(
                     val indexName = resolveFindingsIndexName(getFindingsRequest)
                     val getFindingsResponse = search(searchSourceBuilder, indexName)
                     actionListener.onResponse(getFindingsResponse)
+                } catch (t: AlertingException) {
+                    actionListener.onFailure(t)
                 } catch (t: Exception) {
                     actionListener.onFailure(AlertingException.wrap(t))
                 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetFindingsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetFindingsAction.kt
@@ -139,12 +139,13 @@ class TransportGetFindingsSearchAction @Inject constructor(
 
     suspend fun resolveFindingsIndexName(findingsRequest: GetFindingsRequest): String {
         var indexName = ""
-        // findingIndexName has highest priority, so use that if available
+
         if (findingsRequest.findingIndexName.isNullOrEmpty() == false) {
+            // findingIndexName has highest priority, so use that if available
             indexName = findingsRequest.findingIndexName
-        // second best is monitorId.
-        // We will use it to fetch monitor and then read indexName from dataSources field of monitor
         } else if (findingsRequest.monitorId != null) {
+            // second best is monitorId.
+            // We will use it to fetch monitor and then read indexName from dataSources field of monitor
             withContext(Dispatchers.IO) {
                 val getMonitorRequest = GetMonitorRequest(findingsRequest.monitorId, -3L, RestRequest.Method.GET, null)
                 val getMonitorResponse: GetMonitorResponse =
@@ -153,8 +154,8 @@ class TransportGetFindingsSearchAction @Inject constructor(
                     }
                 indexName = getMonitorResponse.monitor?.dataSources?.findingsIndex ?: ALL_FINDING_INDEX_PATTERN
             }
-        // default is ALL_FINDING_INDEX_PATTERN for bwc and when these 2 parameters are not passed
         } else {
+            // default is ALL_FINDING_INDEX_PATTERN for bwc and when these 2 parameters are not passed
             indexName = ALL_FINDING_INDEX_PATTERN
         }
         return indexName

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetFindingsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetFindingsAction.kt
@@ -8,6 +8,7 @@ package org.opensearch.alerting.transport
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.apache.logging.log4j.LogManager
 import org.apache.lucene.search.join.ScoreMode
 import org.opensearch.action.ActionListener
@@ -20,6 +21,9 @@ import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.alerting.action.GetFindingsAction
 import org.opensearch.alerting.action.GetFindingsRequest
 import org.opensearch.alerting.action.GetFindingsResponse
+import org.opensearch.alerting.action.GetMonitorAction
+import org.opensearch.alerting.action.GetMonitorRequest
+import org.opensearch.alerting.action.GetMonitorResponse
 import org.opensearch.alerting.alerts.AlertIndices.Companion.ALL_FINDING_INDEX_PATTERN
 import org.opensearch.alerting.model.Finding
 import org.opensearch.alerting.model.FindingDocument
@@ -40,6 +44,7 @@ import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.index.query.Operator
 import org.opensearch.index.query.QueryBuilders
+import org.opensearch.rest.RestRequest
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.search.fetch.subphase.FetchSourceContext
 import org.opensearch.search.sort.SortBuilders
@@ -122,7 +127,8 @@ class TransportGetFindingsSearchAction @Inject constructor(
         client.threadPool().threadContext.stashContext().use {
             scope.launch {
                 try {
-                    val getFindingsResponse = search(searchSourceBuilder)
+                    val indexName = resolveFindingsIndexName(getFindingsRequest)
+                    val getFindingsResponse = search(searchSourceBuilder, indexName)
                     actionListener.onResponse(getFindingsResponse)
                 } catch (t: Exception) {
                     actionListener.onFailure(AlertingException.wrap(t))
@@ -131,10 +137,33 @@ class TransportGetFindingsSearchAction @Inject constructor(
         }
     }
 
-    suspend fun search(searchSourceBuilder: SearchSourceBuilder): GetFindingsResponse {
+    suspend fun resolveFindingsIndexName(findingsRequest: GetFindingsRequest): String {
+        var indexName = ""
+        // findingIndexName has highest priority, so use that if available
+        if (findingsRequest.findingIndexName.isNullOrEmpty() == false) {
+            indexName = findingsRequest.findingIndexName
+        // second best is monitorId.
+        // We will use it to fetch monitor and then read indexName from dataSources field of monitor
+        } else if (findingsRequest.monitorId != null) {
+            withContext(Dispatchers.IO) {
+                val getMonitorRequest = GetMonitorRequest(findingsRequest.monitorId, -3L, RestRequest.Method.GET, null)
+                val getMonitorResponse: GetMonitorResponse =
+                    this@TransportGetFindingsSearchAction.client.suspendUntil {
+                        execute(GetMonitorAction.INSTANCE, getMonitorRequest, it)
+                    }
+                indexName = getMonitorResponse.monitor?.dataSources?.findingsIndex ?: ALL_FINDING_INDEX_PATTERN
+            }
+        // default is ALL_FINDING_INDEX_PATTERN for bwc and when these 2 parameters are not passed
+        } else {
+            indexName = ALL_FINDING_INDEX_PATTERN
+        }
+        return indexName
+    }
+
+    suspend fun search(searchSourceBuilder: SearchSourceBuilder, indexName: String): GetFindingsResponse {
         val searchRequest = SearchRequest()
             .source(searchSourceBuilder)
-            .indices(ALL_FINDING_INDEX_PATTERN)
+            .indices(indexName)
         val searchResponse: SearchResponse = client.suspendUntil { client.search(searchRequest, it) }
         val totalFindingCount = searchResponse.hits.totalHits?.value?.toInt()
         val mgetRequest = MultiGetRequest()

--- a/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
@@ -165,6 +165,57 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
         assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("1"))
     }
 
+    fun `test execute monitor with custom findings index and GetFindingsAction`() {
+        val docQuery = DocLevelQuery(query = "test_field:\"us-west-2\"", name = "3")
+        val docLevelInput = DocLevelMonitorInput("description", listOf(index), listOf(docQuery))
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val customFindingsIndex = "custom_findings_index"
+        var monitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger),
+            dataSources = DataSources(findingsIndex = customFindingsIndex)
+        )
+        val monitorResponse = createMonitor(monitor)
+        val testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now().truncatedTo(MILLIS))
+        val testDoc = """{
+            "message" : "This is an error from IAD region",
+            "test_strict_date_time" : "$testTime",
+            "test_field" : "us-west-2"
+        }"""
+        assertFalse(monitorResponse?.id.isNullOrEmpty())
+        monitor = monitorResponse!!.monitor
+        indexDoc(index, "1", testDoc)
+        val monitorId = monitorResponse.id
+        val executeMonitorResponse = executeMonitor(monitor, monitorId, false)
+        Assert.assertEquals(executeMonitorResponse!!.monitorRunResult.monitorName, monitor.name)
+        Assert.assertEquals(executeMonitorResponse.monitorRunResult.triggerResults.size, 1)
+        searchAlerts(monitorId)
+        val findings = searchFindings(monitorId, customFindingsIndex)
+        assertEquals("Findings saved for test monitor", 1, findings.size)
+        assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("1"))
+        // fetch findings - pass monitorId as reference to finding_index
+        val findingsFromAPI1 = getFindings(findings.get(0).id, monitorId, null)
+        assertEquals(
+            "Findings mismatch between manually searched and fetched via GetFindingsAction",
+            findings.get(0).id,
+            findingsFromAPI1.get(0).id
+        )
+        // fetch findings - pass both monitorId and findingIndexName name. Monitor id should be ignored
+        val findingsFromAPI2 = getFindings(findings.get(0).id, "incorrect_monitor_id", customFindingsIndex)
+        assertEquals(
+            "Findings mismatch between manually searched and fetched via GetFindingsAction",
+            findings.get(0).id,
+            findingsFromAPI2.get(0).id
+        )
+        // fetch findings - don't send monitorId or findingIndexName. It should fall back to hardcoded finding index name
+        val findingsFromAPI3 = getFindings(findings.get(0).id, null, null)
+        assertEquals(
+            "Unexpected result when fetching findings from default finding index",
+            0,
+            findingsFromAPI3.size
+        )
+    }
+
     fun `test execute pre-existing monitorand update`() {
         val request = CreateIndexRequest(SCHEDULED_JOBS_INDEX).mapping(ScheduledJobIndices.scheduledJobMappings())
             .settings(Settings.builder().put("index.hidden", true).build())

--- a/alerting/src/test/kotlin/org/opensearch/alerting/TriggerServiceTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/TriggerServiceTests.kt
@@ -37,9 +37,19 @@ class TriggerServiceTests : OpenSearchTestCase() {
         val trigger = randomBucketLevelTrigger(bucketSelector = bucketSelectorExtAggregationBuilder)
         val monitor = randomBucketLevelMonitor(triggers = listOf(trigger))
 
-        val inputResultsStr = "{\"_shards\":{\"total\":1,\"failed\":0,\"successful\":1,\"skipped\":0},\"hits\":{\"hits\":[{\"_index\":\"sample-http-responses\",\"_type\":\"http\",\"_source\":{\"status_code\":100,\"http_4xx\":0,\"http_3xx\":0,\"http_5xx\":0,\"http_2xx\":0,\"timestamp\":100000,\"http_1xx\":1},\"_id\":1,\"_score\":1}],\"total\":{\"value\":4,\"relation\":\"eq\"},\"max_score\":1},\"took\":37,\"timed_out\":false,\"aggregations\":{\"status_code\":{\"doc_count_error_upper_bound\":0,\"sum_other_doc_count\":0,\"buckets\":[{\"doc_count\":2,\"key\":100},{\"doc_count\":1,\"key\":102},{\"doc_count\":1,\"key\":201}]},\"${trigger.id}\":{\"parent_bucket_path\":\"status_code\",\"bucket_indices\":[0,1,2]}}}"
+        val inputResultsStr = "{\"_shards\":" +
+            "{\"total\":1,\"failed\":0,\"successful\":1,\"skipped\":0},\"hits\":{\"hits\":" +
+            "[{\"_index\":\"sample-http-responses\",\"_type\":\"http\",\"_source\":" +
+            "{\"status_code\":100,\"http_4xx\":0,\"http_3xx\":0,\"http_5xx\":0,\"http_2xx\":0," +
+            "\"timestamp\":100000,\"http_1xx\":1},\"_id\":1,\"_score\":1}],\"total\":{\"value\":4,\"relation\":\"eq\"}," +
+            "\"max_score\":1},\"took\":37,\"timed_out\":false,\"aggregations\":{\"status_code\":" +
+            "{\"doc_count_error_upper_bound\":0,\"sum_other_doc_count\":0,\"buckets\":[{\"doc_count\":2,\"key\":100}," +
+            "{\"doc_count\":1,\"key\":102},{\"doc_count\":1,\"key\":201}]},\"${trigger.id}\":{\"parent_bucket_path\":" +
+            "\"status_code\",\"bucket_indices\":[0,1,2]}}}"
 
-        val parser = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, inputResultsStr)
+        val parser = XContentType.JSON.xContent().createParser(
+            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, inputResultsStr
+        )
 
         val inputResults = parser.map()
 
@@ -60,9 +70,23 @@ class TriggerServiceTests : OpenSearchTestCase() {
         val trigger = randomBucketLevelTrigger(bucketSelector = bucketSelectorExtAggregationBuilder)
         val monitor = randomBucketLevelMonitor(triggers = listOf(trigger))
 
-        val inputResultsStr = "{\"_shards\":{\"total\":1, \"failed\":0, \"successful\":1, \"skipped\":0}, \"hits\":{\"hits\":[{\"_index\":\"sample-http-responses\", \"_type\":\"http\", \"_source\":{\"status_code\":100, \"http_4xx\":0, \"http_3xx\":0, \"http_5xx\":0, \"http_2xx\":0, \"timestamp\":100000, \"http_1xx\":1}, \"_id\":1, \"_score\":1.0}, {\"_index\":\"sample-http-responses\", \"_type\":\"http\", \"_source\":{\"status_code\":102, \"http_4xx\":0, \"http_3xx\":0, \"http_5xx\":0, \"http_2xx\":0, \"timestamp\":160000, \"http_1xx\":1}, \"_id\":2, \"_score\":1.0}, {\"_index\":\"sample-http-responses\", \"_type\":\"http\", \"_source\":{\"status_code\":100, \"http_4xx\":0, \"http_3xx\":0, \"http_5xx\":0, \"http_2xx\":0, \"timestamp\":220000, \"http_1xx\":1}, \"_id\":4, \"_score\":1.0}, {\"_index\":\"sample-http-responses\", \"_type\":\"http\", \"_source\":{\"status_code\":201, \"http_4xx\":0, \"http_3xx\":0, \"http_5xx\":0, \"http_2xx\":1, \"timestamp\":280000, \"http_1xx\":0}, \"_id\":5, \"_score\":1.0}], \"total\":{\"value\":4, \"relation\":\"eq\"}, \"max_score\":1.0}, \"took\":15, \"timed_out\":false, \"aggregations\":{\"${trigger.id}\":{\"parent_bucket_path\":\"status_code\", \"bucket_indices\":[0, 1, 2]}, \"status_code\":{\"buckets\":[{\"doc_count\":2, \"key\":{\"status_code\":100}}, {\"doc_count\":1, \"key\":{\"status_code\":102}}, {\"doc_count\":1, \"key\":{\"status_code\":201}}], \"after_key\":{\"status_code\":201}}}}"
+        val inputResultsStr = "{\"_shards\":{\"total\":1, \"failed\":0, \"successful\":1, \"skipped\":0}, \"hits\":{\"hits\":" +
+            "[{\"_index\":\"sample-http-responses\", \"_type\":\"http\", \"_source\":{\"status_code\":100, \"http_4xx\":0," +
+            " \"http_3xx\":0, \"http_5xx\":0, \"http_2xx\":0, \"timestamp\":100000, \"http_1xx\":1}, \"_id\":1, \"_score\":1.0}, " +
+            "{\"_index\":\"sample-http-responses\", \"_type\":\"http\", \"_source\":{\"status_code\":102, \"http_4xx\":0, " +
+            "\"http_3xx\":0, \"http_5xx\":0, \"http_2xx\":0, \"timestamp\":160000, \"http_1xx\":1}, \"_id\":2, \"_score\":1.0}, " +
+            "{\"_index\":\"sample-http-responses\", \"_type\":\"http\", \"_source\":{\"status_code\":100, \"http_4xx\":0, " +
+            "\"http_3xx\":0, \"http_5xx\":0, \"http_2xx\":0, \"timestamp\":220000, \"http_1xx\":1}, \"_id\":4, \"_score\":1.0}, " +
+            "{\"_index\":\"sample-http-responses\", \"_type\":\"http\", \"_source\":{\"status_code\":201, \"http_4xx\":0, " +
+            "\"http_3xx\":0, \"http_5xx\":0, \"http_2xx\":1, \"timestamp\":280000, \"http_1xx\":0}, \"_id\":5, \"_score\":1.0}]," +
+            " \"total\":{\"value\":4, \"relation\":\"eq\"}, \"max_score\":1.0}, \"took\":15, \"timed_out\":false, \"aggregations\":" +
+            "{\"${trigger.id}\":{\"parent_bucket_path\":\"status_code\", \"bucket_indices\":[0, 1, 2]}, \"status_code\":{\"buckets\":" +
+            "[{\"doc_count\":2, \"key\":{\"status_code\":100}}, {\"doc_count\":1, \"key\":{\"status_code\":102}}, {\"doc_count\":1," +
+            " \"key\":{\"status_code\":201}}], \"after_key\":{\"status_code\":201}}}}"
 
-        val parser = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, inputResultsStr)
+        val parser = XContentType.JSON.xContent().createParser(
+            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, inputResultsStr
+        )
 
         val inputResults = parser.map()
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/action/GetFindingsRequestTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/action/GetFindingsRequestTests.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.action
+
+import org.opensearch.alerting.model.Table
+import org.opensearch.common.io.stream.BytesStreamOutput
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.test.OpenSearchTestCase
+
+class GetFindingsRequestTests : OpenSearchTestCase() {
+
+    fun `test get findings request`() {
+
+        val table = Table("asc", "sortString", null, 1, 0, "")
+
+        val req = GetFindingsRequest("2121", table, "1", "finding_index_name")
+        assertNotNull(req)
+
+        val out = BytesStreamOutput()
+        req.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val newReq = GetFindingsRequest(sin)
+
+        assertEquals("1", newReq.monitorId)
+        assertEquals("2121", newReq.findingId)
+        assertEquals("finding_index_name", newReq.findingIndexName)
+        assertEquals(table, newReq.table)
+    }
+
+    fun `test validate returns null`() {
+        val table = Table("asc", "sortString", null, 1, 0, "")
+
+        val req = GetFindingsRequest("2121", table, "1", "active")
+        assertNotNull(req)
+        assertNull(req.validate())
+    }
+}

--- a/alerting/src/test/kotlin/org/opensearch/alerting/action/GetFindingsRequestTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/action/GetFindingsRequestTests.kt
@@ -26,7 +26,7 @@ class GetFindingsRequestTests : OpenSearchTestCase() {
 
         assertEquals("1", newReq.monitorId)
         assertEquals("2121", newReq.findingId)
-        assertEquals("finding_index_name", newReq.findingIndexName)
+        assertEquals("finding_index_name", newReq.findingIndex)
         assertEquals(table, newReq.table)
     }
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/AlertingSingleNodeTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/AlertingSingleNodeTestCase.kt
@@ -13,6 +13,9 @@ import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.action.ExecuteMonitorAction
 import org.opensearch.alerting.action.ExecuteMonitorRequest
 import org.opensearch.alerting.action.ExecuteMonitorResponse
+import org.opensearch.alerting.action.GetFindingsAction
+import org.opensearch.alerting.action.GetFindingsRequest
+import org.opensearch.alerting.action.GetFindingsResponse
 import org.opensearch.alerting.action.GetMonitorAction
 import org.opensearch.alerting.action.GetMonitorRequest
 import org.opensearch.alerting.action.IndexMonitorAction
@@ -22,6 +25,7 @@ import org.opensearch.alerting.alerts.AlertIndices
 import org.opensearch.alerting.model.Alert
 import org.opensearch.alerting.model.Finding
 import org.opensearch.alerting.model.Monitor
+import org.opensearch.alerting.model.Table
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.xcontent.XContentType
@@ -136,6 +140,23 @@ abstract class AlertingSingleNodeTestCase : OpenSearchSingleNodeTestCase() {
             val xcp = createParser(JsonXContent.jsonXContent, it.sourceRef).also { it.nextToken() }
             Finding.parse(xcp)
         }.filter { finding -> finding.monitorId == id }
+    }
+
+    protected fun getFindings(
+        findingId: String,
+        monitorId: String?,
+        findingIndexName: String?,
+    ): List<Finding> {
+
+        val getFindingsRequest = GetFindingsRequest(
+            findingId,
+            Table("asc", "monitor_id", null, 100, 0, null),
+            monitorId,
+            findingIndexName
+        )
+        val getFindingsResponse: GetFindingsResponse = client().execute(GetFindingsAction.INSTANCE, getFindingsRequest).get()
+
+        return getFindingsResponse.findings.map { it.finding }.toList()
     }
 
     protected fun getMonitorResponse(


### PR DESCRIPTION
Signed-off-by: Petar Dzepina <petar.dzepina@vroom.com>

*Issue #, if available:*

*Description of changes:*
Added **_monitorId_** and **_findingsIndexName_** optinal params to GetFindings Action. These will be used to reference finding index, instead of default hardcoded one. **_findingsIndexName_** has higher priority over _**monitorId**_

*CheckList:*
[ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).