### PR TITLE
Use custom query index in update monitor flow

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -536,7 +536,7 @@ class TransportIndexMonitorAction @Inject constructor(
                 if (currentMonitor.monitorType == Monitor.MonitorType.DOC_LEVEL_MONITOR) {
                     client.suspendUntil<Client, BulkByScrollResponse> {
                         DeleteByQueryRequestBuilder(client, DeleteByQueryAction.INSTANCE)
-                            .source(ScheduledJob.DOC_LEVEL_QUERIES_INDEX)
+                            .source(request.monitor.dataSources.queryIndex)
                             .filter(QueryBuilders.matchQuery("monitor_id", currentMonitor.id))
                             .execute(it)
                     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -536,7 +536,7 @@ class TransportIndexMonitorAction @Inject constructor(
                 if (currentMonitor.monitorType == Monitor.MonitorType.DOC_LEVEL_MONITOR) {
                     client.suspendUntil<Client, BulkByScrollResponse> {
                         DeleteByQueryRequestBuilder(client, DeleteByQueryAction.INSTANCE)
-                            .source(request.monitor.dataSources.queryIndex)
+                            .source(currentMonitor.dataSources.queryIndex)
                             .filter(QueryBuilders.matchQuery("monitor_id", currentMonitor.id))
                             .execute(it)
                     }


### PR DESCRIPTION
When updating a monitor with new custom query index (possibly) we need to delete queries from the monitor's current query index

Signed-off-by: Surya Sashank Nistala <snistala@amazon.com>