### PR TITLE
Added exception check once the .opendistro-alerting-config index is b…

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -312,9 +312,13 @@ class TransportIndexMonitorAction @Inject constructor(
                                 val request = ClusterHealthRequest()
                                     .indices(SCHEDULED_JOBS_INDEX)
                                     .waitForYellowStatus()
-                                val response: ClusterHealthResponse = client.suspendUntil { execute(ClusterHealthAction.INSTANCE, request, it) }
+                                val response: ClusterHealthResponse = client.suspendUntil {
+                                    execute(ClusterHealthAction.INSTANCE, request, it)
+                                }
                                 if (response.isTimedOut) {
-                                    actionListener.onFailure(OpenSearchException("Cannot determine that the $SCHEDULED_JOBS_INDEX index is healthy"))
+                                    actionListener.onFailure(
+                                        OpenSearchException("Cannot determine that the $SCHEDULED_JOBS_INDEX index is healthy")
+                                    )
                                 }
                                 // Retry mapping of monitor
                                 onCreateMappingsResponse(true)


### PR DESCRIPTION
…eing created

During .opendistro-alerting-config index creation, if ResourceAlreadyExists exception is being raised, the flow will check first if the index is in yellow state and then it will re-try to index monitor

Signed-off-by: Stevan Buzejic <buzejic.stevan@gmail.com>

*Issue #, if available:*
https://github.com/opensearch-project/alerting/issues/646

*Description of changes:*
Added ResourceAlreadyExists error handling during the .opendistro-alerting-config index creation. If the previously mentioned exception is raised, the flow will check if the cluster for the given index is in yellow state and then will try to prepare monitor for indexing.

*CheckList:*
[ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).