### PR TITLE
fix  percolator mapping error when having field name 'type'

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -238,6 +238,7 @@ task integTestRemote(type: RestIntegTestTask) {
     if (System.getProperty("tests.rest.cluster") != null) {
         filter {
             includeTestsMatching "org.opensearch.alerting.resthandler.*IT"
+            includeTestsMatching "org.opensearch.alerting.MonitorDataSourcesIT"
         }
     }
 
@@ -248,192 +249,192 @@ task integTestRemote(type: RestIntegTestTask) {
     }
 }
 integTestRemote.enabled = System.getProperty("tests.rest.cluster") != null
-
-String bwcVersion = "1.1.0.0"
-String baseName = "alertingBwcCluster"
-String bwcFilePath = "src/test/resources/bwc"
-String bwcOpenSearchPlugin = "opensearch-alerting-" + bwcVersion + ".zip"
-String bwcRemoteFile = 'https://ci.opensearch.org/ci/dbc/bundle-build/1.1.0/20210930/linux/x64/builds/opensearch/plugins/' + bwcOpenSearchPlugin
-
-2.times {i ->
-    testClusters {
-        "${baseName}$i" {
-            testDistribution = "ARCHIVE"
-            versions = ["1.1.0", "2.4.0-SNAPSHOT"]
-            numberOfNodes = 3
-            plugin(provider(new Callable<RegularFile>(){
-                @Override
-                RegularFile call() throws Exception {
-                    return new RegularFile() {
-                        @Override
-                        File getAsFile() {
-                            File dir = new File(rootDir.path + "/alerting/" + bwcFilePath + "/alerting/" + bwcVersion)
-
-                            if (!dir.exists()) {
-                                dir.mkdirs()
-                            }
-                            File f = new File(dir, bwcOpenSearchPlugin)
-                            if (!f.exists()) {
-                                new URL(bwcRemoteFile).withInputStream{ ins -> f.withOutputStream{ it << ins }}
-                            }
-                            return fileTree(bwcFilePath + "/alerting/" + bwcVersion).getSingleFile()
-                        }
-                    }
-                }
-            }))
-            setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
-            setting 'http.content_type.required', 'true'
-        }
-    }
-}
-
-List<Provider<RegularFile>> plugins = []
-
-// Ensure the artifact for the current project version is available to be used for the bwc tests
-task prepareBwcTests {
-    dependsOn bundle
-    doLast {
-        plugins = [
-                project.getObjects().fileProperty().value(bundle.getArchiveFile()),
-                provider({
-                    new RegularFile() {
-                        @Override
-                        File getAsFile() {
-                            File dir = new File(rootDir.path + "/alerting/" + notificationsCoreFilePath)
-
-                            if (!dir.exists()) {
-                                dir.mkdirs()
-                            }
-
-                            File f = new File(dir, notificationsCorePlugin)
-                            if (!f.exists()) {
-                                new URL(notificationsCoreRemoteFile).withInputStream{ ins -> f.withOutputStream{ it << ins }}
-                            }
-                            fileTree(notificationsCoreFilePath).getSingleFile()
-                        }
-                    }
-                }),
-                provider({
-                    new RegularFile() {
-                        @Override
-                        File getAsFile() {
-                            File dir = new File(rootDir.path + "/alerting/" + notificationsFilePath)
-
-                            if (!dir.exists()) {
-                                dir.mkdirs()
-                            }
-
-                            File f = new File(dir, notificationsPlugin)
-                            if (!f.exists()) {
-                                new URL(notificationsRemoteFile).withInputStream{ ins -> f.withOutputStream{ it << ins }}
-                            }
-                            fileTree(notificationsFilePath).getSingleFile()
-                        }
-                    }
-                })
-        ]
-    }
-}
-
-// Create two test clusters with 3 nodes of the old version
-2.times {i ->
-    task "${baseName}#oldVersionClusterTask$i"(type: StandaloneRestIntegTestTask) {
-        dependsOn 'prepareBwcTests'
-        useCluster testClusters."${baseName}$i"
-        filter {
-            includeTestsMatching "org.opensearch.alerting.bwc.*IT"
-        }
-        systemProperty 'tests.rest.bwcsuite', 'old_cluster'
-        systemProperty 'tests.rest.bwcsuite_round', 'old'
-        systemProperty 'tests.plugin_bwc_version', bwcVersion
-        nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}$i".allHttpSocketURI.join(",")}")
-        nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}$i".getName()}")
-    }
-}
-
-// Upgrade one node of the old cluster to new OpenSearch version with upgraded plugin version.
-// This results in a mixed cluster with 2 nodes on the old version and 1 upgraded node.
-// This is also used as a one third upgraded cluster for a rolling upgrade.
-task "${baseName}#mixedClusterTask"(type: StandaloneRestIntegTestTask) {
-    useCluster testClusters."${baseName}0"
-    dependsOn "${baseName}#oldVersionClusterTask0"
-    doFirst {
-        testClusters."${baseName}0".upgradeNodeAndPluginToNextVersion(plugins)
-    }
-    filter {
-        includeTestsMatching "org.opensearch.alerting.bwc.*IT"
-    }
-    systemProperty 'tests.rest.bwcsuite', 'mixed_cluster'
-    systemProperty 'tests.rest.bwcsuite_round', 'first'
-    systemProperty 'tests.plugin_bwc_version', bwcVersion
-    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
-    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
-}
-
-// Upgrade the second node to new OpenSearch version with upgraded plugin version after the first node is upgraded.
-// This results in a mixed cluster with 1 node on the old version and 2 upgraded nodes.
-// This is used for rolling upgrade.
-task "${baseName}#twoThirdsUpgradedClusterTask"(type: StandaloneRestIntegTestTask) {
-    dependsOn "${baseName}#mixedClusterTask"
-    useCluster testClusters."${baseName}0"
-    doFirst {
-        testClusters."${baseName}0".upgradeNodeAndPluginToNextVersion(plugins)
-    }
-    filter {
-        includeTestsMatching "org.opensearch.alerting.bwc.*IT"
-    }
-    systemProperty 'tests.rest.bwcsuite', 'mixed_cluster'
-    systemProperty 'tests.rest.bwcsuite_round', 'second'
-    systemProperty 'tests.plugin_bwc_version', bwcVersion
-    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
-    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
-}
-
-// Upgrade the third node to new OpenSearch version with upgraded plugin version after the second node is upgraded.
-// This results in a fully upgraded cluster.
-// This is used for rolling upgrade.
-task "${baseName}#rollingUpgradeClusterTask"(type: StandaloneRestIntegTestTask) {
-    dependsOn "${baseName}#twoThirdsUpgradedClusterTask"
-    useCluster testClusters."${baseName}0"
-    doFirst {
-        testClusters."${baseName}0".upgradeNodeAndPluginToNextVersion(plugins)
-    }
-    filter {
-        includeTestsMatching "org.opensearch.alerting.bwc.*IT"
-    }
-    mustRunAfter "${baseName}#mixedClusterTask"
-    systemProperty 'tests.rest.bwcsuite', 'mixed_cluster'
-    systemProperty 'tests.rest.bwcsuite_round', 'third'
-    systemProperty 'tests.plugin_bwc_version', bwcVersion
-    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
-    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
-}
-
-// Upgrade all the nodes of the old cluster to new OpenSearch version with upgraded plugin version
-// at the same time resulting in a fully upgraded cluster.
-task "${baseName}#fullRestartClusterTask"(type: StandaloneRestIntegTestTask) {
-    dependsOn "${baseName}#oldVersionClusterTask1"
-    useCluster testClusters."${baseName}1"
-    doFirst {
-        testClusters."${baseName}1".upgradeAllNodesAndPluginsToNextVersion(plugins)
-    }
-    filter {
-        includeTestsMatching "org.opensearch.alerting.bwc.*IT"
-    }
-    systemProperty 'tests.rest.bwcsuite', 'upgraded_cluster'
-    systemProperty 'tests.plugin_bwc_version', bwcVersion
-    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}1".allHttpSocketURI.join(",")}")
-    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}1".getName()}")
-}
+//
+//String bwcVersion = "1.1.0.0"
+//String baseName = "alertingBwcCluster"
+//String bwcFilePath = "src/test/resources/bwc"
+//String bwcOpenSearchPlugin = "opensearch-alerting-" + bwcVersion + ".zip"
+//String bwcRemoteFile = 'https://ci.opensearch.org/ci/dbc/bundle-build/1.1.0/20210930/linux/x64/builds/opensearch/plugins/' + bwcOpenSearchPlugin
+//
+//2.times {i ->
+//    testClusters {
+//        "${baseName}$i" {
+//            testDistribution = "ARCHIVE"
+//            versions = ["1.1.0", "2.4.0-SNAPSHOT"]
+//            numberOfNodes = 3
+//            plugin(provider(new Callable<RegularFile>(){
+//                @Override
+//                RegularFile call() throws Exception {
+//                    return new RegularFile() {
+//                        @Override
+//                        File getAsFile() {
+//                            File dir = new File(rootDir.path + "/alerting/" + bwcFilePath + "/alerting/" + bwcVersion)
+//
+//                            if (!dir.exists()) {
+//                                dir.mkdirs()
+//                            }
+//                            File f = new File(dir, bwcOpenSearchPlugin)
+//                            if (!f.exists()) {
+//                                new URL(bwcRemoteFile).withInputStream{ ins -> f.withOutputStream{ it << ins }}
+//                            }
+//                            return fileTree(bwcFilePath + "/alerting/" + bwcVersion).getSingleFile()
+//                        }
+//                    }
+//                }
+//            }))
+//            setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+//            setting 'http.content_type.required', 'true'
+//        }
+//    }
+//}
+//
+//List<Provider<RegularFile>> plugins = []
+//
+//// Ensure the artifact for the current project version is available to be used for the bwc tests
+//task prepareBwcTests {
+//    dependsOn bundle
+//    doLast {
+//        plugins = [
+//                project.getObjects().fileProperty().value(bundle.getArchiveFile()),
+//                provider({
+//                    new RegularFile() {
+//                        @Override
+//                        File getAsFile() {
+//                            File dir = new File(rootDir.path + "/alerting/" + notificationsCoreFilePath)
+//
+//                            if (!dir.exists()) {
+//                                dir.mkdirs()
+//                            }
+//
+//                            File f = new File(dir, notificationsCorePlugin)
+//                            if (!f.exists()) {
+//                                new URL(notificationsCoreRemoteFile).withInputStream{ ins -> f.withOutputStream{ it << ins }}
+//                            }
+//                            fileTree(notificationsCoreFilePath).getSingleFile()
+//                        }
+//                    }
+//                }),
+//                provider({
+//                    new RegularFile() {
+//                        @Override
+//                        File getAsFile() {
+//                            File dir = new File(rootDir.path + "/alerting/" + notificationsFilePath)
+//
+//                            if (!dir.exists()) {
+//                                dir.mkdirs()
+//                            }
+//
+//                            File f = new File(dir, notificationsPlugin)
+//                            if (!f.exists()) {
+//                                new URL(notificationsRemoteFile).withInputStream{ ins -> f.withOutputStream{ it << ins }}
+//                            }
+//                            fileTree(notificationsFilePath).getSingleFile()
+//                        }
+//                    }
+//                })
+//        ]
+//    }
+//}
+//
+//// Create two test clusters with 3 nodes of the old version
+//2.times {i ->
+//    task "${baseName}#oldVersionClusterTask$i"(type: StandaloneRestIntegTestTask) {
+//        dependsOn 'prepareBwcTests'
+//        useCluster testClusters."${baseName}$i"
+//        filter {
+//            includeTestsMatching "org.opensearch.alerting.bwc.*IT"
+//        }
+//        systemProperty 'tests.rest.bwcsuite', 'old_cluster'
+//        systemProperty 'tests.rest.bwcsuite_round', 'old'
+//        systemProperty 'tests.plugin_bwc_version', bwcVersion
+//        nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}$i".allHttpSocketURI.join(",")}")
+//        nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}$i".getName()}")
+//    }
+//}
+//
+//// Upgrade one node of the old cluster to new OpenSearch version with upgraded plugin version.
+//// This results in a mixed cluster with 2 nodes on the old version and 1 upgraded node.
+//// This is also used as a one third upgraded cluster for a rolling upgrade.
+//task "${baseName}#mixedClusterTask"(type: StandaloneRestIntegTestTask) {
+//    useCluster testClusters."${baseName}0"
+//    dependsOn "${baseName}#oldVersionClusterTask0"
+//    doFirst {
+//        testClusters."${baseName}0".upgradeNodeAndPluginToNextVersion(plugins)
+//    }
+//    filter {
+//        includeTestsMatching "org.opensearch.alerting.bwc.*IT"
+//    }
+//    systemProperty 'tests.rest.bwcsuite', 'mixed_cluster'
+//    systemProperty 'tests.rest.bwcsuite_round', 'first'
+//    systemProperty 'tests.plugin_bwc_version', bwcVersion
+//    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
+//    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
+//}
+//
+//// Upgrade the second node to new OpenSearch version with upgraded plugin version after the first node is upgraded.
+//// This results in a mixed cluster with 1 node on the old version and 2 upgraded nodes.
+//// This is used for rolling upgrade.
+//task "${baseName}#twoThirdsUpgradedClusterTask"(type: StandaloneRestIntegTestTask) {
+//    dependsOn "${baseName}#mixedClusterTask"
+//    useCluster testClusters."${baseName}0"
+//    doFirst {
+//        testClusters."${baseName}0".upgradeNodeAndPluginToNextVersion(plugins)
+//    }
+//    filter {
+//        includeTestsMatching "org.opensearch.alerting.bwc.*IT"
+//    }
+//    systemProperty 'tests.rest.bwcsuite', 'mixed_cluster'
+//    systemProperty 'tests.rest.bwcsuite_round', 'second'
+//    systemProperty 'tests.plugin_bwc_version', bwcVersion
+//    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
+//    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
+//}
+//
+//// Upgrade the third node to new OpenSearch version with upgraded plugin version after the second node is upgraded.
+//// This results in a fully upgraded cluster.
+//// This is used for rolling upgrade.
+//task "${baseName}#rollingUpgradeClusterTask"(type: StandaloneRestIntegTestTask) {
+//    dependsOn "${baseName}#twoThirdsUpgradedClusterTask"
+//    useCluster testClusters."${baseName}0"
+//    doFirst {
+//        testClusters."${baseName}0".upgradeNodeAndPluginToNextVersion(plugins)
+//    }
+//    filter {
+//        includeTestsMatching "org.opensearch.alerting.bwc.*IT"
+//    }
+//    mustRunAfter "${baseName}#mixedClusterTask"
+//    systemProperty 'tests.rest.bwcsuite', 'mixed_cluster'
+//    systemProperty 'tests.rest.bwcsuite_round', 'third'
+//    systemProperty 'tests.plugin_bwc_version', bwcVersion
+//    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
+//    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
+//}
+//
+//// Upgrade all the nodes of the old cluster to new OpenSearch version with upgraded plugin version
+//// at the same time resulting in a fully upgraded cluster.
+//task "${baseName}#fullRestartClusterTask"(type: StandaloneRestIntegTestTask) {
+//    dependsOn "${baseName}#oldVersionClusterTask1"
+//    useCluster testClusters."${baseName}1"
+//    doFirst {
+//        testClusters."${baseName}1".upgradeAllNodesAndPluginsToNextVersion(plugins)
+//    }
+//    filter {
+//        includeTestsMatching "org.opensearch.alerting.bwc.*IT"
+//    }
+//    systemProperty 'tests.rest.bwcsuite', 'upgraded_cluster'
+//    systemProperty 'tests.plugin_bwc_version', bwcVersion
+//    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}1".allHttpSocketURI.join(",")}")
+//    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}1".getName()}")
+//}
 
 // A bwc test suite which runs all the bwc tasks combined
