### PR TITLE
Fix Acknowledge Alert Request class loader issue

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.launch
 import org.apache.logging.log4j.LogManager
 import org.opensearch.ResourceNotFoundException
 import org.opensearch.action.ActionListener
+import org.opensearch.action.ActionRequest
 import org.opensearch.action.bulk.BulkRequest
 import org.opensearch.action.bulk.BulkResponse
 import org.opensearch.action.delete.DeleteRequest
@@ -65,7 +66,7 @@ class TransportAcknowledgeAlertAction @Inject constructor(
     val settings: Settings,
     val xContentRegistry: NamedXContentRegistry,
     val transportGetMonitorAction: TransportGetMonitorAction
-) : HandledTransportAction<AcknowledgeAlertRequest, AcknowledgeAlertResponse>(
+) : HandledTransportAction<ActionRequest, AcknowledgeAlertResponse>(
     AlertingActions.ACKNOWLEDGE_ALERTS_ACTION_NAME, transportService, actionFilters, ::AcknowledgeAlertRequest
 ) {
 
@@ -78,7 +79,7 @@ class TransportAcknowledgeAlertAction @Inject constructor(
 
     override fun doExecute(
         task: Task,
-        acknowledgeAlertRequest: AcknowledgeAlertRequest,
+        acknowledgeAlertRequest: ActionRequest,
         actionListener: ActionListener<AcknowledgeAlertResponse>
     ) {
         val request = acknowledgeAlertRequest as? AcknowledgeAlertRequest


### PR DESCRIPTION
Change transport ack alerts action to accept Action Request and recreate as AckAlertRequest to fix Acknowledge Alert Request class loader issue

Solving the same issue we faced earlier with notifications for ack alerts flow : https://github.com/opensearch-project/common-utils/issues/37

Signed-off-by: Surya Sashank Nistala <snistala@amazon.com>