### PR TITLE
Ack alerts - allow moving alerts to history index with custom datasources

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
@@ -24,7 +24,6 @@ import org.opensearch.action.update.UpdateRequest
 import org.opensearch.alerting.action.GetMonitorAction
 import org.opensearch.alerting.action.GetMonitorRequest
 import org.opensearch.alerting.action.GetMonitorResponse
-import org.opensearch.alerting.alerts.AlertIndices
 import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.util.AlertingException
@@ -161,7 +160,6 @@ class TransportAcknowledgeAlertAction @Inject constructor(
 
                 if (alert.state == Alert.State.ACTIVE) {
                     if (
-                        monitor.dataSources.alertsIndex != AlertIndices.ALERT_INDEX ||
                         alert.findingIds.isEmpty() ||
                         !isAlertHistoryEnabled
                     ) {


### PR DESCRIPTION
Signed-off-by: Petar Dzepina <petar.dzepina@gmail.com>

*Issue #, if available:*

*Description of changes:*
Ack alerts - allow moving alerts to history index with custom datasources

*CheckList:*
[ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).