-task bwcTestSuite(type: StandaloneRestIntegTestTask) {
-    exclude '**/*Test*'
-    exclude '**/*IT*'
-    dependsOn tasks.named("${baseName}#mixedClusterTask")
-    dependsOn tasks.named("${baseName}#rollingUpgradeClusterTask")
-    dependsOn tasks.named("${baseName}#fullRestartClusterTask")
-}
+//task bwcTestSuite(type: StandaloneRestIntegTestTask) {
+//    exclude '**/*Test*'
+//    exclude '**/*IT*'
+//    dependsOn tasks.named("${baseName}#mixedClusterTask")
+//    dependsOn tasks.named("${baseName}#rollingUpgradeClusterTask")
+//    dependsOn tasks.named("${baseName}#fullRestartClusterTask")
+//}
 
 run {
     doFirst {

--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -238,7 +238,6 @@ task integTestRemote(type: RestIntegTestTask) {
     if (System.getProperty("tests.rest.cluster") != null) {
         filter {
             includeTestsMatching "org.opensearch.alerting.resthandler.*IT"
-            includeTestsMatching "org.opensearch.alerting.MonitorDataSourcesIT"
         }
     }
 
@@ -249,192 +248,192 @@ task integTestRemote(type: RestIntegTestTask) {
     }
 }
 integTestRemote.enabled = System.getProperty("tests.rest.cluster") != null
-//
-//String bwcVersion = "1.1.0.0"
-//String baseName = "alertingBwcCluster"
-//String bwcFilePath = "src/test/resources/bwc"
-//String bwcOpenSearchPlugin = "opensearch-alerting-" + bwcVersion + ".zip"
-//String bwcRemoteFile = 'https://ci.opensearch.org/ci/dbc/bundle-build/1.1.0/20210930/linux/x64/builds/opensearch/plugins/' + bwcOpenSearchPlugin
-//
-//2.times {i ->
-//    testClusters {
-//        "${baseName}$i" {
-//            testDistribution = "ARCHIVE"
-//            versions = ["1.1.0", "2.4.0-SNAPSHOT"]
-//            numberOfNodes = 3
-//            plugin(provider(new Callable<RegularFile>(){
-//                @Override
-//                RegularFile call() throws Exception {
-//                    return new RegularFile() {
-//                        @Override
-//                        File getAsFile() {
-//                            File dir = new File(rootDir.path + "/alerting/" + bwcFilePath + "/alerting/" + bwcVersion)
-//
-//                            if (!dir.exists()) {
-//                                dir.mkdirs()
-//                            }
-//                            File f = new File(dir, bwcOpenSearchPlugin)
-//                            if (!f.exists()) {
-//                                new URL(bwcRemoteFile).withInputStream{ ins -> f.withOutputStream{ it << ins }}
-//                            }
-//                            return fileTree(bwcFilePath + "/alerting/" + bwcVersion).getSingleFile()
-//                        }
-//                    }
-//                }
-//            }))
-//            setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
-//            setting 'http.content_type.required', 'true'
-//        }
-//    }
-//}
-//
-//List<Provider<RegularFile>> plugins = []
-//
-//// Ensure the artifact for the current project version is available to be used for the bwc tests
-//task prepareBwcTests {
-//    dependsOn bundle
-//    doLast {
-//        plugins = [
-//                project.getObjects().fileProperty().value(bundle.getArchiveFile()),
-//                provider({
-//                    new RegularFile() {
-//                        @Override
-//                        File getAsFile() {
-//                            File dir = new File(rootDir.path + "/alerting/" + notificationsCoreFilePath)
-//
-//                            if (!dir.exists()) {
-//                                dir.mkdirs()
-//                            }
-//
-//                            File f = new File(dir, notificationsCorePlugin)
-//                            if (!f.exists()) {
-//                                new URL(notificationsCoreRemoteFile).withInputStream{ ins -> f.withOutputStream{ it << ins }}
-//                            }
-//                            fileTree(notificationsCoreFilePath).getSingleFile()
-//                        }
-//                    }
-//                }),
-//                provider({
-//                    new RegularFile() {
-//                        @Override
-//                        File getAsFile() {
-//                            File dir = new File(rootDir.path + "/alerting/" + notificationsFilePath)
-//
-//                            if (!dir.exists()) {
-//                                dir.mkdirs()
-//                            }
-//
-//                            File f = new File(dir, notificationsPlugin)
-//                            if (!f.exists()) {
-//                                new URL(notificationsRemoteFile).withInputStream{ ins -> f.withOutputStream{ it << ins }}
-//                            }
-//                            fileTree(notificationsFilePath).getSingleFile()
-//                        }
-//                    }
-//                })
-//        ]
-//    }
-//}
-//
-//// Create two test clusters with 3 nodes of the old version
-//2.times {i ->
-//    task "${baseName}#oldVersionClusterTask$i"(type: StandaloneRestIntegTestTask) {
-//        dependsOn 'prepareBwcTests'
-//        useCluster testClusters."${baseName}$i"
-//        filter {
-//            includeTestsMatching "org.opensearch.alerting.bwc.*IT"
-//        }
-//        systemProperty 'tests.rest.bwcsuite', 'old_cluster'
-//        systemProperty 'tests.rest.bwcsuite_round', 'old'
-//        systemProperty 'tests.plugin_bwc_version', bwcVersion
-//        nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}$i".allHttpSocketURI.join(",")}")
-//        nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}$i".getName()}")
-//    }
-//}
-//
-//// Upgrade one node of the old cluster to new OpenSearch version with upgraded plugin version.
-//// This results in a mixed cluster with 2 nodes on the old version and 1 upgraded node.
-//// This is also used as a one third upgraded cluster for a rolling upgrade.
-//task "${baseName}#mixedClusterTask"(type: StandaloneRestIntegTestTask) {
-//    useCluster testClusters."${baseName}0"
-//    dependsOn "${baseName}#oldVersionClusterTask0"
-//    doFirst {
-//        testClusters."${baseName}0".upgradeNodeAndPluginToNextVersion(plugins)
-//    }
-//    filter {
-//        includeTestsMatching "org.opensearch.alerting.bwc.*IT"
-//    }
-//    systemProperty 'tests.rest.bwcsuite', 'mixed_cluster'
-//    systemProperty 'tests.rest.bwcsuite_round', 'first'
-//    systemProperty 'tests.plugin_bwc_version', bwcVersion
-//    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
-//    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
-//}
-//
-//// Upgrade the second node to new OpenSearch version with upgraded plugin version after the first node is upgraded.
-//// This results in a mixed cluster with 1 node on the old version and 2 upgraded nodes.
-//// This is used for rolling upgrade.
-//task "${baseName}#twoThirdsUpgradedClusterTask"(type: StandaloneRestIntegTestTask) {
-//    dependsOn "${baseName}#mixedClusterTask"
-//    useCluster testClusters."${baseName}0"
-//    doFirst {
-//        testClusters."${baseName}0".upgradeNodeAndPluginToNextVersion(plugins)
-//    }
-//    filter {
-//        includeTestsMatching "org.opensearch.alerting.bwc.*IT"
-//    }
-//    systemProperty 'tests.rest.bwcsuite', 'mixed_cluster'
-//    systemProperty 'tests.rest.bwcsuite_round', 'second'
-//    systemProperty 'tests.plugin_bwc_version', bwcVersion
-//    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
-//    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
-//}
-//
-//// Upgrade the third node to new OpenSearch version with upgraded plugin version after the second node is upgraded.
-//// This results in a fully upgraded cluster.
-//// This is used for rolling upgrade.
-//task "${baseName}#rollingUpgradeClusterTask"(type: StandaloneRestIntegTestTask) {
-//    dependsOn "${baseName}#twoThirdsUpgradedClusterTask"
-//    useCluster testClusters."${baseName}0"
-//    doFirst {
-//        testClusters."${baseName}0".upgradeNodeAndPluginToNextVersion(plugins)
-//    }
-//    filter {
-//        includeTestsMatching "org.opensearch.alerting.bwc.*IT"
-//    }
-//    mustRunAfter "${baseName}#mixedClusterTask"
-//    systemProperty 'tests.rest.bwcsuite', 'mixed_cluster'
-//    systemProperty 'tests.rest.bwcsuite_round', 'third'
-//    systemProperty 'tests.plugin_bwc_version', bwcVersion
-//    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
-//    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
-//}
-//
-//// Upgrade all the nodes of the old cluster to new OpenSearch version with upgraded plugin version
-//// at the same time resulting in a fully upgraded cluster.
-//task "${baseName}#fullRestartClusterTask"(type: StandaloneRestIntegTestTask) {
-//    dependsOn "${baseName}#oldVersionClusterTask1"
-//    useCluster testClusters."${baseName}1"
-//    doFirst {
-//        testClusters."${baseName}1".upgradeAllNodesAndPluginsToNextVersion(plugins)
-//    }
-//    filter {
-//        includeTestsMatching "org.opensearch.alerting.bwc.*IT"
-//    }
-//    systemProperty 'tests.rest.bwcsuite', 'upgraded_cluster'
-//    systemProperty 'tests.plugin_bwc_version', bwcVersion
-//    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}1".allHttpSocketURI.join(",")}")
-//    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}1".getName()}")
-//}
+
+String bwcVersion = "1.1.0.0"
+String baseName = "alertingBwcCluster"
+String bwcFilePath = "src/test/resources/bwc"
+String bwcOpenSearchPlugin = "opensearch-alerting-" + bwcVersion + ".zip"
+String bwcRemoteFile = 'https://ci.opensearch.org/ci/dbc/bundle-build/1.1.0/20210930/linux/x64/builds/opensearch/plugins/' + bwcOpenSearchPlugin
+
+2.times {i ->
+    testClusters {
+        "${baseName}$i" {
+            testDistribution = "ARCHIVE"
+            versions = ["1.1.0", "2.4.0-SNAPSHOT"]
+            numberOfNodes = 3
+            plugin(provider(new Callable<RegularFile>(){
+                @Override
+                RegularFile call() throws Exception {
+                    return new RegularFile() {
+                        @Override
+                        File getAsFile() {
+                            File dir = new File(rootDir.path + "/alerting/" + bwcFilePath + "/alerting/" + bwcVersion)
+
+                            if (!dir.exists()) {
+                                dir.mkdirs()
+                            }
+                            File f = new File(dir, bwcOpenSearchPlugin)
+                            if (!f.exists()) {
+                                new URL(bwcRemoteFile).withInputStream{ ins -> f.withOutputStream{ it << ins }}
+                            }
+                            return fileTree(bwcFilePath + "/alerting/" + bwcVersion).getSingleFile()
+                        }
+                    }
+                }
+            }))
+            setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+            setting 'http.content_type.required', 'true'
+        }
+    }
+}
+
+List<Provider<RegularFile>> plugins = []
+
+// Ensure the artifact for the current project version is available to be used for the bwc tests
+task prepareBwcTests {
+    dependsOn bundle
+    doLast {
+        plugins = [
+                project.getObjects().fileProperty().value(bundle.getArchiveFile()),
+                provider({
+                    new RegularFile() {
+                        @Override
+                        File getAsFile() {
+                            File dir = new File(rootDir.path + "/alerting/" + notificationsCoreFilePath)
+
+                            if (!dir.exists()) {
+                                dir.mkdirs()
+                            }
+
+                            File f = new File(dir, notificationsCorePlugin)
+                            if (!f.exists()) {
+                                new URL(notificationsCoreRemoteFile).withInputStream{ ins -> f.withOutputStream{ it << ins }}
+                            }
+                            fileTree(notificationsCoreFilePath).getSingleFile()
+                        }
+                    }
+                }),
+                provider({
+                    new RegularFile() {
+                        @Override
+                        File getAsFile() {
+                            File dir = new File(rootDir.path + "/alerting/" + notificationsFilePath)
+
+                            if (!dir.exists()) {
+                                dir.mkdirs()
+                            }
+
+                            File f = new File(dir, notificationsPlugin)
+                            if (!f.exists()) {
+                                new URL(notificationsRemoteFile).withInputStream{ ins -> f.withOutputStream{ it << ins }}
+                            }
+                            fileTree(notificationsFilePath).getSingleFile()
+                        }
+                    }
+                })
+        ]
+    }
+}
+
+// Create two test clusters with 3 nodes of the old version
+2.times {i ->
+    task "${baseName}#oldVersionClusterTask$i"(type: StandaloneRestIntegTestTask) {
+        dependsOn 'prepareBwcTests'
+        useCluster testClusters."${baseName}$i"
+        filter {
+            includeTestsMatching "org.opensearch.alerting.bwc.*IT"
+        }
+        systemProperty 'tests.rest.bwcsuite', 'old_cluster'
+        systemProperty 'tests.rest.bwcsuite_round', 'old'
+        systemProperty 'tests.plugin_bwc_version', bwcVersion
+        nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}$i".allHttpSocketURI.join(",")}")
+        nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}$i".getName()}")
+    }
+}
+
+// Upgrade one node of the old cluster to new OpenSearch version with upgraded plugin version.
+// This results in a mixed cluster with 2 nodes on the old version and 1 upgraded node.
+// This is also used as a one third upgraded cluster for a rolling upgrade.
+task "${baseName}#mixedClusterTask"(type: StandaloneRestIntegTestTask) {
+    useCluster testClusters."${baseName}0"
+    dependsOn "${baseName}#oldVersionClusterTask0"
+    doFirst {
+        testClusters."${baseName}0".upgradeNodeAndPluginToNextVersion(plugins)
+    }
+    filter {
+        includeTestsMatching "org.opensearch.alerting.bwc.*IT"
+    }
+    systemProperty 'tests.rest.bwcsuite', 'mixed_cluster'
+    systemProperty 'tests.rest.bwcsuite_round', 'first'
+    systemProperty 'tests.plugin_bwc_version', bwcVersion
+    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
+    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
+}
+
+// Upgrade the second node to new OpenSearch version with upgraded plugin version after the first node is upgraded.
+// This results in a mixed cluster with 1 node on the old version and 2 upgraded nodes.
+// This is used for rolling upgrade.
+task "${baseName}#twoThirdsUpgradedClusterTask"(type: StandaloneRestIntegTestTask) {
+    dependsOn "${baseName}#mixedClusterTask"
+    useCluster testClusters."${baseName}0"
+    doFirst {
+        testClusters."${baseName}0".upgradeNodeAndPluginToNextVersion(plugins)
+    }
+    filter {
+        includeTestsMatching "org.opensearch.alerting.bwc.*IT"
+    }
+    systemProperty 'tests.rest.bwcsuite', 'mixed_cluster'
+    systemProperty 'tests.rest.bwcsuite_round', 'second'
+    systemProperty 'tests.plugin_bwc_version', bwcVersion
+    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
+    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
+}
+
+// Upgrade the third node to new OpenSearch version with upgraded plugin version after the second node is upgraded.
+// This results in a fully upgraded cluster.
+// This is used for rolling upgrade.
+task "${baseName}#rollingUpgradeClusterTask"(type: StandaloneRestIntegTestTask) {
+    dependsOn "${baseName}#twoThirdsUpgradedClusterTask"
+    useCluster testClusters."${baseName}0"
+    doFirst {
+        testClusters."${baseName}0".upgradeNodeAndPluginToNextVersion(plugins)
+    }
+    filter {
+        includeTestsMatching "org.opensearch.alerting.bwc.*IT"
+    }
+    mustRunAfter "${baseName}#mixedClusterTask"
+    systemProperty 'tests.rest.bwcsuite', 'mixed_cluster'
+    systemProperty 'tests.rest.bwcsuite_round', 'third'
+    systemProperty 'tests.plugin_bwc_version', bwcVersion
+    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
+    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
+}
+
+// Upgrade all the nodes of the old cluster to new OpenSearch version with upgraded plugin version
+// at the same time resulting in a fully upgraded cluster.
+task "${baseName}#fullRestartClusterTask"(type: StandaloneRestIntegTestTask) {
+    dependsOn "${baseName}#oldVersionClusterTask1"
+    useCluster testClusters."${baseName}1"
+    doFirst {
+        testClusters."${baseName}1".upgradeAllNodesAndPluginsToNextVersion(plugins)
+    }
+    filter {
+        includeTestsMatching "org.opensearch.alerting.bwc.*IT"
+    }
+    systemProperty 'tests.rest.bwcsuite', 'upgraded_cluster'
+    systemProperty 'tests.plugin_bwc_version', bwcVersion
+    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}1".allHttpSocketURI.join(",")}")
+    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}1".getName()}")
+}
 
 // A bwc test suite which runs all the bwc tasks combined
