### PR TITLE
[Backport 2.x] QueryIndex rollover when field mapping limit is reached.

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -234,6 +234,14 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
         destinationMigrationCoordinator = DestinationMigrationCoordinator(client, clusterService, threadPool, scheduledJobIndices)
         this.threadPool = threadPool
         this.clusterService = clusterService
+
+        MonitorMetadataService.initialize(
+            client,
+            clusterService,
+            xContentRegistry,
+            settings
+        )
+
         return listOf(sweeper, scheduler, runner, scheduledJobIndices, docLevelMonitorQueries, destinationMigrationCoordinator)
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt
@@ -1,0 +1,245 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting
+
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import org.apache.logging.log4j.LogManager
+import org.opensearch.ExceptionsHelper
+import org.opensearch.OpenSearchSecurityException
+import org.opensearch.action.DocWriteRequest
+import org.opensearch.action.DocWriteResponse
+import org.opensearch.action.admin.indices.get.GetIndexRequest
+import org.opensearch.action.admin.indices.get.GetIndexResponse
+import org.opensearch.action.admin.indices.stats.IndicesStatsAction
+import org.opensearch.action.admin.indices.stats.IndicesStatsRequest
+import org.opensearch.action.admin.indices.stats.IndicesStatsResponse
+import org.opensearch.action.get.GetRequest
+import org.opensearch.action.get.GetResponse
+import org.opensearch.action.index.IndexRequest
+import org.opensearch.action.index.IndexResponse
+import org.opensearch.action.support.WriteRequest
+import org.opensearch.alerting.model.MonitorMetadata
+import org.opensearch.alerting.opensearchapi.suspendUntil
+import org.opensearch.alerting.settings.AlertingSettings
+import org.opensearch.alerting.util.AlertingException
+import org.opensearch.client.Client
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.unit.TimeValue
+import org.opensearch.common.xcontent.LoggingDeprecationHandler
+import org.opensearch.common.xcontent.NamedXContentRegistry
+import org.opensearch.common.xcontent.ToXContent
+import org.opensearch.common.xcontent.XContentFactory
+import org.opensearch.common.xcontent.XContentHelper
+import org.opensearch.common.xcontent.XContentParser
+import org.opensearch.common.xcontent.XContentParserUtils
+import org.opensearch.common.xcontent.XContentType
+import org.opensearch.commons.alerting.model.DocLevelMonitorInput
+import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.ScheduledJob
+import org.opensearch.index.seqno.SequenceNumbers
+import org.opensearch.rest.RestStatus
+import org.opensearch.transport.RemoteTransportException
+
+private val log = LogManager.getLogger(MonitorMetadataService::class.java)
+
+object MonitorMetadataService :
+    CoroutineScope by CoroutineScope(SupervisorJob() + Dispatchers.Default + CoroutineName("MonitorMetadataService")) {
+
+    private lateinit var client: Client
+    private lateinit var xContentRegistry: NamedXContentRegistry
+    private lateinit var clusterService: ClusterService
+    private lateinit var settings: Settings
+
+    @Volatile private lateinit var indexTimeout: TimeValue
+
+    fun initialize(
+        client: Client,
+        clusterService: ClusterService,
+        xContentRegistry: NamedXContentRegistry,
+        settings: Settings
+    ) {
+        this.clusterService = clusterService
+        this.client = client
+        this.xContentRegistry = xContentRegistry
+        this.settings = settings
+        this.indexTimeout = AlertingSettings.INDEX_TIMEOUT.get(settings)
+        this.clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.INDEX_TIMEOUT) { indexTimeout = it }
+    }
+
+    @Suppress("ComplexMethod", "ReturnCount")
+    suspend fun upsertMetadata(metadata: MonitorMetadata, updating: Boolean): MonitorMetadata {
+        try {
+            val indexRequest = IndexRequest(ScheduledJob.SCHEDULED_JOBS_INDEX)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                .source(metadata.toXContent(XContentFactory.jsonBuilder(), ToXContent.MapParams(mapOf("with_type" to "true"))))
+                .id(metadata.id)
+                .routing(metadata.monitorId)
+                .setIfSeqNo(metadata.seqNo)
+                .setIfPrimaryTerm(metadata.primaryTerm)
+                .timeout(indexTimeout)
+
+            if (updating) {
+                indexRequest.id(metadata.id).setIfSeqNo(metadata.seqNo).setIfPrimaryTerm(metadata.primaryTerm)
+            } else {
+                indexRequest.opType(DocWriteRequest.OpType.CREATE)
+            }
+            val response: IndexResponse = client.suspendUntil { index(indexRequest, it) }
+            when (response.result) {
+                DocWriteResponse.Result.DELETED, DocWriteResponse.Result.NOOP, DocWriteResponse.Result.NOT_FOUND, null -> {
+                    val failureReason = "The upsert metadata call failed with a ${response.result?.lowercase} result"
+                    log.error(failureReason)
+                    throw AlertingException(failureReason, RestStatus.INTERNAL_SERVER_ERROR, IllegalStateException(failureReason))
+                }
+                DocWriteResponse.Result.CREATED, DocWriteResponse.Result.UPDATED -> {
+                    log.debug("Successfully upserted MonitorMetadata:${metadata.id} ")
+                }
+            }
+            return metadata.copy(
+                seqNo = response.seqNo,
+                primaryTerm = response.primaryTerm
+            )
+        } catch (e: Exception) {
+            throw AlertingException.wrap(e)
+        }
+    }
+
+    suspend fun getOrCreateMetadata(monitor: Monitor, createWithRunContext: Boolean = true): Pair<MonitorMetadata, Boolean> {
+        try {
+            val created = true
+            val metadata = getMetadata(monitor)
+            return if (metadata != null) {
+                metadata to !created
+            } else {
+                val newMetadata = createNewMetadata(monitor, createWithRunContext = createWithRunContext)
+                upsertMetadata(newMetadata, updating = false) to created
+            }
+        } catch (e: Exception) {
+            throw AlertingException.wrap(e)
+        }
+    }
+
+    suspend fun getMetadata(monitor: Monitor): MonitorMetadata? {
+        try {
+            val metadataId = MonitorMetadata.getId(monitor)
+            val getRequest = GetRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, metadataId).routing(monitor.id)
+
+            val getResponse: GetResponse = client.suspendUntil { get(getRequest, it) }
+            return if (getResponse.isExists) {
+                val xcp = XContentHelper.createParser(
+                    xContentRegistry, LoggingDeprecationHandler.INSTANCE,
+                    getResponse.sourceAsBytesRef, XContentType.JSON
+                )
+                XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp)
+                MonitorMetadata.parse(xcp)
+            } else {
+                null
+            }
+        } catch (e: Exception) {
+            if (e.message?.contains("no such index") == true) {
+                return null
+            } else {
+                throw AlertingException.wrap(e)
+            }
+        }
+    }
+
+    suspend fun recreateRunContext(metadata: MonitorMetadata, monitor: Monitor): MonitorMetadata {
+        try {
+            val monitorIndex = if (monitor.monitorType == Monitor.MonitorType.DOC_LEVEL_MONITOR)
+                (monitor.inputs[0] as DocLevelMonitorInput).indices[0]
+            else null
+            val runContext = if (monitor.monitorType == Monitor.MonitorType.DOC_LEVEL_MONITOR)
+                createFullRunContext(monitorIndex, metadata.lastRunContext as MutableMap<String, MutableMap<String, Any>>)
+            else null
+            if (runContext != null) {
+                return metadata.copy(
+                    lastRunContext = runContext
+                )
+            } else {
+                return metadata
+            }
+        } catch (e: Exception) {
+            throw AlertingException.wrap(e)
+        }
+    }
+
+    private suspend fun createNewMetadata(monitor: Monitor, createWithRunContext: Boolean): MonitorMetadata {
+        val monitorIndex = if (monitor.monitorType == Monitor.MonitorType.DOC_LEVEL_MONITOR)
+            (monitor.inputs[0] as DocLevelMonitorInput).indices[0]
+        else null
+        val runContext =
+            if (monitor.monitorType == Monitor.MonitorType.DOC_LEVEL_MONITOR && createWithRunContext)
+                createFullRunContext(monitorIndex)
+            else emptyMap()
+        return MonitorMetadata(
+            id = "${monitor.id}-metadata",
+            seqNo = SequenceNumbers.UNASSIGNED_SEQ_NO,
+            primaryTerm = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
+            monitorId = monitor.id,
+            lastActionExecutionTimes = emptyList(),
+            lastRunContext = runContext,
+            sourceToQueryIndexMapping = mutableMapOf()
+        )
+    }
+
+    private suspend fun createFullRunContext(
+        index: String?,
+        existingRunContext: MutableMap<String, MutableMap<String, Any>>? = null
+    ): MutableMap<String, MutableMap<String, Any>> {
+        val lastRunContext = existingRunContext?.toMutableMap() ?: mutableMapOf()
+        try {
+            if (index == null) return mutableMapOf()
+            val getIndexRequest = GetIndexRequest().indices(index)
+            val getIndexResponse: GetIndexResponse = client.suspendUntil {
+                client.admin().indices().getIndex(getIndexRequest, it)
+            }
+            val indices = getIndexResponse.indices()
+
+            indices.forEach { indexName ->
+                if (!lastRunContext.containsKey(indexName)) {
+                    lastRunContext[indexName] = createRunContextForIndex(index)
+                }
+            }
+        } catch (e: RemoteTransportException) {
+            val unwrappedException = ExceptionsHelper.unwrapCause(e) as Exception
+            throw AlertingException("Failed fetching index stats", RestStatus.INTERNAL_SERVER_ERROR, unwrappedException)
+        } catch (e: OpenSearchSecurityException) {
+            throw AlertingException(
+                "Failed fetching index stats - missing required index permissions: ${e.localizedMessage}",
+                RestStatus.INTERNAL_SERVER_ERROR,
+                e
+            )
+        } catch (e: Exception) {
+            throw AlertingException("Failed fetching index stats", RestStatus.INTERNAL_SERVER_ERROR, e)
+        }
+        return lastRunContext
+    }
+
+    suspend fun createRunContextForIndex(index: String, createdRecently: Boolean = false): MutableMap<String, Any> {
+        val request = IndicesStatsRequest().indices(index).clear()
+        val response: IndicesStatsResponse = client.suspendUntil { execute(IndicesStatsAction.INSTANCE, request, it) }
+        if (response.status != RestStatus.OK) {
+            val errorMessage = "Failed fetching index stats for index:$index"
+            throw AlertingException(errorMessage, RestStatus.INTERNAL_SERVER_ERROR, IllegalStateException(errorMessage))
+        }
+        val shards = response.shards.filter { it.shardRouting.primary() && it.shardRouting.active() }
+        val lastRunContext = HashMap<String, Any>()
+        lastRunContext["index"] = index
+        val count = shards.size
+        lastRunContext["shards_count"] = count
+
+        for (shard in shards) {
+            lastRunContext[shard.shardRouting.id.toString()] =
+                if (createdRecently) -1L
+                else shard.seqNoStats?.globalCheckpoint ?: SequenceNumbers.UNASSIGNED_SEQ_NO
+        }
+        return lastRunContext
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
@@ -10,7 +10,6 @@ import org.opensearch.alerting.action.GetDestinationsAction
 import org.opensearch.alerting.action.GetDestinationsRequest
 import org.opensearch.alerting.action.GetDestinationsResponse
 import org.opensearch.alerting.model.ActionRunResult
-import org.opensearch.alerting.model.MonitorMetadata
 import org.opensearch.alerting.model.MonitorRunResult
 import org.opensearch.alerting.model.destination.Destination
 import org.opensearch.alerting.opensearchapi.InjectorContextElement
@@ -179,9 +178,5 @@ abstract class MonitorRunner {
         }
 
         return NotificationActionConfigs(destination, channel)
-    }
-
-    protected fun createMonitorMetadata(monitorId: String): MonitorMetadata {
-        return MonitorMetadata("$monitorId-metadata", monitorId, emptyList(), emptyMap())
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/AlertingConfigAccessor.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/AlertingConfigAccessor.kt
@@ -17,39 +17,14 @@ import org.opensearch.common.bytes.BytesReference
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
 import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.common.xcontent.XContentHelper
-import org.opensearch.common.xcontent.XContentParser
-import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.alerting.model.ScheduledJob
-import org.opensearch.index.IndexNotFoundException
 
 /**
  * This is an accessor class to retrieve documents/information from the Alerting config index.
  */
 class AlertingConfigAccessor {
     companion object {
-
-        suspend fun getMonitorMetadata(client: Client, xContentRegistry: NamedXContentRegistry, metadataId: String): MonitorMetadata? {
-            return try {
-                val jobSource = getAlertingConfigDocumentSource(client, "Monitor Metadata", metadataId)
-                withContext(Dispatchers.IO) {
-                    val xcp = XContentHelper.createParser(
-                        xContentRegistry, LoggingDeprecationHandler.INSTANCE,
-                        jobSource, XContentType.JSON
-                    )
-                    XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp)
-                    MonitorMetadata.parse(xcp)
-                }
-            } catch (e: IllegalStateException) {
-                if (e.message?.equals("Monitor Metadata document with id $metadataId not found or source is empty") == true) {
-                    return null
-                } else throw e
-            } catch (e: IndexNotFoundException) {
-                if (e.message?.equals("no such index [.opendistro-alerting-config]") == true) {
-                    return null
-                } else throw e
-            }
-        }
 
         suspend fun getEmailAccountInfo(client: Client, xContentRegistry: NamedXContentRegistry, emailAccountId: String): EmailAccount {
             val source = getAlertingConfigDocumentSource(client, "Email account", emailAccountId)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/MonitorMetadata.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/MonitorMetadata.kt
@@ -5,6 +5,7 @@
 
 package org.opensearch.alerting.model
 
+import org.opensearch.alerting.model.destination.Destination.Companion.NO_ID
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.StreamOutput
 import org.opensearch.common.io.stream.Writeable
@@ -14,29 +15,40 @@ import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.util.instant
+import org.opensearch.index.seqno.SequenceNumbers
 import java.io.IOException
 import java.time.Instant
 
 data class MonitorMetadata(
     val id: String,
+    val seqNo: Long = SequenceNumbers.UNASSIGNED_SEQ_NO,
+    val primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
     val monitorId: String,
     val lastActionExecutionTimes: List<ActionExecutionTime>,
-    val lastRunContext: Map<String, Any>
+    val lastRunContext: Map<String, Any>,
+    // Maps (sourceIndex + monitorId) --> concreteQueryIndex
+    val sourceToQueryIndexMapping: MutableMap<String, String> = mutableMapOf()
 ) : Writeable, ToXContent {
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         id = sin.readString(),
+        seqNo = sin.readLong(),
+        primaryTerm = sin.readLong(),
         monitorId = sin.readString(),
         lastActionExecutionTimes = sin.readList(ActionExecutionTime::readFrom),
-        lastRunContext = Monitor.suppressWarning(sin.readMap())
+        lastRunContext = Monitor.suppressWarning(sin.readMap()),
+        sourceToQueryIndexMapping = sin.readMap() as MutableMap<String, String>
     )
 
     override fun writeTo(out: StreamOutput) {
         out.writeString(id)
+        out.writeLong(seqNo)
+        out.writeLong(primaryTerm)
         out.writeString(monitorId)
         out.writeCollection(lastActionExecutionTimes)
         out.writeMap(lastRunContext)
+        out.writeMap(sourceToQueryIndexMapping as MutableMap<String, Any>)
     }
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
@@ -45,6 +57,9 @@ data class MonitorMetadata(
         builder.field(MONITOR_ID_FIELD, monitorId)
             .field(LAST_ACTION_EXECUTION_FIELD, lastActionExecutionTimes.toTypedArray())
         if (lastRunContext.isNotEmpty()) builder.field(LAST_RUN_CONTEXT_FIELD, lastRunContext)
+        if (sourceToQueryIndexMapping.isNotEmpty()) {
+            builder.field(SOURCE_TO_QUERY_INDEX_MAP_FIELD, sourceToQueryIndexMapping as MutableMap<String, Any>)
+        }
         if (params.paramAsBoolean("with_type", false)) builder.endObject()
         return builder.endObject()
     }
@@ -54,13 +69,20 @@ data class MonitorMetadata(
         const val MONITOR_ID_FIELD = "monitor_id"
         const val LAST_ACTION_EXECUTION_FIELD = "last_action_execution_times"
         const val LAST_RUN_CONTEXT_FIELD = "last_run_context"
+        const val SOURCE_TO_QUERY_INDEX_MAP_FIELD = "source_to_query_index_mapping"
 
         @JvmStatic @JvmOverloads
         @Throws(IOException::class)
-        fun parse(xcp: XContentParser): MonitorMetadata {
+        fun parse(
+            xcp: XContentParser,
+            id: String = NO_ID,
+            seqNo: Long = SequenceNumbers.UNASSIGNED_SEQ_NO,
+            primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM
+        ): MonitorMetadata {
             lateinit var monitorId: String
             val lastActionExecutionTimes = mutableListOf<ActionExecutionTime>()
             var lastRunContext: Map<String, Any> = mapOf()
+            var sourceToQueryIndexMapping: MutableMap<String, String> = mutableMapOf()
 
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
             while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -76,14 +98,18 @@ data class MonitorMetadata(
                         }
                     }
                     LAST_RUN_CONTEXT_FIELD -> lastRunContext = xcp.map()
+                    SOURCE_TO_QUERY_INDEX_MAP_FIELD -> sourceToQueryIndexMapping = xcp.map() as MutableMap<String, String>
                 }
             }
 
             return MonitorMetadata(
-                "$monitorId-metadata",
+                if (id != NO_ID) id else "$monitorId-metadata",
+                seqNo = seqNo,
+                primaryTerm = primaryTerm,
                 monitorId = monitorId,
                 lastActionExecutionTimes = lastActionExecutionTimes,
-                lastRunContext = lastRunContext
+                lastRunContext = lastRunContext,
+                sourceToQueryIndexMapping = sourceToQueryIndexMapping
             )
         }
 
@@ -91,6 +117,10 @@ data class MonitorMetadata(
         @Throws(IOException::class)
         fun readFrom(sin: StreamInput): MonitorMetadata {
             return MonitorMetadata(sin)
+        }
+
+        fun getId(monitor: Monitor): String {
+            return monitor.id + "-metadata"
         }
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
@@ -6,22 +6,11 @@
 package org.opensearch.alerting.util
 
 import org.apache.logging.log4j.LogManager
-import org.opensearch.action.index.IndexRequest
-import org.opensearch.action.index.IndexResponse
-import org.opensearch.action.support.WriteRequest
 import org.opensearch.alerting.model.BucketLevelTriggerRunResult
-import org.opensearch.alerting.model.MonitorMetadata
 import org.opensearch.alerting.model.destination.Destination
-import org.opensearch.alerting.opensearchapi.suspendUntil
-import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.settings.DestinationSettings
-import org.opensearch.client.Client
-import org.opensearch.common.settings.Settings
-import org.opensearch.common.xcontent.ToXContent
-import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.commons.alerting.model.AggregationResultBucket
 import org.opensearch.commons.alerting.model.Monitor
-import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.model.action.Action
 import org.opensearch.commons.alerting.model.action.ActionExecutionPolicy
 import org.opensearch.commons.alerting.model.action.ActionExecutionScope
@@ -121,14 +110,4 @@ fun defaultToPerExecutionAction(
     }
 
     return false
-}
-
-suspend fun updateMonitorMetadata(client: Client, settings: Settings, monitorMetadata: MonitorMetadata): IndexResponse {
-    val indexRequest = IndexRequest(ScheduledJob.SCHEDULED_JOBS_INDEX)
-        .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-        .source(monitorMetadata.toXContent(XContentFactory.jsonBuilder(), ToXContent.MapParams(mapOf("with_type" to "true"))))
-        .id(monitorMetadata.id)
-        .timeout(AlertingSettings.INDEX_TIMEOUT.get(settings))
-
-    return client.suspendUntil { client.index(indexRequest, it) }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
@@ -6,17 +6,23 @@
 package org.opensearch.alerting.util
 
 import org.apache.logging.log4j.LogManager
+import org.opensearch.OpenSearchStatusException
 import org.opensearch.ResourceAlreadyExistsException
+import org.opensearch.action.admin.indices.alias.Alias
 import org.opensearch.action.admin.indices.create.CreateIndexRequest
 import org.opensearch.action.admin.indices.create.CreateIndexResponse
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest
 import org.opensearch.action.admin.indices.get.GetIndexRequest
 import org.opensearch.action.admin.indices.get.GetIndexResponse
 import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest
+import org.opensearch.action.admin.indices.rollover.RolloverRequest
+import org.opensearch.action.admin.indices.rollover.RolloverResponse
 import org.opensearch.action.bulk.BulkRequest
 import org.opensearch.action.bulk.BulkResponse
 import org.opensearch.action.index.IndexRequest
 import org.opensearch.action.support.WriteRequest.RefreshPolicy
 import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.alerting.model.MonitorMetadata
 import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.client.Client
 import org.opensearch.cluster.service.ClusterService
@@ -27,11 +33,17 @@ import org.opensearch.commons.alerting.model.DocLevelMonitorInput
 import org.opensearch.commons.alerting.model.DocLevelQuery
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.ScheduledJob
+import org.opensearch.rest.RestStatus
 
 private val log = LogManager.getLogger(DocLevelMonitorQueries::class.java)
 
 class DocLevelMonitorQueries(private val client: Client, private val clusterService: ClusterService) {
     companion object {
+
+        const val PROPERTIES = "properties"
+        const val NESTED = "nested"
+        const val TYPE = "type"
+        const val INDEX_PATTERN_SUFFIX = "-000001"
         @JvmStatic
         fun docLevelQueriesMappings(): String {
             return DocLevelMonitorQueries::class.java.classLoader.getResource("mappings/doc-level-queries.json").readText()
@@ -40,8 +52,23 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
 
     suspend fun initDocLevelQueryIndex(): Boolean {
         if (!docLevelQueryIndexExists()) {
-            val indexRequest = CreateIndexRequest(ScheduledJob.DOC_LEVEL_QUERIES_INDEX)
+            // Since we changed queryIndex to be alias now, for backwards compatibility, we have to delete index with same name
+            // as our alias, to avoid name clash.
+            if (clusterService.state().metadata.hasIndex(ScheduledJob.DOC_LEVEL_QUERIES_INDEX)) {
+                val acknowledgedResponse: AcknowledgedResponse = client.suspendUntil {
+                    admin().indices().delete(DeleteIndexRequest(ScheduledJob.DOC_LEVEL_QUERIES_INDEX), it)
+                }
+                if (!acknowledgedResponse.isAcknowledged) {
+                    val errorMessage = "Deletion of old queryIndex [${ScheduledJob.DOC_LEVEL_QUERIES_INDEX}] index is not acknowledged!"
+                    log.error(errorMessage)
+                    throw AlertingException.wrap(OpenSearchStatusException(errorMessage, RestStatus.INTERNAL_SERVER_ERROR))
+                }
+            }
+            val alias = ScheduledJob.DOC_LEVEL_QUERIES_INDEX
+            val indexPattern = ScheduledJob.DOC_LEVEL_QUERIES_INDEX + INDEX_PATTERN_SUFFIX
+            val indexRequest = CreateIndexRequest(indexPattern)
                 .mapping(docLevelQueriesMappings())
+                .alias(Alias(alias))
                 .settings(
                     Settings.builder().put("index.hidden", true)
                         .build()
@@ -63,10 +90,24 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
         if (dataSources.queryIndex == ScheduledJob.DOC_LEVEL_QUERIES_INDEX) {
             return initDocLevelQueryIndex()
         }
-        val queryIndex = dataSources.queryIndex
-        if (!clusterService.state().routingTable.hasIndex(queryIndex)) {
-            val indexRequest = CreateIndexRequest(queryIndex)
+        // Since we changed queryIndex to be alias now, for backwards compatibility, we have to delete index with same name
+        // as our alias, to avoid name clash.
+        if (clusterService.state().metadata.hasIndex(dataSources.queryIndex)) {
+            val acknowledgedResponse: AcknowledgedResponse = client.suspendUntil {
+                admin().indices().delete(DeleteIndexRequest(dataSources.queryIndex), it)
+            }
+            if (!acknowledgedResponse.isAcknowledged) {
+                val errorMessage = "Deletion of old queryIndex [${dataSources.queryIndex}] index is not acknowledged!"
+                log.error(errorMessage)
+                throw AlertingException.wrap(OpenSearchStatusException(errorMessage, RestStatus.INTERNAL_SERVER_ERROR))
+            }
+        }
+        val alias = dataSources.queryIndex
+        val indexPattern = dataSources.queryIndex + INDEX_PATTERN_SUFFIX
+        if (!clusterService.state().metadata.hasAlias(alias)) {
+            val indexRequest = CreateIndexRequest(indexPattern)
                 .mapping(docLevelQueriesMappings())
+                .alias(Alias(alias))
                 .settings(
                     Settings.builder().put("index.hidden", true)
                         .build()
@@ -87,17 +128,70 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
 
     fun docLevelQueryIndexExists(dataSources: DataSources): Boolean {
         val clusterState = clusterService.state()
-        return clusterState.routingTable.hasIndex(dataSources.queryIndex)
+        return clusterState.metadata.hasAlias(dataSources.queryIndex)
     }
 
     fun docLevelQueryIndexExists(): Boolean {
         val clusterState = clusterService.state()
-        return clusterState.routingTable.hasIndex(ScheduledJob.DOC_LEVEL_QUERIES_INDEX)
+        return clusterState.metadata.hasAlias(ScheduledJob.DOC_LEVEL_QUERIES_INDEX)
+    }
+
+    /**
+     * Does a DFS traversal of index mappings tree.
+     * Calls processLeafFn on every leaf node.
+     * Populates flattenPaths list with full paths of leaf nodes
+     * @param node current node which we're visiting
+     * @param currentPath current node path from root node
+     * @param processLeafFn leaf processor function which is called on every leaf discovered
+     * @param flattenPaths list of full paths of all leaf nodes relative to root
+     */
+    fun traverseMappingsAndUpdate(
+        node: MutableMap<String, Any>,
+        currentPath: String,
+        processLeafFn: (String, MutableMap<String, Any>) -> Triple<String, String, MutableMap<String, Any>>,
+        flattenPaths: MutableList<String>
+    ) {
+        // If node contains "properties" property then it is internal(non-leaf) node
+        if (node.containsKey(PROPERTIES)) {
+            return traverseMappingsAndUpdate(node.get(PROPERTIES) as MutableMap<String, Any>, currentPath, processLeafFn, flattenPaths)
+        } else if (node.containsKey(TYPE) == false) {
+            // If there is no "type" property, this is either internal(non-leaf) node or leaf node
+            // newNodes will hold list of updated leaf properties
+            var newNodes = ArrayList<Triple<String, String, Any>>(node.size)
+            node.entries.forEach {
+                // Compute full path relative to root
+                val fullPath = if (currentPath.isEmpty()) it.key
+                else "$currentPath.${it.key}"
+                val nodeProps = it.value as MutableMap<String, Any>
+                // If it has type property and type is not "nested" then this is a leaf
+                if (nodeProps.containsKey(TYPE) && nodeProps[TYPE] != NESTED) {
+                    // At this point we know full path of node, so we add it to output array
+                    flattenPaths.add(fullPath)
+                    // Calls processLeafFn and gets old node name, new node name and new properties of node.
+                    // This is all information we need to update this node
+                    val (oldName, newName, props) = processLeafFn(it.key, it.value as MutableMap<String, Any>)
+                    newNodes.add(Triple(oldName, newName, props))
+                } else {
+                    // Internal(non-leaf) node - visit children
+                    traverseMappingsAndUpdate(nodeProps[PROPERTIES] as MutableMap<String, Any>, fullPath, processLeafFn, flattenPaths)
+                }
+            }
+            // Here we can update all processed leaves in tree
+            newNodes.forEach {
+                // If we renamed leaf, we have to remove it first
+                if (it.first != it.second) {
+                    node.remove(it.first)
+                }
+                // Put new properties of leaf
+                node.put(it.second, it.third)
+            }
+        }
     }
 
     suspend fun indexDocLevelQueries(
         monitor: Monitor,
         monitorId: String,
+        monitorMetadata: MonitorMetadata,
         refreshPolicy: RefreshPolicy = RefreshPolicy.IMMEDIATE,
         indexTimeout: TimeValue
     ) {
@@ -113,64 +207,185 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
         }
         val indices = getIndexResponse.indices()
 
+        // Run through each backing index and apply appropriate mappings to query index
         indices?.forEach { indexName ->
             if (clusterState.routingTable.hasIndex(indexName)) {
                 val indexMetadata = clusterState.metadata.index(indexName)
                 if (indexMetadata.mapping()?.sourceAsMap?.get("properties") != null) {
                     val properties = (
                         (indexMetadata.mapping()?.sourceAsMap?.get("properties"))
-                            as Map<String, Map<String, Any>>
+                            as MutableMap<String, Any>
                         )
-
-                    val updatedProperties = properties.entries.associate {
-                        val newVal = it.value.toMutableMap()
-                        if (monitor.dataSources.queryIndexMappingsByType.isNotEmpty()) {
-                            val mappingsByType = monitor.dataSources.queryIndexMappingsByType
-                            if (it.value.containsKey("type") && mappingsByType.containsKey(it.value["type"]!!)) {
-                                mappingsByType[it.value["type"]]?.entries?.forEach { iter: Map.Entry<String, String> ->
-                                    newVal[iter.key] = iter.value
+                    // Node processor function is used to process leaves of index mappings tree
+                    //
+                    val leafNodeProcessor =
+                        fun(fieldName: String, props: MutableMap<String, Any>): Triple<String, String, MutableMap<String, Any>> {
+                            val newProps = props.toMutableMap()
+                            if (monitor.dataSources.queryIndexMappingsByType.isNotEmpty()) {
+                                val mappingsByType = monitor.dataSources.queryIndexMappingsByType
+                                if (props.containsKey("type") && mappingsByType.containsKey(props["type"]!!)) {
+                                    mappingsByType[props["type"]]?.entries?.forEach { iter: Map.Entry<String, String> ->
+                                        newProps[iter.key] = iter.value
+                                    }
                                 }
                             }
+                            if (props.containsKey("path")) {
+                                newProps["path"] = "${props["path"]}_${indexName}_$monitorId"
+                            }
+                            return Triple(fieldName, "${fieldName}_${indexName}_$monitorId", newProps)
                         }
-                        if (it.value.containsKey("path")) newVal["path"] = "${it.value["path"]}_${indexName}_$monitorId"
-                        "${it.key}_${indexName}_$monitorId" to newVal
-                    }
-                    val queryIndex = monitor.dataSources.queryIndex
-
-                    val updateMappingRequest = PutMappingRequest(queryIndex)
-                    updateMappingRequest.source(mapOf<String, Any>("properties" to updatedProperties))
-                    val updateMappingResponse: AcknowledgedResponse = client.suspendUntil {
-                        client.admin().indices().putMapping(updateMappingRequest, it)
-                    }
+                    // Traverse and update index mappings here while extracting flatten field paths
+                    val flattenPaths = mutableListOf<String>()
+                    traverseMappingsAndUpdate(properties, "", leafNodeProcessor, flattenPaths)
+                    // Updated mappings ready to be applied on queryIndex
+                    val updatedProperties = properties
+                    // Updates mappings of concrete queryIndex. This can rollover queryIndex if field mapping limit is reached.
+                    var (updateMappingResponse, concreteQueryIndex) = updateQueryIndexMappings(
+                        monitor,
+                        monitorMetadata,
+                        indexName,
+                        updatedProperties
+                    )
 
                     if (updateMappingResponse.isAcknowledged) {
-                        val indexRequests = mutableListOf<IndexRequest>()
-                        queries.forEach {
-                            var query = it.query
-                            properties.forEach { prop ->
-                                query = query.replace("${prop.key}:", "${prop.key}_${indexName}_$monitorId:")
-                            }
-                            val indexRequest = IndexRequest(queryIndex)
-                                .id(it.id + "_${indexName}_$monitorId")
-                                .source(
-                                    mapOf(
-                                        "query" to mapOf("query_string" to mapOf("query" to query)),
-                                        "monitor_id" to monitorId,
-                                        "index" to indexName
-                                    )
-                                )
-                            indexRequests.add(indexRequest)
-                        }
-                        if (indexRequests.isNotEmpty()) {
-                            val bulkResponse: BulkResponse = client.suspendUntil {
-                                client.bulk(
-                                    BulkRequest().setRefreshPolicy(refreshPolicy).timeout(indexTimeout).add(indexRequests), it
-                                )
-                            }
-                        }
+                        doIndexAllQueries(concreteQueryIndex, indexName, monitorId, queries, flattenPaths, refreshPolicy, indexTimeout)
                     }
                 }
             }
         }
+    }
+
+    private suspend fun doIndexAllQueries(
+        concreteQueryIndex: String,
+        sourceIndex: String,
+        monitorId: String,
+        queries: List<DocLevelQuery>,
+        flattenPaths: MutableList<String>,
+        refreshPolicy: RefreshPolicy,
+        indexTimeout: TimeValue
+    ) {
+        val indexRequests = mutableListOf<IndexRequest>()
+        queries.forEach {
+            var query = it.query
+            flattenPaths.forEach { fieldPath ->
+                query = query.replace("$fieldPath:", "${fieldPath}_${sourceIndex}_$monitorId:")
+            }
+            val indexRequest = IndexRequest(concreteQueryIndex)
+                .id(it.id + "_${sourceIndex}_$monitorId")
+                .source(
+                    mapOf(
+                        "query" to mapOf("query_string" to mapOf("query" to query)),
+                        "monitor_id" to monitorId,
+                        "index" to sourceIndex
+                    )
+                )
+            indexRequests.add(indexRequest)
+        }
+        if (indexRequests.isNotEmpty()) {
+            val bulkResponse: BulkResponse = client.suspendUntil {
+                client.bulk(
+                    BulkRequest().setRefreshPolicy(refreshPolicy).timeout(indexTimeout).add(indexRequests), it
+                )
+            }
+            bulkResponse.forEach { bulkItemResponse ->
+                if (bulkItemResponse.isFailed) {
+                    log.debug(bulkItemResponse.failureMessage)
+                }
+            }
+        }
+    }
+
+    private suspend fun updateQueryIndexMappings(
+        monitor: Monitor,
+        monitorMetadata: MonitorMetadata,
+        sourceIndex: String,
+        updatedProperties: MutableMap<String, Any>
+    ): Pair<AcknowledgedResponse, String> {
+        var targetQueryIndex = monitorMetadata.sourceToQueryIndexMapping[sourceIndex + monitor.id]
+        if (targetQueryIndex == null) {
+            // queryIndex is alias which will always have only 1 backing index which is writeIndex
+            // This is due to a fact that that _rollover API would maintain only single index under alias
+            // if you don't add is_write_index setting when creating index initially
+            targetQueryIndex = getWriteIndexNameForAlias(monitor.dataSources.queryIndex)
+            if (targetQueryIndex == null) {
+                val message = "Failed to get write index for queryIndex alias:${monitor.dataSources.queryIndex}"
+                log.error(message)
+                throw AlertingException.wrap(
+                    OpenSearchStatusException(message, RestStatus.INTERNAL_SERVER_ERROR)
+                )
+            }
+            monitorMetadata.sourceToQueryIndexMapping[sourceIndex + monitor.id] = targetQueryIndex
+        }
+        val updateMappingRequest = PutMappingRequest(targetQueryIndex)
+        updateMappingRequest.source(mapOf<String, Any>("properties" to updatedProperties))
+        var updateMappingResponse = AcknowledgedResponse(false)
+        try {
+            updateMappingResponse = client.suspendUntil {
+                client.admin().indices().putMapping(updateMappingRequest, it)
+            }
+            return Pair(updateMappingResponse, targetQueryIndex)
+        } catch (e: Exception) {
+            // If we reached limit for total number of fields in mappings, do a rollover here
+            if (e.message?.contains("Limit of total fields") == true) {
+                targetQueryIndex = rolloverQueryIndex(monitor)
+                try {
+                    // PUT mappings to newly created index
+                    val updateMappingRequest = PutMappingRequest(targetQueryIndex)
+                    updateMappingRequest.source(mapOf<String, Any>("properties" to updatedProperties))
+                    updateMappingResponse = client.suspendUntil {
+                        client.admin().indices().putMapping(updateMappingRequest, it)
+                    }
+                } catch (e: Exception) {
+                    // If we reached limit for total number of fields in mappings after rollover
+                    // it means that source index has more then (FIELD_LIMIT - 3) fields (every query index has 3 fields defined)
+                    // TODO maybe split queries/mappings between multiple query indices?
+                    if (e.message?.contains("Limit of total fields") == true) {
+                        val errorMessage =
+                            "Monitor [${monitorMetadata.monitorId}] can't process index [$sourceIndex] due to field mapping limit"
+                        log.error(errorMessage)
+                        throw AlertingException(errorMessage, RestStatus.INTERNAL_SERVER_ERROR, e)
+                    } else {
+                        throw AlertingException.wrap(e)
+                    }
+                }
+            } else {
+                throw AlertingException.wrap(e)
+            }
+        }
+        // We did rollover, so try to apply mappings again on new targetQueryIndex
+        if (targetQueryIndex.isNotEmpty()) {
+            // add newly created index to monitor's metadata object so that we can fetch it later on, when either applying mappings or running queries
+            monitorMetadata.sourceToQueryIndexMapping[sourceIndex + monitor.id] = targetQueryIndex
+        } else {
+            val failureMessage = "Failed to resolve targetQueryIndex!"
+            log.error(failureMessage)
+            throw AlertingException(failureMessage, RestStatus.INTERNAL_SERVER_ERROR, IllegalStateException(failureMessage))
+        }
+        return Pair(updateMappingResponse, targetQueryIndex)
+    }
+
+    private suspend fun rolloverQueryIndex(monitor: Monitor): String? {
+        val queryIndex = monitor.dataSources.queryIndex
+        val queryIndexPattern = monitor.dataSources.queryIndex + INDEX_PATTERN_SUFFIX
+
+        val request = RolloverRequest(queryIndex, null)
+        request.createIndexRequest.index(queryIndexPattern)
+            .mapping(docLevelQueriesMappings())
+            .settings(Settings.builder().put("index.hidden", true).build())
+        val response: RolloverResponse = client.suspendUntil {
+            client.admin().indices().rolloverIndex(request, it)
+        }
+        if (response.isRolledOver == false) {
+            val message = "failed to rollover queryIndex:$queryIndex queryIndexPattern:$queryIndexPattern"
+            log.error(message)
+            throw AlertingException.wrap(
+                OpenSearchStatusException(message, RestStatus.INTERNAL_SERVER_ERROR)
+            )
+        }
+        return response.newIndex
+    }
+
+    private fun getWriteIndexNameForAlias(alias: String): String? {
+        return this.clusterService.state().metadata().indicesLookup?.get(alias)?.writeIndex?.index?.name
     }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
@@ -74,7 +74,6 @@ import javax.management.MBeanServerInvocationHandler
 import javax.management.ObjectName
 import javax.management.remote.JMXConnectorFactory
 import javax.management.remote.JMXServiceURL
-import kotlin.collections.HashMap
 
 /**
  * Superclass for tests that interact with an external test cluster using OpenSearch's RestClient
@@ -686,7 +685,7 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
     }
 
     protected fun refreshIndex(index: String): Response {
-        val response = client().makeRequest("POST", "/$index/_refresh")
+        val response = client().makeRequest("POST", "/$index/_refresh?expand_wildcards=all")
         assertEquals("Unable to refresh index", RestStatus.OK, response.restStatus())
         return response
     }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/alerts/AlertIndicesIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/alerts/AlertIndicesIT.kt
@@ -62,7 +62,7 @@ class AlertIndicesIT : AlertingRestTestCase() {
         executeMonitor(createRandomMonitor())
         assertIndexExists(AlertIndices.ALERT_INDEX)
         assertIndexExists(AlertIndices.ALERT_HISTORY_WRITE_INDEX)
-        verifyIndexSchemaVersion(ScheduledJob.SCHEDULED_JOBS_INDEX, 5)
+        verifyIndexSchemaVersion(ScheduledJob.SCHEDULED_JOBS_INDEX, 6)
         verifyIndexSchemaVersion(AlertIndices.ALERT_INDEX, 4)
         verifyIndexSchemaVersion(AlertIndices.ALERT_HISTORY_WRITE_INDEX, 4)
     }
@@ -86,7 +86,7 @@ class AlertIndicesIT : AlertingRestTestCase() {
         val trueMonitor = createMonitor(randomDocumentLevelMonitor(inputs = listOf(docLevelInput), triggers = listOf(trigger)))
         executeMonitor(trueMonitor.id)
         assertIndexExists(AlertIndices.FINDING_HISTORY_WRITE_INDEX)
-        verifyIndexSchemaVersion(ScheduledJob.SCHEDULED_JOBS_INDEX, 5)
+        verifyIndexSchemaVersion(ScheduledJob.SCHEDULED_JOBS_INDEX, 6)
         verifyIndexSchemaVersion(AlertIndices.FINDING_HISTORY_WRITE_INDEX, 1)
     }
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/model/XContentTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/model/XContentTests.kt
@@ -80,7 +80,13 @@ class XContentTests : OpenSearchTestCase() {
     }
 
     fun `test MonitorMetadata`() {
-        val monitorMetadata = MonitorMetadata("monitorId-metadata", "monitorId", emptyList(), emptyMap())
+        val monitorMetadata = MonitorMetadata(
+            id = "monitorId-metadata",
+            monitorId = "monitorId",
+            lastActionExecutionTimes = emptyList(),
+            lastRunContext = emptyMap(),
+            sourceToQueryIndexMapping = mutableMapOf()
+        )
         val monitorMetadataString = monitorMetadata.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS).string()
         val parsedMonitorMetadata = MonitorMetadata.parse(parser(monitorMetadataString))
         assertEquals("Round tripping MonitorMetadata doesn't work", monitorMetadata, parsedMonitorMetadata)

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -61,6 +61,7 @@ import org.opensearch.test.rest.OpenSearchRestTestCase
 import java.time.Instant
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
 
 @TestLogging("level:DEBUG", reason = "Debug for tests.")
 @Suppress("UNCHECKED_CAST")
@@ -866,14 +867,26 @@ class MonitorRestApiIT : AlertingRestTestCase() {
             updatedMonitor.toHttpEntity()
         )
         assertEquals("Update request not successful", RestStatus.OK, updateResponse.restStatus())
-
-        // Wait 5 seconds for event to be processed and alerts moved
-        Thread.sleep(5000)
-
+        // Wait until postIndex hook is executed due to monitor update
+        waitUntil({
+            val alerts = searchAlerts(monitor)
+            if (alerts.size == 1) {
+                return@waitUntil true
+            }
+            return@waitUntil false
+        }, 60, TimeUnit.SECONDS)
         val alerts = searchAlerts(monitor)
         // We have two alerts from above, 1 for each trigger, there should be only 1 left in active index
         assertEquals("One alert should be in active index", 1, alerts.size)
         assertEquals("Wrong alert in active index", alertKeep.toJsonString(), alerts.single().toJsonString())
+
+        waitUntil({
+            val alerts = searchAlerts(monitor, AlertIndices.ALERT_HISTORY_WRITE_INDEX)
+            if (alerts.size == 1) {
+                return@waitUntil true
+            }
+            return@waitUntil false
+        }, 60, TimeUnit.SECONDS)
 
         val historyAlerts = searchAlerts(monitor, AlertIndices.ALERT_HISTORY_WRITE_INDEX)
         // Only alertDelete should of been moved to history index

--- a/core/src/main/resources/mappings/scheduled-jobs.json
+++ b/core/src/main/resources/mappings/scheduled-jobs.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 5
+    "schema_version": 6
   },
   "properties": {
     "monitor": {
@@ -510,6 +510,10 @@
           }
         },
         "last_run_context": {
+          "type": "object",
+          "enabled": false
+        },
+        "source_to_query_index_mapping": {
           "type": "object",
           "enabled": false
         }


### PR DESCRIPTION
Signed-off-by: Petar Dzepina <petar.dzepina@gmail.com>

*Issue #, if available:*

*Description of changes:*

*CheckList:*
[ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).