### PR TITLE
Fixed transformation of document field names before running percolator search

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -121,6 +121,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
     testImplementation "org.mockito:mockito-core:${versions.mockito}"
     testImplementation "org.opensearch.plugin:reindex-client:${opensearch_version}"
+    testImplementation "org.opensearch.plugin:parent-join-client:${opensearch_version}"
 }
 
 javadoc.enabled = false // turn off javadoc as it barfs on Kotlin code

--- a/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
@@ -5,6 +5,7 @@
 
 package org.opensearch.alerting
 
+import kotlin.math.max
 import org.apache.logging.log4j.LogManager
 import org.opensearch.OpenSearchStatusException
 import org.opensearch.action.index.IndexRequest
@@ -52,7 +53,6 @@ import org.opensearch.search.sort.SortOrder
 import java.io.IOException
 import java.time.Instant
 import java.util.UUID
-import kotlin.math.max
 
 object DocumentLevelMonitorRunner : MonitorRunner() {
     private val logger = LogManager.getLogger(javaClass)
@@ -564,14 +564,30 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
             val sourceMap = hit.sourceAsMap
 
             var xContentBuilder = XContentFactory.jsonBuilder().startObject()
-            sourceMap.forEach { (k, v) ->
-                xContentBuilder = xContentBuilder.field("${k}_${index}_$monitorId", v)
-            }
+
+            transformDocumentFieldNames(sourceMap, xContentBuilder, "${index}_$monitorId")
+
             xContentBuilder = xContentBuilder.endObject()
 
             val sourceRef = BytesReference.bytes(xContentBuilder)
 
             Pair(hit.id, sourceRef)
+        }
+    }
+
+    private fun transformDocumentFieldNames(
+        sourceAsMap: Map<String, Any>,
+        xContentBuilder: XContentBuilder,
+        fieldNameSuffix: String,
+        currentPath: String = ""
+    ) {
+        sourceAsMap.forEach { (k, v) ->
+            val path = if (currentPath == "") k else "$currentPath.$k"
+            if (v is Map<*, *>) {
+                transformDocumentFieldNames(v as Map<String, Any>, xContentBuilder, fieldNameSuffix, path)
+            } else {
+                xContentBuilder.field("${path}_$fieldNameSuffix", v)
+            }
         }
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
@@ -5,7 +5,6 @@
 
 package org.opensearch.alerting
 
-import kotlin.math.max
 import org.apache.logging.log4j.LogManager
 import org.opensearch.OpenSearchStatusException
 import org.opensearch.action.index.IndexRequest
@@ -53,6 +52,7 @@ import org.opensearch.search.sort.SortOrder
 import java.io.IOException
 import java.time.Instant
 import java.util.UUID
+import kotlin.math.max
 
 object DocumentLevelMonitorRunner : MonitorRunner() {
     private val logger = LogManager.getLogger(javaClass)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
@@ -5,6 +5,7 @@
 
 package org.opensearch.alerting
 
+import kotlin.math.max
 import org.apache.logging.log4j.LogManager
 import org.opensearch.ExceptionsHelper
 import org.opensearch.OpenSearchStatusException
@@ -53,7 +54,6 @@ import org.opensearch.search.sort.SortOrder
 import java.io.IOException
 import java.time.Instant
 import java.util.UUID
-import kotlin.math.max
 
 object DocumentLevelMonitorRunner : MonitorRunner() {
     private val logger = LogManager.getLogger(javaClass)
@@ -563,6 +563,13 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
 
     /**
      * Traverses document fields in leaves recursively and appends [fieldNameSuffix] to field names.
+     *
+     * Example for index name is my_log_index and Monitor ID is TReewWdsf2gdJFV:
+     * {                         {
+     *   "a": {                     "a": {
+     *     "b": 1234      ---->       "b_my_log_index_TReewWdsf2gdJFV": 1234
+     *   }                          }
+     * }
      *
      * @param jsonAsMap               Input JSON (as Map)
      * @param fieldNameSuffix         Field suffix which is appended to existing field name

--- a/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
@@ -5,7 +5,6 @@
 
 package org.opensearch.alerting
 
-import kotlin.math.max
 import org.apache.logging.log4j.LogManager
 import org.opensearch.ExceptionsHelper
 import org.opensearch.OpenSearchStatusException
@@ -54,6 +53,7 @@ import org.opensearch.search.sort.SortOrder
 import java.io.IOException
 import java.time.Instant
 import java.util.UUID
+import kotlin.math.max
 
 object DocumentLevelMonitorRunner : MonitorRunner() {
     private val logger = LogManager.getLogger(javaClass)
@@ -555,7 +555,7 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
 
             val sourceRef = BytesReference.bytes(xContentBuilder)
 
-            logger.trace("Document [${hit.id}] payload after transform: ", sourceRef.utf8ToString())
+            logger.debug("Document [${hit.id}] payload after transform: ", sourceRef.utf8ToString())
 
             Pair(hit.id, sourceRef)
         }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
@@ -235,6 +235,14 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
             "properties": {
                 "source.device.port": { "type": "long" },
                 "source.device.hwd.id": { "type": "long" },
+                "nested_field": {
+                  "type": "nested",
+                  "properties": {
+                    "test1": {
+                      "type": "keyword"
+                    }
+                  }
+                },
                 "my_join_field": { 
                   "type": "join",
                   "relations": {
@@ -252,7 +260,8 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
         // testing both, nested and flatten documents
         val testDocuments = mutableListOf<String>()
         testDocuments += """{
-            "source" : { "device": {"port" : 12345 } }
+            "source" : { "device": {"port" : 12345 } },
+            "nested_field": { "test1": "some text" }
         }"""
         testDocuments += """{
             "source.device.port" : "12345"

--- a/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
@@ -234,7 +234,13 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
         val mappings = """{
             "properties": {
                 "source.device.port": { "type": "long" },
-                "source.device.hwd.id": { "type": "long" }
+                "source.device.hwd.id": { "type": "long" },
+                "my_join_field": { 
+                  "type": "join",
+                  "relations": {
+                     "question": "answer" 
+                  }
+               }
             }
         }"""
 
@@ -259,6 +265,11 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
         }"""
         testDocuments += """{
             "source.device.hwd.id" : 12345
+        }"""
+        // Document with join field
+        testDocuments += """{
+            "source" : { "device" : { "hwd": { "id" : 12345 } } },
+            "my_join_field": { "name": "question" }
         }"""
         // Checking if these pointless but valid documents cause any issues
         testDocuments += """{
@@ -297,7 +308,7 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
         Assert.assertTrue(getAlertsResponse != null)
         Assert.assertTrue(getAlertsResponse.alerts.size == 1)
         val findings = searchFindings(id, customFindingsIndex)
-        assertEquals("Findings saved for test monitor", 5, findings.size)
+        assertEquals("Findings saved for test monitor", 6, findings.size)
         assertEquals("Didn't match query", 1, findings[0].docLevelQueries.size)
     }
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/AlertingSingleNodeTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/AlertingSingleNodeTestCase.kt
@@ -38,6 +38,7 @@ import org.opensearch.commons.alerting.model.Table
 import org.opensearch.index.query.TermQueryBuilder
 import org.opensearch.index.reindex.ReindexModulePlugin
 import org.opensearch.index.seqno.SequenceNumbers
+import org.opensearch.join.ParentJoinModulePlugin
 import org.opensearch.plugins.Plugin
 import org.opensearch.rest.RestRequest
 import org.opensearch.search.builder.SearchSourceBuilder
@@ -229,7 +230,7 @@ abstract class AlertingSingleNodeTestCase : OpenSearchSingleNodeTestCase() {
     ).get()
 
     override fun getPlugins(): List<Class<out Plugin>> {
-        return listOf(AlertingPlugin::class.java, ReindexModulePlugin::class.java)
+        return listOf(AlertingPlugin::class.java, ReindexModulePlugin::class.java, ParentJoinModulePlugin::class.java)
     }
 
     override fun resetNodeAfterTest(): Boolean {


### PR DESCRIPTION
*Issue #, if available:* #844

*Description of changes:*

Fixed transformation of document field names before running percolator search.

Documents which are ingested with "nested fields" weren't handled properly. Example:
```
"field1": {
   "field2": 12345
}
```

*CheckList:*
[ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).