### PR TITLE
minor fix to prevent flaky tests in downstream plugins

### DIFF
--- a/core/src/main/resources/mappings/scheduled-jobs.json
+++ b/core/src/main/resources/mappings/scheduled-jobs.json
@@ -514,8 +514,7 @@
           "enabled": false
         },
         "source_to_query_index_mapping": {
-          "type": "object",
-          "enabled": false
+          "type": "object"
         }
       }
     }


### PR DESCRIPTION
minor fix to prevent flaky tests in downstream plugins

*Issue #, if available:*
sample flaky run: https://github.com/phaseshiftg/security-analytics/actions/runs/4228665096/jobs/7344314835

*Description of changes:*
https://stackoverflow.com/questions/58644738/update-a-field-from-a-elasticsearch-document
https://www.elastic.co/guide/en/elasticsearch/reference/current/enabled.html

*CheckList:*
[X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).