### PR TITLE
[Backport 2.5] Fix setting default title only when no subject has been set

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
@@ -19,7 +19,6 @@ import org.opensearch.alerting.script.QueryLevelTriggerExecutionContext
 import org.opensearch.alerting.script.TriggerExecutionContext
 import org.opensearch.alerting.util.destinationmigration.NotificationActionConfigs
 import org.opensearch.alerting.util.destinationmigration.NotificationApiUtils.Companion.getNotificationConfigInfo
-import org.opensearch.alerting.util.destinationmigration.createMessageContent
 import org.opensearch.alerting.util.destinationmigration.getTitle
 import org.opensearch.alerting.util.destinationmigration.publishLegacyNotification
 import org.opensearch.alerting.util.destinationmigration.sendNotification
@@ -109,7 +108,7 @@ abstract class MonitorRunner {
             ?.sendNotification(
                 monitorCtx.client!!,
                 config.channel.getTitle(subject),
-                config.channel.createMessageContent(subject, message)
+                message
             ) ?: actionResponseContent
 
         actionResponseContent = config.destination

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/NotificationApiUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/NotificationApiUtils.kt
@@ -14,7 +14,6 @@ import org.opensearch.alerting.opensearchapi.retryForNotification
 import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.client.Client
 import org.opensearch.client.node.NodeClient
-import org.opensearch.common.Strings
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.commons.ConfigConstants
 import org.opensearch.commons.destination.message.LegacyBaseMessage
@@ -27,7 +26,6 @@ import org.opensearch.commons.notifications.action.LegacyPublishNotificationRequ
 import org.opensearch.commons.notifications.action.LegacyPublishNotificationResponse
 import org.opensearch.commons.notifications.action.SendNotificationResponse
 import org.opensearch.commons.notifications.model.ChannelMessage
-import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.notifications.model.EventSource
 import org.opensearch.commons.notifications.model.NotificationConfigInfo
 import org.opensearch.commons.notifications.model.SeverityType
@@ -138,33 +136,11 @@ suspend fun NotificationConfigInfo.sendNotification(client: Client, title: Strin
 }
 
 /**
- * For most channel types, a placeholder Alerting title will be used but the email channel will
- * use the subject, so it appears as the actual subject of the email.
+ * A placeholder Alerting title will be used if no subject is passed in.
  */
 fun NotificationConfigInfo.getTitle(subject: String?): String {
     val defaultTitle = "Alerting-Notification Action"
-    if (this.notificationConfig.configType == ConfigType.EMAIL) {
-        return if (subject.isNullOrEmpty()) defaultTitle else subject
-    }
-
-    return defaultTitle
-}
-
-fun NotificationConfigInfo.createMessageContent(subject: String?, message: String): String {
-    // For Email Channels, the subject is not passed in the main message since it's used as the title
-    if (this.notificationConfig.configType == ConfigType.EMAIL) {
-        return constructMessageContent("", message)
-    }
-
-    return constructMessageContent(subject, message)
-}
-
-/**
- * Similar to Destinations, this is a generic utility method for constructing message content from
- * a subject and message body when sending through Notifications since the Action definition in Monitors can have both.
- */
-private fun constructMessageContent(subject: String?, message: String): String {
-    return if (Strings.isNullOrEmpty(subject)) message else "$subject \n\n $message"
+    return if (subject.isNullOrEmpty()) defaultTitle else subject
 }
 
 /**


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Backport https://github.com/opensearch-project/alerting/commit/830dff1d17c9a002efe417b55b84219b14c0c2fe from https://github.com/opensearch-project/alerting/pull/750
*CheckList:*
[X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).