### PR TITLE
Support to specify backend roles for monitors

### DIFF
--- a/.github/workflows/security-test-workflow.yml
+++ b/.github/workflows/security-test-workflow.yml
@@ -43,7 +43,12 @@ jobs:
           plugin_version=`echo $plugin|awk -F- '{print $3}'| cut -d. -f 1-4`
           qualifier=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-1`
           candidate_version=`echo $plugin|awk -F- '{print $5}'| cut -d. -f 1-1`
-          docker_version=$version
+          if qualifier
+          then
+            docker_version=$version-$qualifier
+          else
+            docker_version=$version
+          fi
 
           [[ -z $candidate_version ]] && candidate_version=$qualifier && qualifier=""
 

--- a/.github/workflows/security-test-workflow.yml
+++ b/.github/workflows/security-test-workflow.yml
@@ -43,7 +43,7 @@ jobs:
           plugin_version=`echo $plugin|awk -F- '{print $3}'| cut -d. -f 1-4`
           qualifier=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-1`
           candidate_version=`echo $plugin|awk -F- '{print $5}'| cut -d. -f 1-1`
-          docker_version=$version-$qualifier
+          docker_version=$version
 
           [[ -z $candidate_version ]] && candidate_version=$qualifier && qualifier=""
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt
@@ -84,6 +84,8 @@ class RestIndexMonitorAction : BaseRestHandler() {
         val xcp = request.contentParser()
         ensureExpectedToken(Token.START_OBJECT, xcp.nextToken(), xcp)
         val monitor = Monitor.parse(xcp, id).copy(lastUpdateTime = Instant.now())
+        val rbacRoles = request.contentParser().map()["rbac_roles"] as List<String>?
+
         validateDataSources(monitor)
         val monitorType = monitor.monitorType
         val triggers = monitor.triggers
@@ -117,7 +119,7 @@ class RestIndexMonitorAction : BaseRestHandler() {
         } else {
             WriteRequest.RefreshPolicy.IMMEDIATE
         }
-        val indexMonitorRequest = IndexMonitorRequest(id, seqNo, primaryTerm, refreshPolicy, request.method(), monitor)
+        val indexMonitorRequest = IndexMonitorRequest(id, seqNo, primaryTerm, refreshPolicy, request.method(), monitor, rbacRoles)
 
         return RestChannelConsumer { channel ->
             client.execute(AlertingActions.INDEX_MONITOR_ACTION_TYPE, indexMonitorRequest, indexMonitorResponse(channel, request.method()))

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
@@ -61,7 +61,7 @@ interface SecureTransportAction {
     /**
      *  'all_access' role users are treated as admins.
      */
-    private fun isAdmin(user: User?): Boolean {
+    fun isAdmin(user: User?): Boolean {
         return when {
             user == null -> {
                 false

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AccessRoles.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AccessRoles.kt
@@ -6,6 +6,7 @@
 package org.opensearch.alerting
 
 val ALL_ACCESS_ROLE = "all_access"
+val READALL_AND_MONITOR_ROLE = "readall_and_monitor"
 val ALERTING_FULL_ACCESS_ROLE = "alerting_full_access"
 val ALERTING_READ_ONLY_ACCESS = "alerting_read_access"
 val ALERTING_NO_ACCESS_ROLE = "no_access"

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
@@ -106,8 +106,8 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         return entityAsMap(this)
     }
 
-    private fun createMonitorEntityWithBackendRoles(monitor: Monitor, rbacRoles: List<String>): HttpEntity {
-        if (rbacRoles.isNullOrEmpty()) {
+    private fun createMonitorEntityWithBackendRoles(monitor: Monitor, rbacRoles: List<String>?): HttpEntity {
+        if (rbacRoles == null) {
             return monitor.toHttpEntity()
         }
         val temp = monitor.toJsonString()
@@ -120,7 +120,7 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
     protected fun createMonitorWithClient(
         client: RestClient,
         monitor: Monitor,
-        rbacRoles: List<String> = emptyList(),
+        rbacRoles: List<String>? = null,
         refresh: Boolean = true
     ): Monitor {
         val response = client.makeRequest(

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
@@ -106,10 +106,26 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         return entityAsMap(this)
     }
 
-    protected fun createMonitorWithClient(client: RestClient, monitor: Monitor, refresh: Boolean = true): Monitor {
+    private fun createMonitorEntityWithBackendRoles(monitor: Monitor, rbacRoles: List<String>): HttpEntity {
+        if (rbacRoles.isNullOrEmpty()) {
+            return monitor.toHttpEntity()
+        }
+        val temp = monitor.toJsonString()
+        val toReplace = temp.lastIndexOf("}")
+        val rbacString = rbacRoles.joinToString { "\"$it\"" }
+        val jsonString = temp.substring(0, toReplace) + ", \"rbac_roles\": [$rbacString] }"
+        return StringEntity(jsonString, APPLICATION_JSON)
+    }
+
+    protected fun createMonitorWithClient(
+        client: RestClient,
+        monitor: Monitor,
+        rbacRoles: List<String> = emptyList(),
+        refresh: Boolean = true
+    ): Monitor {
         val response = client.makeRequest(
             "POST", "$ALERTING_BASE_URI?refresh=$refresh", emptyMap(),
-            monitor.toHttpEntity()
+            createMonitorEntityWithBackendRoles(monitor, rbacRoles)
         )
         assertEquals("Unable to create a new monitor", RestStatus.CREATED, response.restStatus())
 
@@ -123,7 +139,7 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
     }
 
     protected fun createMonitor(monitor: Monitor, refresh: Boolean = true): Monitor {
-        return createMonitorWithClient(client(), monitor, refresh)
+        return createMonitorWithClient(client(), monitor, emptyList(), refresh)
     }
 
     protected fun deleteMonitor(monitor: Monitor, refresh: Boolean = true): Response {
@@ -493,6 +509,21 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         val response = client().makeRequest(
             "PUT", "${monitor.relativeUrl()}?refresh=$refresh",
             emptyMap(), monitor.toHttpEntity()
+        )
+        assertEquals("Unable to update a monitor", RestStatus.OK, response.restStatus())
+        assertUserNull(response.asMap()["monitor"] as Map<String, Any>)
+        return getMonitor(monitorId = monitor.id)
+    }
+
+    protected fun updateMonitorWithClient(
+        client: RestClient,
+        monitor: Monitor,
+        rbacRoles: List<String> = emptyList(),
+        refresh: Boolean = true
+    ): Monitor {
+        val response = client.makeRequest(
+            "PUT", "${monitor.relativeUrl()}?refresh=$refresh",
+            emptyMap(), createMonitorEntityWithBackendRoles(monitor, rbacRoles)
         )
         assertEquals("Unable to update a monitor", RestStatus.OK, response.restStatus())
         assertUserNull(response.asMap()["monitor"] as Map<String, Any>)
@@ -1089,6 +1120,18 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         client().performRequest(request)
     }
 
+    fun patchUserBackendRoles(name: String, backendRoles: Array<String>) {
+        val request = Request("PATCH", "/_plugins/_security/api/internalusers/$name")
+        val broles = backendRoles.joinToString { "\"$it\"" }
+        var entity = " [{\n" +
+            "\"op\": \"replace\",\n" +
+            "\"path\": \"/backend_roles\",\n" +
+            "\"value\": [$broles]\n" +
+            "}]"
+        request.setJsonEntity(entity)
+        client().performRequest(request)
+    }
+
     fun createIndexRole(name: String, index: String) {
         val request = Request("PUT", "/_plugins/_security/api/roles/$name")
         var entity = "{\n" +
@@ -1174,6 +1217,22 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         client().performRequest(request)
     }
 
+    fun updateRoleMapping(role: String, users: List<String>, addUser: Boolean) {
+        val request = Request("PATCH", "/_plugins/_security/api/rolesmapping/$role")
+        val usersStr = users.joinToString { it -> "\"$it\"" }
+
+        val op = if (addUser) "add" else "remove"
+
+        val entity = "[{\n" +
+            "  \"op\" : \"$op\",\n" +
+            "  \"path\" : \"/users\",\n" +
+            "  \"value\" : [$usersStr]\n" +
+            "}]"
+
+        request.setJsonEntity(entity)
+        client().performRequest(request)
+    }
+
     fun deleteUser(name: String) {
         client().makeRequest("DELETE", "/_plugins/_security/api/internalusers/$name")
     }
@@ -1202,13 +1261,29 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         user: String,
         index: String,
         role: String,
-        backendRole: String,
+        backendRoles: List<String>,
         clusterPermissions: String?
     ) {
-        createUser(user, user, arrayOf(backendRole))
+        createUser(user, user, backendRoles.toTypedArray())
         createTestIndex(index)
         createCustomIndexRole(role, index, clusterPermissions)
         createUserRolesMapping(role, arrayOf(user))
+    }
+
+    fun createUserWithRoles(
+        user: String,
+        roles: List<String>,
+        backendRoles: List<String>,
+        isExistingRole: Boolean
+    ) {
+        createUser(user, user, backendRoles.toTypedArray())
+        for (role in roles) {
+            if (isExistingRole) {
+                updateRoleMapping(role, listOf(user), true)
+            } else {
+                createUserRolesMapping(role, arrayOf(user))
+            }
+        }
     }
 
     fun createUserWithDocLevelSecurityTestData(

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureDestinationRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureDestinationRestApiIT.kt
@@ -139,7 +139,7 @@ class SecureDestinationRestApiIT : AlertingRestTestCase() {
             user,
             TEST_HR_INDEX,
             TEST_HR_ROLE,
-            TEST_HR_BACKEND_ROLE,
+            listOf(TEST_HR_BACKEND_ROLE),
             getClusterPermissionsFromCustomRole(ALERTING_GET_DESTINATION_ACCESS)
         )
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureEmailAccountRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureEmailAccountRestApiIT.kt
@@ -76,7 +76,7 @@ class SecureEmailAccountRestApiIT : AlertingRestTestCase() {
             user,
             TEST_HR_INDEX,
             TEST_HR_ROLE,
-            TEST_HR_BACKEND_ROLE,
+            listOf(TEST_HR_BACKEND_ROLE),
             getClusterPermissionsFromCustomRole(ALERTING_GET_EMAIL_ACCOUNT_ACCESS)
         )
 
@@ -105,7 +105,7 @@ class SecureEmailAccountRestApiIT : AlertingRestTestCase() {
             user,
             TEST_HR_INDEX,
             TEST_HR_ROLE,
-            TEST_HR_BACKEND_ROLE,
+            listOf(TEST_HR_BACKEND_ROLE),
             getClusterPermissionsFromCustomRole(ALERTING_SEARCH_EMAIL_ACCOUNT_ACCESS)
         )
 
@@ -132,7 +132,7 @@ class SecureEmailAccountRestApiIT : AlertingRestTestCase() {
             user,
             TEST_HR_INDEX,
             TEST_HR_ROLE,
-            TEST_HR_BACKEND_ROLE,
+            listOf(TEST_HR_BACKEND_ROLE),
             getClusterPermissionsFromCustomRole(ALERTING_NO_ACCESS_ROLE)
         )
 
@@ -162,7 +162,7 @@ class SecureEmailAccountRestApiIT : AlertingRestTestCase() {
             user,
             TEST_HR_INDEX,
             TEST_HR_ROLE,
-            TEST_HR_BACKEND_ROLE,
+            listOf(TEST_HR_BACKEND_ROLE),
             getClusterPermissionsFromCustomRole(ALERTING_NO_ACCESS_ROLE)
         )
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureEmailGroupsRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureEmailGroupsRestApiIT.kt
@@ -78,7 +78,7 @@ class SecureEmailGroupsRestApiIT : AlertingRestTestCase() {
             user,
             TEST_HR_INDEX,
             TEST_HR_ROLE,
-            TEST_HR_BACKEND_ROLE,
+            listOf(TEST_HR_BACKEND_ROLE),
             getClusterPermissionsFromCustomRole(ALERTING_GET_EMAIL_GROUP_ACCESS)
         )
 
@@ -105,7 +105,7 @@ class SecureEmailGroupsRestApiIT : AlertingRestTestCase() {
             user,
             TEST_HR_INDEX,
             TEST_HR_ROLE,
-            TEST_HR_BACKEND_ROLE,
+            listOf(TEST_HR_BACKEND_ROLE),
             getClusterPermissionsFromCustomRole(ALERTING_SEARCH_EMAIL_GROUP_ACCESS)
         )
 


### PR DESCRIPTION
Signed-off-by: Ashish Agrawal <ashisagr@amazon.com>

*Issue #, if available:*
#138 

*Description of changes:*
Support specify backend roles for monitors
New Scenarios:
- Create monitor scenario:
  - User specified backend roles
    - Admin user: use all the specified backend roles to associate to the monitor
    - Normal user: use all the specified backend roles (that the user already has in their list of backend roles) to associate to the monitor
  - User did not specify backend roles:
    - Copy user’s backend roles and associate them to the monitor
 

- Update monitor scenario:
  - User specified backend roles
    - Admin user: Remove all the backend roles associate to the monitor and then use all the specified backend roles to associate to the monitor
    - Normal user: Remove backend roles associated to the monitor that the user has access to, but didn’t specify. Then add all the other specified backend roles (that the user already has in their list of backend roles) to the monitor
  - User did not specify backend roles:
    - Don’t update the backend roles on the monitor

- Empty list is considered as removing all permissions the user has access to or create a monitor with no backend roles
- Throw exceptions if a user tries to associate roles that they do not have access to
- Only admin users can pass in an empty list. Non-admin users need to pass in at least 1 backend role so they dont remove their access from the monitor for mistakes

Example of new create/update monitor request (**`rbac_roles`** is the new optional parameter):
```
POST _plugins/_alerting/monitors
{
  "type": "monitor",
  "name": "test-monitor",
  "monitor_type": "query_level_monitor",
  "enabled": true,
  "schedule": {
    "period": {
      "interval": 1,
      "unit": "MINUTES"
    }
  },
  "inputs": [{
    "search": {
      "indices": ["movies"],
      "query": {
        "size": 0,
        "aggregations": {},
        "query": {
          "bool": {
            "filter": {
              "range": {
                "@timestamp": {
                  "gte": "{{period_end}}||-1h",
                  "lte": "{{period_end}}",
                  "format": "epoch_millis"
                }
              }
            }
          }
        }
      }
    }
  }],
  "triggers": [{
    "name": "test-trigger",
    "severity": "1",
    "condition": {
      "script": {
        "source": "ctx.results[0].hits.total.value > 0",
        "lang": "painless"
      }
    },
    "actions": [{
      "name": "test-action",
      "destination_id": "ld7912sBlQ5JUWWFThoW",
      "message_template": {
        "source": "This is my message body."
      },
      "throttle_enabled": true,
      "throttle": {
        "value": 27,
        "unit": "MINUTES"
      },
      "subject_template": {
        "source": "TheSubject"
      }
    }]
  }],
  "rbac_roles": ["role1", "role2"]
}
```

*CheckList:*
[X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).