### PR TITLE
Feature/monitor explain api

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -12,6 +12,7 @@ import org.opensearch.alerting.action.GetDestinationsAction
 import org.opensearch.alerting.action.GetEmailAccountAction
 import org.opensearch.alerting.action.GetEmailGroupAction
 import org.opensearch.alerting.action.GetMonitorAction
+import org.opensearch.alerting.action.MonitorExplainAction
 import org.opensearch.alerting.action.SearchEmailAccountAction
 import org.opensearch.alerting.action.SearchEmailGroupAction
 import org.opensearch.alerting.action.SearchMonitorAction
@@ -34,6 +35,7 @@ import org.opensearch.alerting.resthandler.RestGetEmailGroupAction
 import org.opensearch.alerting.resthandler.RestGetFindingsAction
 import org.opensearch.alerting.resthandler.RestGetMonitorAction
 import org.opensearch.alerting.resthandler.RestIndexMonitorAction
+import org.opensearch.alerting.resthandler.RestMonitorExplainAction
 import org.opensearch.alerting.resthandler.RestSearchEmailAccountAction
 import org.opensearch.alerting.resthandler.RestSearchEmailGroupAction
 import org.opensearch.alerting.resthandler.RestSearchMonitorAction
@@ -52,6 +54,7 @@ import org.opensearch.alerting.transport.TransportGetEmailGroupAction
 import org.opensearch.alerting.transport.TransportGetFindingsSearchAction
 import org.opensearch.alerting.transport.TransportGetMonitorAction
 import org.opensearch.alerting.transport.TransportIndexMonitorAction
+import org.opensearch.alerting.transport.TransportMonitorExplainAction
 import org.opensearch.alerting.transport.TransportSearchEmailAccountAction
 import org.opensearch.alerting.transport.TransportSearchEmailGroupAction
 import org.opensearch.alerting.transport.TransportSearchMonitorAction
@@ -161,7 +164,8 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             RestGetEmailGroupAction(),
             RestGetDestinationsAction(),
             RestGetAlertsAction(),
-            RestGetFindingsAction()
+            RestGetFindingsAction(),
+            RestMonitorExplainAction()
         )
     }
 
@@ -180,7 +184,8 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             ActionPlugin.ActionHandler(SearchEmailGroupAction.INSTANCE, TransportSearchEmailGroupAction::class.java),
             ActionPlugin.ActionHandler(GetDestinationsAction.INSTANCE, TransportGetDestinationsAction::class.java),
             ActionPlugin.ActionHandler(AlertingActions.GET_ALERTS_ACTION_TYPE, TransportGetAlertsAction::class.java),
