### PR TITLE
Bumps alerting to 2.4

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     implementation "com.github.seancfoley:ipaddress:5.3.3"
 
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
-    testImplementation "org.mockito:mockito-core:4.6.1"
+    testImplementation "org.mockito:mockito-core:4.7.0"
     testImplementation "org.opensearch.plugin:reindex-client:${opensearch_version}"
 }
 

--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -258,7 +258,7 @@ String bwcRemoteFile = 'https://ci.opensearch.org/ci/dbc/bundle-build/1.1.0/2021
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-            versions = ["1.1.0", "2.2.0-SNAPSHOT"]
+            versions = ["1.1.0", "2.4.0-SNAPSHOT"]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>(){
                 @Override

--- a/build.gradle
+++ b/build.gradle
@@ -7,10 +7,10 @@ buildscript {
     apply from: 'build-tools/repositories.gradle'
 
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.2.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.4.0-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        // 2.2.0-SNAPSHOT -> 2.2.0.0-SNAPSHOT
+        // 2.4.0-SNAPSHOT -> 2.4.0.0-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'
         plugin_no_snapshot = opensearch_build


### PR DESCRIPTION
Bumps alerting to 2.4
This PR also bumps org.mockito:mockito-core dependency  to 4.7.0

Signed-off-by: Surya Sashank Nistala <snistala@amazon.com>