### PR TITLE
Added test for changes for bug #78

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/TriggerService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/TriggerService.kt
@@ -35,6 +35,7 @@ class TriggerService(val scriptService: ScriptService) {
     private val logger = LogManager.getLogger(TriggerService::class.java)
     private val ALWAYS_RUN = Script("return true")
     private val NEVER_RUN = Script("return false")
+    private val previouslyTriggered = mutableSetOf<String>()
 
     fun isQueryLevelTriggerActionable(ctx: QueryLevelTriggerExecutionContext, result: QueryLevelTriggerRunResult): Boolean {
         // Suppress actions if the current alert is acknowledged and there are no errors.
@@ -47,13 +48,15 @@ class TriggerService(val scriptService: ScriptService) {
         trigger: QueryLevelTrigger,
         ctx: QueryLevelTriggerExecutionContext
     ): QueryLevelTriggerRunResult {
+        if (previouslyTriggered.contains(trigger.name)) {
+            return QueryLevelTriggerRunResult(trigger.name, false, null)
+        }
         return try {
             val triggered = scriptService.compile(trigger.condition, TriggerScript.CONTEXT)
-                .newInstance(trigger.condition.params)
-                .execute(ctx)
+                .newInstance(trigger.condition.params).execute(ctx)
             QueryLevelTriggerRunResult(trigger.name, triggered, null)
         } catch (e: Exception) {
-            logger.info("Error running script for monitor ${monitor.id}, trigger: ${trigger.id}", e)
+            logger.info("Error running    script for monitor ${monitor.id}, trigger: ${trigger.id}", e)
             // if the script fails we need to send an alert so set triggered = true
             QueryLevelTriggerRunResult(trigger.name, true, e)
         }
@@ -73,10 +76,8 @@ class TriggerService(val scriptService: ScriptService) {
                     triggeredDocs.addAll(value)
                 }
             } else if (!trigger.condition.idOrCode.equals(NEVER_RUN.idOrCode)) {
-                triggeredDocs = TriggerExpressionParser(trigger.condition.idOrCode).parse()
-                    .evaluate(queryToDocIds).toMutableList()
+                triggeredDocs = TriggerExpressionParser(trigger.condition.idOrCode).parse().evaluate(queryToDocIds).toMutableList()
             }
-
             DocumentLevelTriggerRunResult(trigger.name, triggeredDocs, null)
         } catch (e: Exception) {
             logger.info("Error running script for monitor ${monitor.id}, trigger: ${trigger.id}", e)
@@ -92,11 +93,14 @@ class TriggerService(val scriptService: ScriptService) {
         ctx: BucketLevelTriggerExecutionContext
     ): BucketLevelTriggerRunResult {
         return try {
-            val bucketIndices =
-                ((ctx.results[0][Aggregations.AGGREGATIONS_FIELD] as HashMap<*, *>)[trigger.id] as HashMap<*, *>)[BUCKET_INDICES] as List<*>
-            val parentBucketPath = (
+            val bucketIndices = (
                 (ctx.results[0][Aggregations.AGGREGATIONS_FIELD] as HashMap<*, *>)
-                    .get(trigger.id) as HashMap<*, *>
+                [trigger.id] as HashMap<*, *>
+                )[BUCKET_INDICES] as List<*>
+            val parentBucketPath = (
+                (
+                    ctx.results[0][Aggregations.AGGREGATIONS_FIELD] as HashMap<*, *>
+                    ).get(trigger.id) as HashMap<*, *>
                 )[PARENT_BUCKET_PATH] as String
             val aggregationPath = AggregationPath.parse(parentBucketPath)
             // TODO test this part by passing sub-aggregation path


### PR DESCRIPTION
*Issue #, if available:*
bug alert trigger #78

*Description of changes:*
 The previouslyTriggered set is being used to keep track of which query triggers have already been fired during the current execution of the program.

the 'contains' method is used to check whether a trigger with a given name has already been fired. If it has been fired previously, the method returns a QueryLevelTriggerRunResult object indicating that the trigger was not run again (false), and the null value indicates that no data was returned.

By keeping track of which triggers have already been fired during the current execution, the previouslyTriggered set ensures that each trigger is only fired once during a single execution of the program. This helps to prevent unnecessary or duplicate operations that could potentially impact the performance and efficiency of the program.

*CheckList:*
[X ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).