-            ActionPlugin.ActionHandler(AlertingActions.GET_FINDINGS_ACTION_TYPE, TransportGetFindingsSearchAction::class.java)
+            ActionPlugin.ActionHandler(AlertingActions.GET_FINDINGS_ACTION_TYPE, TransportGetFindingsSearchAction::class.java),
+            ActionPlugin.ActionHandler(MonitorExplainAction.INSTANCE, TransportMonitorExplainAction::class.java)
 
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/action/MonitorExplainAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/action/MonitorExplainAction.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.action
+
+import org.opensearch.action.ActionType
+
+class MonitorExplainAction private constructor() : ActionType<MonitorExplainResponse>(NAME, ::MonitorExplainResponse) {
+    companion object {
+        val INSTANCE = MonitorExplainAction()
+        const val NAME = "cluster:admin/opendistro/alerting/monitor/explain"
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/action/MonitorExplainRequest.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/action/MonitorExplainRequest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.action
+
+import org.opensearch.action.ActionRequest
+import org.opensearch.action.ActionRequestValidationException
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.io.stream.StreamOutput
+import java.io.IOException
+class MonitorExplainRequest : ActionRequest {
+
+    val monitorId: String
+    val docDiff: Boolean
+    constructor(
+        monitorId: String,
+        docDiff: Boolean
+    ) : super() {
+        this.monitorId = monitorId
+        this.docDiff = docDiff
+    }
+
+    @Throws(IOException::class)
+    constructor(sin: StreamInput) : this(
+        sin.readString(),
+        sin.readBoolean()
+    )
+
+    override fun validate(): ActionRequestValidationException? {
+        return null
+    }
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        out.writeString(monitorId)
+        out.writeBoolean(docDiff)
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/action/MonitorExplainResponse.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/action/MonitorExplainResponse.kt
@@ -16,41 +16,33 @@ import java.io.IOException
 
 class MonitorExplainResponse : ActionResponse, ToXContentObject {
     var monitorId: String
-    var seqNoDiff: Long
-    var docDiff: Long?
+    var documentsBehind: Long
 
     constructor(
         monitorId: String,
-        seqNoDiff: Long,
-        docDiff: Long?
+        documentsBehind: Long,
     ) : super() {
         this.monitorId = monitorId
-        this.seqNoDiff = seqNoDiff
-        this.docDiff = docDiff
+        this.documentsBehind = documentsBehind
     }
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         sin.readString(), // id
-        sin.readLong(), // seqNo
-        sin.readOptionalLong() // docDiff
+        sin.readLong(), // documentsBehind
     )
 
     @Throws(IOException::class)
     override fun writeTo(out: StreamOutput) {
         out.writeString(monitorId)
-        out.writeLong(seqNoDiff)
-        out.writeOptionalLong(docDiff)
+        out.writeLong(documentsBehind)
     }
 
     @Throws(IOException::class)
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         builder.startObject()
             .field(_ID, monitorId)
-            .field("seq_no_diff", seqNoDiff)
-
-        if (docDiff != null)
-            builder.field("doc_diff", docDiff)
+            .field("documents_behind", documentsBehind)
 
         return builder.endObject()
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/action/MonitorExplainResponse.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/action/MonitorExplainResponse.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.action
+
+import org.opensearch.action.ActionResponse
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.common.xcontent.ToXContent
+import org.opensearch.common.xcontent.ToXContentObject
+import org.opensearch.common.xcontent.XContentBuilder
+import org.opensearch.commons.alerting.util.IndexUtils.Companion._ID
+import java.io.IOException
+
+class MonitorExplainResponse : ActionResponse, ToXContentObject {
+    var monitorId: String
+    var seqNoDiff: Long
+    var docDiff: Long?
+
+    constructor(
+        monitorId: String,
+        seqNoDiff: Long,
+        docDiff: Long?
+    ) : super() {
+        this.monitorId = monitorId
+        this.seqNoDiff = seqNoDiff
+        this.docDiff = docDiff
+    }
+
+    @Throws(IOException::class)
+    constructor(sin: StreamInput) : this(
+        sin.readString(), // id
+        sin.readLong(), // seqNo
+        sin.readOptionalLong() // docDiff
+    )
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        out.writeString(monitorId)
+        out.writeLong(seqNoDiff)
+        out.writeOptionalLong(docDiff)
+    }
+
+    @Throws(IOException::class)
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        builder.startObject()
+            .field(_ID, monitorId)
+            .field("seq_no_diff", seqNoDiff)
+
+        if (docDiff != null)
+            builder.field("doc_diff", docDiff)
+
+        return builder.endObject()
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestMonitorExplainAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestMonitorExplainAction.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.resthandler
+
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import org.opensearch.alerting.AlertingPlugin
+import org.opensearch.alerting.action.MonitorExplainAction
+import org.opensearch.alerting.action.MonitorExplainRequest
+import org.opensearch.client.node.NodeClient
+import org.opensearch.rest.BaseRestHandler
+import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestHandler.Route
+import org.opensearch.rest.RestRequest
+import org.opensearch.rest.action.RestToXContentListener
+
+private val log: Logger = LogManager.getLogger(RestMonitorExplainAction::class.java)
+class RestMonitorExplainAction : BaseRestHandler() {
+    override fun getName(): String {
+        return "monitor_explain_action"
+    }
+
+    override fun routes(): List<Route> {
+        return listOf()
+    }
+
+    override fun replacedRoutes(): MutableList<RestHandler.ReplacedRoute> {
+        return mutableListOf(
+            // Search for monitors
+            RestHandler.ReplacedRoute(
+                RestRequest.Method.GET,
+                "${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}/_explain",
+                RestRequest.Method.GET,
+                "${AlertingPlugin.LEGACY_OPENDISTRO_MONITOR_BASE_URI}/{monitorID}/_explain"
+            )
+        )
+    }
+
+    override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
+        log.debug("${request.method()} ${AlertingPlugin.MONITOR_BASE_URI}/{monitorID}/_explain")
+
+        val monitorId = request.param("monitorID")
+
+        val docDiffString = request.param("doc_diff")
+        val docDiff = docDiffString?.toBoolean() ?: false
+
+        log.debug("${request.method()} ${AlertingPlugin.MONITOR_BASE_URI}/$monitorId")
+
+        val monitorExplainRequest = MonitorExplainRequest(monitorId, docDiff)
+
+        return RestChannelConsumer { channel -> client.execute(MonitorExplainAction.INSTANCE, monitorExplainRequest, RestToXContentListener(channel)) }
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportMonitorExplainAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportMonitorExplainAction.kt
@@ -1,0 +1,211 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+package org.opensearch.alerting.transport
+
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import org.apache.logging.log4j.LogManager
+import org.opensearch.OpenSearchStatusException
+import org.opensearch.action.ActionListener
+import org.opensearch.action.admin.indices.get.GetIndexRequest
+import org.opensearch.action.admin.indices.get.GetIndexResponse
+import org.opensearch.action.get.GetRequest
+import org.opensearch.action.get.GetResponse
+import org.opensearch.action.search.SearchRequest
+import org.opensearch.action.search.SearchResponse
+import org.opensearch.action.support.ActionFilters
+import org.opensearch.action.support.HandledTransportAction
+import org.opensearch.alerting.MonitorMetadataService
+import org.opensearch.alerting.action.MonitorExplainAction
+import org.opensearch.alerting.action.MonitorExplainRequest
+import org.opensearch.alerting.action.MonitorExplainResponse
+import org.opensearch.alerting.opensearchapi.suspendUntil
+import org.opensearch.alerting.settings.AlertingSettings
+import org.opensearch.alerting.settings.DestinationSettings.Companion.ALLOW_LIST
+import org.opensearch.alerting.util.AlertingException
+import org.opensearch.client.Client
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.inject.Inject
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.xcontent.LoggingDeprecationHandler
+import org.opensearch.common.xcontent.NamedXContentRegistry
+import org.opensearch.common.xcontent.XContentHelper
+import org.opensearch.common.xcontent.XContentType
+import org.opensearch.commons.alerting.model.DocLevelMonitorInput
+import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.ScheduledJob
+import org.opensearch.commons.authuser.User
+import org.opensearch.index.query.BoolQueryBuilder
+import org.opensearch.index.query.QueryBuilders
+import org.opensearch.rest.RestStatus
+import org.opensearch.search.builder.SearchSourceBuilder
+import org.opensearch.tasks.Task
+import org.opensearch.transport.TransportService
+import java.io.IOException
+
+private val log = LogManager.getLogger(TransportMonitorExplainAction::class.java)
+
+class TransportMonitorExplainAction @Inject constructor(
+    transportService: TransportService,
+    val client: Client,
+    actionFilters: ActionFilters,
+    val clusterService: ClusterService,
+    settings: Settings,
+    val xContentRegistry: NamedXContentRegistry
+) : HandledTransportAction<MonitorExplainRequest, MonitorExplainResponse>(
+    MonitorExplainAction.NAME, transportService, actionFilters, ::MonitorExplainRequest
+),
+    SecureTransportAction {
+
+    @Volatile
+    override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+
+    @Volatile
+    private var allowList = ALLOW_LIST.get(settings)
+
+    init {
+        clusterService.clusterSettings.addSettingsUpdateConsumer(ALLOW_LIST) { allowList = it }
+    }
+
+    override fun doExecute(
+        task: Task,
+        monitorExplainRequest: MonitorExplainRequest,
+        actionListener: ActionListener<MonitorExplainResponse>
+    ) {
+        val user: User? = readUserFromThreadContext(client)
+
+        val validateBackendRoleMessage: Boolean = validateUserBackendRoles(user, actionListener)
+        if (!validateBackendRoleMessage) {
+            actionListener.onFailure(
+                OpenSearchStatusException(
+                    "Do not have permissions to resource",
+                    RestStatus.FORBIDDEN
+                )
+            )
+            return
+        }
+
+        client.threadPool().threadContext.stashContext().use {
+            GlobalScope.launch(Dispatchers.IO + CoroutineName("MonitorExplainAction")) {
+                MonitorExplainHandler(client, actionListener, monitorExplainRequest.monitorId, monitorExplainRequest.docDiff, user).start()
+            }
+        }
+    }
+    inner class MonitorExplainHandler(
+        private val client: Client,
+        private val actionListener: ActionListener<MonitorExplainResponse>,
+        private val monitorId: String,
+        private val docDiffRequested: Boolean,
+        private val user: User?
+    ) {
+        suspend fun start() {
+            try {
+                val monitor = getMonitor()
+
+                if (!checkUserPermissionsWithResource(
+                        user,
+                        monitor.user,
+                        actionListener,
+                        "monitor",
+                        monitor.id
+                    )
+                ) {
+                    return
+                }
+
+                if (monitor.monitorType == Monitor.MonitorType.DOC_LEVEL_MONITOR) {
+                    log.debug("Doc-level monitor hit.")
+
+                    val docLevelMonitorInput = monitor.inputs[0] as DocLevelMonitorInput
+                    val index = docLevelMonitorInput.indices[0]
+
+                    val getIndexRequest = GetIndexRequest().indices(index)
+                    val getIndexResponse: GetIndexResponse = client.suspendUntil {
+                        client.admin().indices().getIndex(getIndexRequest, it)
+                    }
+                    val indices = getIndexResponse.indices()
+
+                    val monitorMetadata = MonitorMetadataService.getMetadata(monitor)
+                        ?: throw IllegalStateException("Monitor created without metadata not explainable!")
+
+                    val lastRunContext = if (monitorMetadata.lastRunContext.isEmpty()) mutableMapOf()
+                    else monitorMetadata.lastRunContext.toMutableMap() as MutableMap<String, MutableMap<String, Any>>
+
+                    var seqNoDiffAmount: Long = 0
+                    var docDiffAmount: Long = 0
+
+                    indices.forEach { indexName ->
+                        val indexLastRunContext = lastRunContext.getOrPut(indexName) {
+                            MonitorMetadataService.createRunContextForIndex(indexName)
+                        }
+
+                        val indexUpdatedRunContext = MonitorMetadataService.createRunContextForIndex(
+                            indexName
+                        )
+
+                        val count: Int = indexUpdatedRunContext["shards_count"] as Int
+                        for (i: Int in 0 until count) {
+                            val shard = i.toString()
+
+                            val maxSeqNo: Long = indexUpdatedRunContext[shard].toString().toLong()
+                            val prevSeqNo: Long = indexLastRunContext[shard].toString().toLong()
+
+                            seqNoDiffAmount += maxSeqNo - prevSeqNo
+
+                            if (docDiffRequested) {
+                                val boolQueryBuilder = BoolQueryBuilder()
+                                boolQueryBuilder.filter(QueryBuilders.rangeQuery("_seq_no").gt(prevSeqNo).lte(maxSeqNo))
+
+                                val request: SearchRequest = SearchRequest()
+                                    .indices(indexName)
+                                    .preference("_shards:$shard")
+                                    .source(
+                                        SearchSourceBuilder()
+                                            .query(boolQueryBuilder)
+                                            .size(0)
+                                    )
+
+                                val response: SearchResponse = client.suspendUntil { client.search(request, it) }
+                                if (response.status() !== RestStatus.OK) {
+                                    throw IOException("Failed to search shard: $shard")
+                                }
+
+                                docDiffAmount += response.hits.totalHits?.value ?: 0
+                            }
+                        }
+                    }
+                    val docDiffResult: Long? = if (docDiffRequested) docDiffAmount else null
+                    actionListener.onResponse(MonitorExplainResponse(monitorId, seqNoDiffAmount, docDiffResult))
+                } else {
+                    actionListener.onFailure(
+                        AlertingException("Not allowed to explain this type of monitor!", RestStatus.FORBIDDEN, IllegalStateException())
+                    )
+                }
+            } catch (e: Exception) {
+                actionListener.onFailure(AlertingException.wrap(e))
+            }
+        }
+        private suspend fun getMonitor(): Monitor {
+            val getRequest = GetRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, monitorId)
+
+            val getResponse: GetResponse = client.suspendUntil { get(getRequest, it) }
+            if (!getResponse.isExists) {
+                actionListener.onFailure(
+                    AlertingException.wrap(
+                        OpenSearchStatusException("Monitor with $monitorId is not found", RestStatus.NOT_FOUND)
+                    )
+                )
+            }
+            val xcp = XContentHelper.createParser(
+                xContentRegistry, LoggingDeprecationHandler.INSTANCE,
+                getResponse.sourceAsBytesRef, XContentType.JSON
+            )
+            return ScheduledJob.parse(xcp, getResponse.id, getResponse.version) as Monitor
+        }
+    }
+}

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AccessRoles.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AccessRoles.kt
@@ -21,6 +21,7 @@ val ALERTING_EXECUTE_MONITOR_ACCESS = "alerting_execute_monitor_access"
 val ALERTING_DELETE_MONITOR_ACCESS = "alerting_delete_monitor_access"
 val ALERTING_GET_DESTINATION_ACCESS = "alerting_get_destination_access"
 val ALERTING_GET_ALERTS_ACCESS = "alerting_get_alerts_access"
+val ALERTING_EXPLAIN_MONITOR_ACCES = "alerting_explain_monitor_access"
 
 val ROLE_TO_PERMISSION_MAPPING = mapOf(
     ALERTING_NO_ACCESS_ROLE to "",
@@ -34,5 +35,6 @@ val ROLE_TO_PERMISSION_MAPPING = mapOf(
     ALERTING_EXECUTE_MONITOR_ACCESS to "cluster:admin/opendistro/alerting/monitor/execute",
     ALERTING_DELETE_MONITOR_ACCESS to "cluster:admin/opendistro/alerting/monitor/delete",
     ALERTING_GET_DESTINATION_ACCESS to "cluster:admin/opendistro/alerting/destination/get",
-    ALERTING_GET_ALERTS_ACCESS to "cluster:admin/opendistro/alerting/alerts/get"
+    ALERTING_GET_ALERTS_ACCESS to "cluster:admin/opendistro/alerting/alerts/get",
+    ALERTING_EXPLAIN_MONITOR_ACCES to "cluster:admin/opendistro/alerting/monitor/explain"
 )

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
@@ -696,6 +696,20 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         return response
     }
 
+    protected fun explainMonitor(monitorId: String, doc_diff: Boolean = false): Response {
+        return explainMonitor(client(), monitorId, doc_diff)
+    }
+
+    protected fun explainMonitor(client: RestClient, monitorId: String, doc_diff: Boolean): Response {
+        val params: Map<String, String> = mutableMapOf()
+        return client.makeRequest("GET", "$ALERTING_BASE_URI/$monitorId/_explain?doc_diff=$doc_diff", params)
+    }
+
+    protected fun explainMonitor(client: RestClient, monitor: Monitor, doc_diff: Boolean = false): Response {
+        val params: Map<String, String> = mutableMapOf()
+        return client.makeRequest("GET", "$ALERTING_BASE_URI/_explain?doc_diff=$doc_diff", params, monitor.toHttpEntityWithUser())
+    }
+
     protected fun executeMonitor(monitorId: String, params: Map<String, String> = mutableMapOf()): Response {
         return executeMonitor(client(), monitorId, params)
     }
@@ -749,6 +763,10 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         return indexDoc(client(), index, id, doc, refresh)
     }
 
+    protected fun updateDoc(index: String, id: String, doc: String, params: Map<String, String> = mutableMapOf()): Response {
+        return updateDoc(client(), index, id, doc, params)
+    }
+
     protected fun indexDocWithAdminClient(index: String, id: String, doc: String, refresh: Boolean = true): Response {
         return indexDoc(adminClient(), index, id, doc, refresh)
     }
@@ -759,6 +777,16 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         val response = client.makeRequest("PUT", "$index/_doc/$id", params, requestBody)
         assertTrue(
             "Unable to index doc: '${doc.take(15)}...' to index: '$index'",
+            listOf(RestStatus.OK, RestStatus.CREATED).contains(response.restStatus())
+        )
+        return response
+    }
+
+    private fun updateDoc(client: RestClient, index: String, id: String, doc: String, params: Map<String, String>): Response {
+        val requestBody = StringEntity(doc, APPLICATION_JSON)
+        val response = client.makeRequest("POST", "$index/_update/$id", params, requestBody)
+        assertTrue(
+            "Unable to update doc: '${doc.take(15)}...' to index: '$index'",
             listOf(RestStatus.OK, RestStatus.CREATED).contains(response.restStatus())
         )
         return response

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -404,23 +404,21 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         val monitor = createMonitor(randomDocumentLevelMonitor(inputs = listOf(docLevelInput), triggers = listOf(trigger)))
         assertNotNull(monitor.id)
 
-        var response = explainMonitor(monitor.id)
-        var output = entityAsMap(response)
+        var output = entityAsMap(explainMonitor(monitor.id))
 
-        assertEquals(monitor.id, output["_id"])
-        assertEquals(0, output["seq_no_diff"])
+        assertEquals("Documents behind miscount", monitor.id, output["_id"])
+        assertEquals("Documents behind miscount", 0, output["documents_behind"])
 
         indexDoc(testIndex, "1", testDoc)
         indexDoc(testIndex, "5", testDoc)
 
-        response = explainMonitor(monitor.id)
-        output = entityAsMap(response)
+        output = entityAsMap(explainMonitor(monitor.id))
 
-        assertEquals(monitor.id, output["_id"])
-        assertEquals(2, output["seq_no_diff"])
+        assertEquals("Documents behind miscount", monitor.id, output["_id"])
+        assertEquals("Documents behind miscount", 2, output["documents_behind"])
     }
 
-    fun `test monitor explain shard seq_no and doc_diff difference`() {
+    fun `test monitor explain shard seq_no and document difference`() {
         val testIndex = createTestIndex()
         val testDoc = """{
             "test_field" : "us-west-2"
@@ -442,15 +440,14 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         updateDoc(testIndex, "1", updateDoc)
         indexDoc(testIndex, "5", testDoc)
 
-        val response = explainMonitor(monitor.id, true)
-        val output = entityAsMap(response)
+        val responseNoDocDiff = entityAsMap(explainMonitor(monitor.id, false))
+        val responseDocDiff = entityAsMap(explainMonitor(monitor.id, true))
 
-        assertEquals(monitor.id, output["_id"])
-        assertEquals(3, output["seq_no_diff"])
-        assertEquals(2, output["doc_diff"])
+        assertEquals("Documents behind miscount", 3, responseNoDocDiff["documents_behind"])
+        assertEquals("Documents behind miscount", 2, responseDocDiff["documents_behind"])
     }
 
-    fun `test monitor explain seq_no diff and doc diff with wildcard index`() {
+    fun `test monitor explain seq_no and doc difference with wildcard index`() {
         val testIndex = createTestIndex("test1")
         val testIndex2 = createTestIndex("test2")
         val testDoc = """{
@@ -473,12 +470,11 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         updateDoc(testIndex, "1", updateDoc)
         indexDoc(testIndex2, "5", testDoc)
 
-        val response = explainMonitor(monitor.id, true)
-        val output = entityAsMap(response)
+        val responseNoDocDiff = entityAsMap(explainMonitor(monitor.id, false))
+        val responseDocDiff = entityAsMap(explainMonitor(monitor.id, true))
 
-        assertEquals(monitor.id, output["_id"])
-        assertEquals(3, output["seq_no_diff"])
-        assertEquals(2, output["doc_diff"])
+        assertEquals("Documents behind miscount", 3, responseNoDocDiff["documents_behind"])
+        assertEquals("Documents behind miscount", 2, responseDocDiff["documents_behind"])
     }
 
     @Throws(Exception::class)


### PR DESCRIPTION
Issuer (#751)

Implementation of some basic functionalities listed in issue above. Addition of few integration tests - testing variations of *documents_behind* response field depending on *count_docs* request field, one test demonstrating invalid API invocation (explaining a non document level monitor) and two tests utilizing access roles - another PR in security-analytics is probably required to add an explain role.

*CheckList:*
[] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).