### PR TITLE
Seperate variables for alert and finding scheduled rollovers

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
@@ -162,7 +162,9 @@ class AlertIndices(
 
     private var alertIndexInitialized: Boolean = false
 
-    private var scheduledRollover: Cancellable? = null
+    private var scheduledAlertRollover: Cancellable? = null
+
+    private var scheduledFindingRollover: Cancellable? = null
 
     fun onMaster() {
         try {
@@ -170,9 +172,9 @@ class AlertIndices(
             rolloverAlertHistoryIndex()
             rolloverFindingHistoryIndex()
             // schedule the next rollover for approx MAX_AGE later
-            scheduledRollover = threadPool
+            scheduledAlertRollover = threadPool
                 .scheduleWithFixedDelay({ rolloverAndDeleteAlertHistoryIndices() }, alertHistoryRolloverPeriod, executorName())
-            scheduledRollover = threadPool
+            scheduledFindingRollover = threadPool
                 .scheduleWithFixedDelay({ rolloverAndDeleteFindingHistoryIndices() }, findingHistoryRolloverPeriod, executorName())
         } catch (e: Exception) {
             // This should be run on cluster startup
@@ -185,7 +187,8 @@ class AlertIndices(
     }
 
     fun offMaster() {
-        scheduledRollover?.cancel()
+        scheduledAlertRollover?.cancel()
+        scheduledFindingRollover?.cancel()
     }
 
     private fun executorName(): String {
@@ -213,16 +216,16 @@ class AlertIndices(
 
     private fun rescheduleAlertRollover() {
         if (clusterService.state().nodes.isLocalNodeElectedMaster) {
-            scheduledRollover?.cancel()
-            scheduledRollover = threadPool
+            scheduledAlertRollover?.cancel()
+            scheduledAlertRollover = threadPool
                 .scheduleWithFixedDelay({ rolloverAndDeleteAlertHistoryIndices() }, alertHistoryRolloverPeriod, executorName())
         }
     }
 
     private fun rescheduleFindingRollover() {
         if (clusterService.state().nodes.isLocalNodeElectedMaster) {
-            scheduledRollover?.cancel()
-            scheduledRollover = threadPool
+            scheduledFindingRollover?.cancel()
+            scheduledFindingRollover = threadPool
                 .scheduleWithFixedDelay({ rolloverAndDeleteFindingHistoryIndices() }, findingHistoryRolloverPeriod, executorName())
         }
     }


### PR DESCRIPTION
Signed-off-by: Ashish Agrawal <ashisagr@amazon.com>

*Issue #, if available:*
#703 
*Description of changes:*
Seperate variables for alert and finding scheduled rollovers to prevent both tasks to get cancelled

*CheckList:*
[X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).