### PR TITLE
Use latest common-utils snapshot

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation "com.cronutils:cron-utils:9.1.6"
     api "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
     implementation 'com.google.googlejavaformat:google-java-format:1.10.0'
-    api "org.opensearch:common-utils:${common_utils_version}"
+    api "org.opensearch:common-utils:${common_utils_version}@jar"
     implementation 'commons-validator:commons-validator:1.7'
 
     testImplementation "org.opensearch.test:framework:${opensearch_version}"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Use latest common-utils snapshot. This allows alerting ci builds to pick up the latest changes from common-utils instead of waiting for successful build distribution from infrastructure. 

*CheckList:*
[X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).