### PR TITLE
Added document _id as param for terms query when searching alerts by …

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
@@ -100,7 +100,7 @@ class TransportGetAlertsAction @Inject constructor(
             queryBuilder.filter(QueryBuilders.termQuery("state", getAlertsRequest.alertState))
 
         if (getAlertsRequest.alertIds.isNullOrEmpty() == false) {
-            queryBuilder.filter(QueryBuilders.termsQuery("id", getAlertsRequest.alertIds))
+            queryBuilder.filter(QueryBuilders.termsQuery("_id", getAlertsRequest.alertIds))
         }
 
         if (getAlertsRequest.monitorId != null) {


### PR DESCRIPTION
…their ids

Signed-off-by: Stevan Buzejic <buzejic.stevan@gmail.com>

*(https://github.com/opensearch-project/alerting/issues/748)*

*Description of changes:*
Changed the terms query used for getting the alerts to use the doc id (_id) instead of the alert id
*CheckList:*
[ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).