### PR TITLE
changes to properly get userstr when RBAC is enabled and set it in threadcontext

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunnerService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunnerService.kt
@@ -253,6 +253,14 @@ object MonitorRunnerService : JobRunner, CoroutineScope, AbstractLifecycleCompon
         }
     }
 
+    internal fun getUserStrForMonitor(monitor: Monitor): String {
+        return if (monitor.user != null) {
+            monitor.user!!.name + "|" + monitor.user!!.backendRoles.joinToString()
+        } else {
+            return ""
+        }
+    }
+
     // TODO: Can this be updated to just use 'Instant.now()'?
     //  'threadPool.absoluteTimeInMillis()' is referring to a cached value of System.currentTimeMillis() that by default updates every 200ms
     internal fun currentTime() = Instant.ofEpochMilli(monitorCtx.threadPool!!.absoluteTimeInMillis())


### PR DESCRIPTION
https://github.com/opensearch-project/alerting/issues/698

*Description of changes:*

userstr is properly obtained and set in threadcontext. 

*CheckList:*
[ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).