### PR TITLE
Fix setting default title only when no subject has been set

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
@@ -19,7 +19,6 @@ import org.opensearch.alerting.script.QueryLevelTriggerExecutionContext
 import org.opensearch.alerting.script.TriggerExecutionContext
 import org.opensearch.alerting.util.destinationmigration.NotificationActionConfigs
 import org.opensearch.alerting.util.destinationmigration.NotificationApiUtils.Companion.getNotificationConfigInfo
-import org.opensearch.alerting.util.destinationmigration.createMessageContent
 import org.opensearch.alerting.util.destinationmigration.getTitle
 import org.opensearch.alerting.util.destinationmigration.publishLegacyNotification
 import org.opensearch.alerting.util.destinationmigration.sendNotification
@@ -109,7 +108,7 @@ abstract class MonitorRunner {
             ?.sendNotification(
                 monitorCtx.client!!,
                 config.channel.getTitle(subject),
-                config.channel.createMessageContent(subject, message)
+                message
             ) ?: actionResponseContent
 
         actionResponseContent = config.destination

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/NotificationApiUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/NotificationApiUtils.kt
@@ -14,7 +14,6 @@ import org.opensearch.alerting.opensearchapi.retryForNotification
 import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.client.Client
 import org.opensearch.client.node.NodeClient
-import org.opensearch.common.Strings
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.commons.ConfigConstants
 import org.opensearch.commons.destination.message.LegacyBaseMessage
@@ -27,7 +26,6 @@ import org.opensearch.commons.notifications.action.LegacyPublishNotificationRequ
 import org.opensearch.commons.notifications.action.LegacyPublishNotificationResponse
 import org.opensearch.commons.notifications.action.SendNotificationResponse
 import org.opensearch.commons.notifications.model.ChannelMessage
-import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.notifications.model.EventSource
 import org.opensearch.commons.notifications.model.NotificationConfigInfo
 import org.opensearch.commons.notifications.model.SeverityType
@@ -138,33 +136,11 @@ suspend fun NotificationConfigInfo.sendNotification(client: Client, title: Strin
 }
 
 /**
- * For most channel types, a placeholder Alerting title will be used but the email channel/SNS notification will
- * use the subject, so it appears as the actual subject of the email/SNS notification.
+ * A placeholder Alerting title will be used if no subject is passed in.
  */
 fun NotificationConfigInfo.getTitle(subject: String?): String {
     val defaultTitle = "Alerting-Notification Action"
-    if (this.notificationConfig.configType == ConfigType.EMAIL || this.notificationConfig.configType == ConfigType.SNS) {
-        return if (subject.isNullOrEmpty()) defaultTitle else subject
-    }
-
-    return defaultTitle
-}
-
-fun NotificationConfigInfo.createMessageContent(subject: String?, message: String): String {
-    // For Email Channels, the subject is not passed in the main message since it's used as the title
-    if (this.notificationConfig.configType == ConfigType.EMAIL) {
-        return constructMessageContent("", message)
-    }
-
-    return constructMessageContent(subject, message)
-}
-
-/**
- * Similar to Destinations, this is a generic utility method for constructing message content from
- * a subject and message body when sending through Notifications since the Action definition in Monitors can have both.
- */
-private fun constructMessageContent(subject: String?, message: String): String {
-    return if (Strings.isNullOrEmpty(subject)) message else "$subject \n\n $message"
+    return if (subject.isNullOrEmpty()) defaultTitle else subject
 }
 
 /**


### PR DESCRIPTION
Signed-off-by: Ashish Agrawal <ashisagr@amazon.com>

*Issue #, if available:*
#529, #731
*Description of changes:*
Set default title only when there is no subject passed.

action message configuration example:
![action message configuration](https://user-images.githubusercontent.com/7276393/214720200-9b946b89-9e42-4de0-9cc5-779440db7c43.png)


Current message look in chime:
![old notification look](https://user-images.githubusercontent.com/7276393/214720270-60fa379e-4567-4d58-8878-3b7c71c1d0c5.png)


Before Notification plugin introduction in chime:
![before 2 0 behavior](https://user-images.githubusercontent.com/7276393/214720340-54b2acb9-00c1-45a6-9f0a-0837b3eab0bf.png)


With the fix look in chime:
![updated message look](https://user-images.githubusercontent.com/7276393/214720403-9997fb80-5de3-45ea-9fe0-4bec8d392582.png)

With the fix for SNS:
<img width="806" alt="Screen Shot 2023-02-09 at 11 14 16 AM" src="https://user-images.githubusercontent.com/7276393/217914683-d08e1413-f3a0-484a-b0c7-2ccfc06ba683.png">


*CheckList:*
[X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).