### PR TITLE
Fix getAlerts API for standard Alerting monitors

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
@@ -169,7 +169,10 @@ class TransportGetAlertsAction @Inject constructor(
                     alertIndex = getMonitorResponse.monitor!!.dataSources.alertsIndex
                 }
             }
-        return alertIndex
+        return if (alertIndex == AlertIndices.ALERT_INDEX)
+            AlertIndices.ALL_ALERT_INDEX_PATTERN
+        else
+            alertIndex
     }
 
     fun getAlerts(

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -823,6 +823,29 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         )
     }
 
+    fun `test delete monitor moves alerts then try to search alert by monitorId to find alert in history index`() {
+        client().updateSettings(ScheduledJobSettings.SWEEPER_ENABLED.key, true)
+        putAlertMappings()
+        val monitor = createRandomMonitor(true)
+        val alert = createAlert(randomAlert(monitor).copy(state = Alert.State.ACTIVE))
+        refreshIndex("*")
+        val deleteResponse = client().makeRequest("DELETE", "$ALERTING_BASE_URI/${monitor.id}")
+        assertEquals("Delete request not successful", RestStatus.OK, deleteResponse.restStatus())
+
+        // Wait 5 seconds for event to be processed and alerts moved
+        Thread.sleep(5000)
+
+        val alerts = searchAlerts(monitor)
+        assertEquals("Active alert was not deleted", 0, alerts.size)
+
+        // Find alert by id and make sure it checks the history of alerts as well
+        val inputMap = HashMap<String, Any>()
+        inputMap["monitorId"] = monitor.id
+        val responseMap = getAlerts(inputMap).asMap()
+
+        assertEquals(1, responseMap["totalAlerts"])
+    }
+
     fun `test delete trigger moves alerts`() {
         client().updateSettings(ScheduledJobSettings.SWEEPER_ENABLED.key, true)
         putAlertMappings()


### PR DESCRIPTION
*Issue #, if available:*
#842
*Description of changes:*
Fix getAlerts API for standard Alerting monitors since it was defaulting to searching the alerts index instead of `ALL_ALERT_INDEX_PATTERN`
*CheckList:*
[X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).