### PR TITLE
doc transform 2.5 backport

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -105,6 +105,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
     testImplementation "org.mockito:mockito-core:4.7.0"
     testImplementation "org.opensearch.plugin:reindex-client:${opensearch_version}"
+    testImplementation "org.opensearch.plugin:parent-join-client:${opensearch_version}"
 }
 
 javadoc.enabled = false // turn off javadoc as it barfs on Kotlin code

--- a/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
@@ -13,6 +13,7 @@ import org.opensearch.action.admin.indices.get.GetIndexResponse
 import org.opensearch.action.admin.indices.mapping.get.GetMappingsRequest
 import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest
 import org.opensearch.action.admin.indices.refresh.RefreshRequest
+import org.opensearch.action.fieldcaps.FieldCapabilitiesRequest
 import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.support.WriteRequest
 import org.opensearch.alerting.action.SearchMonitorAction
@@ -206,6 +207,117 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
         assertEquals("Findings saved for test monitor", 1, findings.size)
         assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("1"))
         assertEquals("Didn't match all 8 queries", 8, findings[0].docLevelQueries.size)
+    }
+
+    fun `test execute monitor with non-flattened json doc as source`() {
+        val docQuery1 = DocLevelQuery(query = "source.device.port:12345 OR source.device.hwd.id:12345", name = "3")
+
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(docQuery1)
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val customFindingsIndex = "custom_findings_index"
+        val customFindingsIndexPattern = "custom_findings_index-1"
+        val customQueryIndex = "custom_alerts_index"
+        var monitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger),
+            dataSources = DataSources(
+                queryIndex = customQueryIndex,
+                findingsIndex = customFindingsIndex,
+                findingsIndexPattern = customFindingsIndexPattern
+            )
+        )
+        val monitorResponse = createMonitor(monitor)
+
+        val mappings = """{
+            "properties": {
+                "source.device.port": { "type": "long" },
+                "source.device.hwd.id": { "type": "long" },
+                "nested_field": {
+                  "type": "nested",
+                  "properties": {
+                    "test1": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "my_join_field": { 
+                  "type": "join",
+                  "relations": {
+                     "question": "answer" 
+                  }
+               }
+            }
+        }"""
+
+        client().admin().indices().putMapping(PutMappingRequest(index).source(mappings, XContentType.JSON)).get()
+        val getFieldCapabilitiesResp = client().fieldCaps(FieldCapabilitiesRequest().indices(index).fields("*")).get()
+        assertTrue(getFieldCapabilitiesResp.getField("source").containsKey("object"))
+        assertTrue(getFieldCapabilitiesResp.getField("source.device").containsKey("object"))
+        assertTrue(getFieldCapabilitiesResp.getField("source.device.hwd").containsKey("object"))
+        // testing both, nested and flatten documents
+        val testDocuments = mutableListOf<String>()
+        testDocuments += """{
+            "source" : { "device": {"port" : 12345 } },
+            "nested_field": { "test1": "some text" }
+        }"""
+        testDocuments += """{
+            "source.device.port" : "12345"
+        }"""
+        testDocuments += """{
+            "source.device.port" : 12345
+        }"""
+        testDocuments += """{
+            "source" : { "device": {"hwd": { "id": 12345 } } }
+        }"""
+        testDocuments += """{
+            "source.device.hwd.id" : 12345
+        }"""
+        // Document with join field
+        testDocuments += """{
+            "source" : { "device" : { "hwd": { "id" : 12345 } } },
+            "my_join_field": { "name": "question" }
+        }"""
+        // Checking if these pointless but valid documents cause any issues
+        testDocuments += """{
+            "source" : {}
+        }"""
+        testDocuments += """{
+            "source.device" : null
+        }"""
+        testDocuments += """{
+            "source.device" : {}
+        }"""
+        testDocuments += """{
+            "source.device.hwd" : {}
+        }"""
+        testDocuments += """{
+            "source.device.hwd.id" : null
+        }"""
+        testDocuments += """{
+            "some.multi.val.field" : [12345, 10, 11]
+        }"""
+        // Insert all documents
+        for (i in testDocuments.indices) {
+            indexDoc(index, "$i", testDocuments[i])
+        }
+        assertFalse(monitorResponse?.id.isNullOrEmpty())
+        monitor = monitorResponse!!.monitor
+        val id = monitorResponse.id
+        val executeMonitorResponse = executeMonitor(monitor, id, false)
+        Assert.assertEquals(executeMonitorResponse!!.monitorRunResult.monitorName, monitor.name)
+        Assert.assertEquals(executeMonitorResponse.monitorRunResult.triggerResults.size, 1)
+        searchAlerts(id)
+        val table = Table("asc", "id", null, 1, 0, "")
+        var getAlertsResponse = client()
+            .execute(AlertingActions.GET_ALERTS_ACTION_TYPE, GetAlertsRequest(table, "ALL", "ALL", null, null))
+            .get()
+        Assert.assertTrue(getAlertsResponse != null)
+        Assert.assertTrue(getAlertsResponse.alerts.size == 1)
+        val findings = searchFindings(id, customFindingsIndex)
+        assertEquals("Findings saved for test monitor", 6, findings.size)
+        assertEquals("Didn't match query", 1, findings[0].docLevelQueries.size)
     }
 
     fun `test execute monitor with custom query index old`() {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/AlertingSingleNodeTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/AlertingSingleNodeTestCase.kt
@@ -36,8 +36,9 @@ import org.opensearch.commons.alerting.model.Finding
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.Table
 import org.opensearch.index.query.TermQueryBuilder
-import org.opensearch.index.reindex.ReindexPlugin
+import org.opensearch.index.reindex.ReindexModulePlugin
 import org.opensearch.index.seqno.SequenceNumbers
+import org.opensearch.join.ParentJoinModulePlugin
 import org.opensearch.plugins.Plugin
 import org.opensearch.rest.RestRequest
 import org.opensearch.search.builder.SearchSourceBuilder
@@ -229,7 +230,7 @@ abstract class AlertingSingleNodeTestCase : OpenSearchSingleNodeTestCase() {
     ).get()
 
     override fun getPlugins(): List<Class<out Plugin>> {
-        return listOf(AlertingPlugin::class.java, ReindexPlugin::class.java)
+        return listOf(AlertingPlugin::class.java, ReindexModulePlugin::class.java, ParentJoinModulePlugin::class.java)
     }
 
     override fun resetNodeAfterTest(): Boolean {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/AlertingSingleNodeTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/AlertingSingleNodeTestCase.kt
@@ -36,9 +36,9 @@ import org.opensearch.commons.alerting.model.Finding
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.Table
 import org.opensearch.index.query.TermQueryBuilder
-import org.opensearch.index.reindex.ReindexModulePlugin
+import org.opensearch.index.reindex.ReindexPlugin
 import org.opensearch.index.seqno.SequenceNumbers
-import org.opensearch.join.ParentJoinModulePlugin
+import org.opensearch.join.ParentJoinPlugin
 import org.opensearch.plugins.Plugin
 import org.opensearch.rest.RestRequest
 import org.opensearch.search.builder.SearchSourceBuilder
@@ -230,7 +230,7 @@ abstract class AlertingSingleNodeTestCase : OpenSearchSingleNodeTestCase() {
     ).get()
 
     override fun getPlugins(): List<Class<out Plugin>> {
-        return listOf(AlertingPlugin::class.java, ReindexModulePlugin::class.java, ParentJoinModulePlugin::class.java)
+        return listOf(AlertingPlugin::class.java, ReindexPlugin::class.java, ParentJoinPlugin::class.java)
     }
 
     override fun resetNodeAfterTest(): Boolean {


### PR DESCRIPTION
…r search (#845)

* Fixed transformation of document field names before running percolator search

Signed-off-by: Petar Dzepina <petar.dzepina@gmail.com>
(cherry picked from commit 702da92495481bebfc18dbee2de9544a4245759a)

*Issue #, if available:*
#844

*Description of changes:*

*CheckList:*
[ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).