### PR TITLE
[Backport 2.7] Fix getAlerts API for standard Alerting monitors (#870)

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
@@ -174,7 +174,10 @@ class TransportGetAlertsAction @Inject constructor(
                 }
             }
         }
-        return alertIndex
+        return if (alertIndex == AlertIndices.ALERT_INDEX)
+            AlertIndices.ALL_ALERT_INDEX_PATTERN
+        else
+            alertIndex
     }
 
     fun getAlerts(


### PR DESCRIPTION
*Issue #, if available:*
#842
*Description of changes:*
Backport #870
*CheckList:*
[X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).