### PR TITLE
Adjusted mockito dependency to retrieve the version from OpenSearch core.

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -119,7 +119,7 @@ dependencies {
     implementation "com.github.seancfoley:ipaddress:5.3.3"
 
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
-    testImplementation "org.mockito:mockito-core:5.1.0"
+    testImplementation "org.mockito:mockito-core:5.2.0"
     testImplementation "org.opensearch.plugin:reindex-client:${opensearch_version}"
 }
 

--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -119,7 +119,7 @@ dependencies {
     implementation "com.github.seancfoley:ipaddress:5.3.3"
 
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
-    testImplementation "org.mockito:mockito-core:5.2.0"
+    testImplementation "org.mockito:mockito-core:${versions.mockito}"
     testImplementation "org.opensearch.plugin:reindex-client:${opensearch_version}"
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adjusted mockito dependency to retrieve the version from [OpenSearch core](https://github.com/opensearch-project/OpenSearch/blob/main/buildSrc/version.properties#L52).

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).