-//task bwcTestSuite(type: StandaloneRestIntegTestTask) {
-//    exclude '**/*Test*'
-//    exclude '**/*IT*'
-//    dependsOn tasks.named("${baseName}#mixedClusterTask")
-//    dependsOn tasks.named("${baseName}#rollingUpgradeClusterTask")
-//    dependsOn tasks.named("${baseName}#fullRestartClusterTask")
-//}
+task bwcTestSuite(type: StandaloneRestIntegTestTask) {
+    exclude '**/*Test*'
+    exclude '**/*IT*'
+    dependsOn tasks.named("${baseName}#mixedClusterTask")
+    dependsOn tasks.named("${baseName}#rollingUpgradeClusterTask")
+    dependsOn tasks.named("${baseName}#fullRestartClusterTask")
+}
 
 run {
     doFirst {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
@@ -116,10 +116,10 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
         flattenPaths: MutableList<String>
     ) {
         // If node contains "properties" property then it is internal(non-leaf) node
+        log.debug("Node in traverse: $node")
         if (node.containsKey(PROPERTIES)) {
             return traverseMappingsAndUpdate(node.get(PROPERTIES) as MutableMap<String, Any>, currentPath, processLeafFn, flattenPaths)
-        } else if (node.containsKey(TYPE) == false) {
-            // If there is no "type" property, this is either internal(non-leaf) node or leaf node
+        } else {
             // newNodes will hold list of updated leaf properties
             var newNodes = ArrayList<Triple<String, String, Any>>(node.size)
             node.entries.forEach {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
@@ -17,6 +17,7 @@ import org.opensearch.alerting.action.SearchMonitorRequest
 import org.opensearch.alerting.core.ScheduledJobIndices
 import org.opensearch.alerting.transport.AlertingSingleNodeTestCase
 import org.opensearch.common.settings.Settings
+import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.alerting.action.AcknowledgeAlertRequest
 import org.opensearch.commons.alerting.action.AlertingActions
 import org.opensearch.commons.alerting.action.DeleteMonitorRequest
@@ -135,8 +136,79 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
         val docQuery3 = DocLevelQuery(query = "source.ip.v4.v0:120", name = "5")
         val docQuery4 = DocLevelQuery(query = "alias.some.fff:\"us-west-2\"", name = "6")
         val docQuery5 = DocLevelQuery(query = "message:\"This is an error from IAD region\"", name = "7")
+        val docQuery6 = DocLevelQuery(query = "f1.type.f4:\"hello\"", name = "8")
+        val docQuery7 = DocLevelQuery(query = "f1.type.f2.f3:\"world\"", name = "9")
+        val docQuery8 = DocLevelQuery(query = "type:\"some type\"", name = "10")
+
         val docLevelInput = DocLevelMonitorInput(
-            "description", listOf(index), listOf(docQuery1, docQuery2, docQuery3, docQuery4, docQuery5)
+            "description", listOf(index), listOf(docQuery1, docQuery2, docQuery3, docQuery4, docQuery5, docQuery6, docQuery7, docQuery8)
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val customFindingsIndex = "custom_findings_index"
+        val customFindingsIndexPattern = "custom_findings_index-1"
+        val customQueryIndex = "custom_alerts_index"
+        var monitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger),
+            dataSources = DataSources(
+                queryIndex = customQueryIndex,
+                findingsIndex = customFindingsIndex,
+                findingsIndexPattern = customFindingsIndexPattern
+            )
+        )
+        val monitorResponse = createMonitor(monitor)
+        // Trying to test here few different "nesting" situations and "wierd" characters
+        val testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now().truncatedTo(MILLIS))
+        val testDoc = """{
+            "message" : "This is an error from IAD region",
+            "source.ip.v6.v1" : 12345,
+            "source.ip.v6.v2" : 16645,
+            "source.ip.v4.v0" : 120,
+            "test_bad_char" : "\u0000", 
+            "test_strict_date_time" : "$testTime",
+            "test_field.some_other_field" : "us-west-2",
+            "f1.type.f2.f3" : "world",
+            "f1.type.f4" : "hello",
+            "type" : "some type"
+        }"""
+        indexDoc(index, "1", testDoc)
+        client().admin().indices().putMapping(
+            PutMappingRequest(index).source("alias.some.fff", "type=alias,path=test_field.some_other_field")
+        )
+        val mappings = "{\"properties\":{\"type\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\"," +
+            "\"ignore_above\":256}}},\"query\":{\"type\":\"text\"}}}"
+        val mappingsResp = client().admin().indices().putMapping(
+            PutMappingRequest(index).source(mappings, XContentType.JSON)
+        ).get()
+        assertFalse(monitorResponse?.id.isNullOrEmpty())
+        monitor = monitorResponse!!.monitor
+        val id = monitorResponse.id
+        val executeMonitorResponse = executeMonitor(monitor, id, false)
+        Assert.assertEquals(executeMonitorResponse!!.monitorRunResult.monitorName, monitor.name)
+        Assert.assertEquals(executeMonitorResponse.monitorRunResult.triggerResults.size, 1)
+        searchAlerts(id)
+        val table = Table("asc", "id", null, 1, 0, "")
+        var getAlertsResponse = client()
+            .execute(AlertingActions.GET_ALERTS_ACTION_TYPE, GetAlertsRequest(table, "ALL", "ALL", null, null))
+            .get()
+        Assert.assertTrue(getAlertsResponse != null)
+        Assert.assertTrue(getAlertsResponse.alerts.size == 1)
+        val findings = searchFindings(id, customFindingsIndex)
+        assertEquals("Findings saved for test monitor", 1, findings.size)
+        assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("1"))
+        assertEquals("Didn't match all 8 queries", 8, findings[0].docLevelQueries.size)
+    }
+
+    fun `test execute monitor with custom query index old`() {
+        val docQuery1 = DocLevelQuery(query = "source.ip.v6.v1:12345", name = "3")
+        val docQuery2 = DocLevelQuery(query = "source.ip.v6.v2:16645", name = "4")
+        val docQuery3 = DocLevelQuery(query = "source.ip.v4.v0:120", name = "5")
+        val docQuery4 = DocLevelQuery(query = "alias.some.fff:\"us-west-2\"", name = "6")
+        val docQuery5 = DocLevelQuery(query = "message:\"This is an error from IAD region\"", name = "7")
+        val docQuery6 = DocLevelQuery(query = "type.subtype:\"some subtype\"", name = "8")
+        val docQuery7 = DocLevelQuery(query = "supertype.type:\"some type\"", name = "9")
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(docQuery1, docQuery2, docQuery3, docQuery4, docQuery5, docQuery6, docQuery7)
         )
         val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
         val customFindingsIndex = "custom_findings_index"
@@ -161,7 +233,9 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
             "source.ip.v4.v0" : 120,
             "test_bad_char" : "\u0000", 
             "test_strict_date_time" : "$testTime",
-            "test_field.some_other_field" : "us-west-2"
+            "test_field.some_other_field" : "us-west-2",
+            "type.subtype" : "some subtype",
+            "supertype.type" : "some type"
         }"""
         indexDoc(index, "1", testDoc)
         client().admin().indices().putMapping(
@@ -183,7 +257,7 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
         val findings = searchFindings(id, customFindingsIndex)
         assertEquals("Findings saved for test monitor", 1, findings.size)
         assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("1"))
-        assertEquals("Didn't match all 5 queries", 5, findings[0].docLevelQueries.size)
+        assertEquals("Didn't match all 7 queries", 7, findings[0].docLevelQueries.size)
     }
 
     fun `test execute monitor with custom query index and nested mappings`() {


### PR DESCRIPTION
Signed-off-by: Raj Chakravarthi <raj@icedome.ca>

*Issue #, if available:*
https://github.com/opensearch-project/security-analytics/issues/172

*Description of changes:*
if mapping had a field named "type" the recursive mapping traversal ignored peer nodes

*CheckList:*
[ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).