### PR TITLE
Fix error message bug to show the correct destination ID thats missing

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
@@ -90,7 +90,7 @@ abstract class MonitorRunner {
     ): String {
         val config = getConfigForNotificationAction(action, monitorCtx)
         if (config.destination == null && config.channel == null) {
-            throw IllegalStateException("Unable to find a Notification Channel or Destination config with id [${action.id}]")
+            throw IllegalStateException("Unable to find a Notification Channel or Destination config with id [${action.destinationId}]")
         }
 
         // Adding a check on TEST_ACTION Destination type here to avoid supporting it as a LegacyBaseMessage type


### PR DESCRIPTION
Signed-off-by: Ashish Agrawal <ashisagr@amazon.com>

*Issue #, if available:*
N/A

*Description of changes:*
When the destination or notification channel cannot be found, the error message shows the action Id instead of the destination/notification id.

*CheckList:*
[X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).