### PR TITLE
Set message when building LegacyCustomWebhookMessage

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/destination/Destination.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/destination/Destination.kt
@@ -260,7 +260,7 @@ data class Destination(
             }
             DestinationType.CUSTOM_WEBHOOK -> {
                 destinationMessage = LegacyCustomWebhookMessage.Builder(name)
-                    .withUrl(getLegacyCustomWebhookMessageURL(customWebhook))
+                    .withUrl(getLegacyCustomWebhookMessageURL(customWebhook, compiledMessage))
                     .withHeaderParams(customWebhook?.headerParams)
                     .withMessage(compiledMessage).build()
             }
@@ -296,7 +296,7 @@ data class Destination(
         return content
     }
 
-    private fun getLegacyCustomWebhookMessageURL(customWebhook: CustomWebhook?): String {
+    private fun getLegacyCustomWebhookMessageURL(customWebhook: CustomWebhook?, message: String): String {
         return LegacyCustomWebhookMessage.Builder(name)
             .withUrl(customWebhook?.url)
             .withScheme(customWebhook?.scheme)
@@ -304,6 +304,7 @@ data class Destination(
             .withPort(customWebhook?.port)
             .withPath(customWebhook?.path)
             .withQueryParams(customWebhook?.queryParams)
+            .withMessage(message)
             .build().uri.toString()
     }
 }


### PR DESCRIPTION
Signed-off-by: Petar Partlov <partlov@gmail.com>

*Issue #, if available:*

*Description of changes:*
While testing legacy destinations for custom webhooks I discovered issue which is 100% reproducible. Scope should not be huge as this can influence only users with some issue during migration of old legacy notification system to new which uses notification plugin.

Issue is that one of required field (message) was not set during building instance of LegacyCustomWebhookMessage object.

*CheckList:*
[ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).