### PR TITLE
Return empty title for slack notifications

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/NotificationApiUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/NotificationApiUtils.kt
@@ -145,8 +145,9 @@ fun NotificationConfigInfo.getTitle(subject: String?): String {
     val defaultTitle = "Alerting-Notification Action"
     if (this.notificationConfig.configType == ConfigType.EMAIL) {
         return if (subject.isNullOrEmpty()) defaultTitle else subject
+    } else if (this.notificationConfig.configType == ConfigType.SLACK) {
+        return " "
     }
-
     return defaultTitle
 }
 


### PR DESCRIPTION
*Issue #, if available:* #529

*Description of changes:*
I managed to reproduce the issue and was able to remove the title by passing a blank space for cases of slack notifications.

*CheckList:*
[ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).