### PR TITLE
[Backport 2.x] Notification security fix (#861)

### DIFF
--- a/core/src/main/kotlin/org/opensearch/alerting/opensearchapi/OpenSearchExtensions.kt
+++ b/core/src/main/kotlin/org/opensearch/alerting/opensearchapi/OpenSearchExtensions.kt
@@ -18,7 +18,6 @@ import org.opensearch.action.search.ShardSearchFailure
 import org.opensearch.client.OpenSearchClient
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.util.concurrent.ThreadContext
-import org.opensearch.common.util.concurrent.ThreadContext.StoredContext
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.InjectSecurity
@@ -171,28 +170,13 @@ suspend fun <T> NotificationsPluginInterface.suspendUntil(block: NotificationsPl
         })
     }
 
-/**
- * Store a [ThreadContext] and restore a [ThreadContext] when the coroutine resumes on a different thread.
- *
- * @param threadContext - a [ThreadContext] instance
- */
-class ElasticThreadContextElement(private val threadContext: ThreadContext) : ThreadContextElement<Unit> {
-
-    companion object Key : CoroutineContext.Key<ElasticThreadContextElement>
-    private var context: StoredContext = threadContext.newStoredContext(true)
-
-    override val key: CoroutineContext.Key<*>
-        get() = Key
-
-    override fun restoreThreadContext(context: CoroutineContext, oldState: Unit) {
-        this.context = threadContext.stashContext()
-    }
-
-    override fun updateThreadContext(context: CoroutineContext) = this.context.close()
-}
-
-class InjectorContextElement(id: String, settings: Settings, threadContext: ThreadContext, private val roles: List<String>?) :
-    ThreadContextElement<Unit> {
+class InjectorContextElement(
+    id: String,
+    settings: Settings,
+    threadContext: ThreadContext,
+    private val roles: List<String>?,
+    private val user: User? = null
+) : ThreadContextElement<Unit> {
 
     companion object Key : CoroutineContext.Key<InjectorContextElement>
     override val key: CoroutineContext.Key<*>
@@ -202,6 +186,8 @@ class InjectorContextElement(id: String, settings: Settings, threadContext: Thre
 
     override fun updateThreadContext(context: CoroutineContext) {
         rolesInjectorHelper.injectRoles(roles)
+        // This is from where plugins extract backend roles. It should be passed when calling APIs of other plugins
+        rolesInjectorHelper.injectUserInfo(user)
     }
 
     override fun restoreThreadContext(context: CoroutineContext, oldState: Unit) {


### PR DESCRIPTION
* Notification security fix (#852)

* added injecting whole user object in threadContext before calling notification APIs so that backend roles are available to notification plugin



* compile fix



* refactored user_info injection to use InjectSecurity



* ktlint fix



---------


(cherry picked from commit e0b7a5a7905b977e58d80e3b9134b14893d122b0)

* remove unneeded import



---------

*Issue #, if available:*

*Description of changes:*

*CheckList:*
[ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).