### PR TITLE
[BUG] ExecuteMonitor inserting metadata doc during dry run

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt
@@ -123,7 +123,7 @@ object MonitorMetadataService :
             } else {
                 val newMetadata = createNewMetadata(monitor, createWithRunContext = createWithRunContext)
                 if (skipIndex) {
-                    newMetadata to false
+                    newMetadata to created
                 } else {
                     upsertMetadata(newMetadata, updating = false) to created
                 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt
@@ -110,7 +110,11 @@ object MonitorMetadataService :
         }
     }
 
-    suspend fun getOrCreateMetadata(monitor: Monitor, createWithRunContext: Boolean = true): Pair<MonitorMetadata, Boolean> {
+    suspend fun getOrCreateMetadata(
+        monitor: Monitor,
+        createWithRunContext: Boolean = true,
+        skipIndex: Boolean = false
+    ): Pair<MonitorMetadata, Boolean> {
         try {
             val created = true
             val metadata = getMetadata(monitor)
@@ -118,7 +122,11 @@ object MonitorMetadataService :
                 metadata to !created
             } else {
                 val newMetadata = createNewMetadata(monitor, createWithRunContext = createWithRunContext)
-                upsertMetadata(newMetadata, updating = false) to created
+                if (skipIndex) {
+                    newMetadata to false
+                } else {
+                    upsertMetadata(newMetadata, updating = false) to created
+                }
             }
         } catch (e: Exception) {
             throw AlertingException.wrap(e)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
@@ -130,7 +130,7 @@ class TransportExecuteMonitorAction @Inject constructor(
                                 docLevelMonitorQueries.initDocLevelQueryIndex(monitor.dataSources)
                                 log.info("Central Percolation index ${ScheduledJob.DOC_LEVEL_QUERIES_INDEX} created")
                             }
-                            val (metadata, _) = MonitorMetadataService.getOrCreateMetadata(monitor)
+                            val (metadata, _) = MonitorMetadataService.getOrCreateMetadata(monitor, skipIndex = true)
                             docLevelMonitorQueries.indexDocLevelQueries(
                                 monitor,
                                 monitor.id,

--- a/alerting/src/test/kotlin/org/opensearch/alerting/DocumentMonitorRunnerIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/DocumentMonitorRunnerIT.kt
@@ -237,6 +237,8 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
             }
         }
 
+        refreshAllIndices()
+
         val alerts = searchAlertsWithFilter(monitor)
         assertEquals("Alert saved for test monitor", 2, alerts.size)
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/AlertingSingleNodeTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/AlertingSingleNodeTestCase.kt
@@ -69,7 +69,7 @@ abstract class AlertingSingleNodeTestCase : OpenSearchSingleNodeTestCase() {
         return getIndexResponse.indices().toList()
     }
 
-    protected fun executeMonitor(monitor: Monitor, id: String, dryRun: Boolean = true): ExecuteMonitorResponse? {
+    protected fun executeMonitor(monitor: Monitor, id: String?, dryRun: Boolean = true): ExecuteMonitorResponse? {
         val request = ExecuteMonitorRequest(dryRun, TimeValue(Instant.now().toEpochMilli()), id, monitor)
         return client().execute(ExecuteMonitorAction.INSTANCE, request).get()
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixed ExecuteMonitor Action inserting metadata doc during dryrun

*CheckList:*
[ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).