### PR TITLE
log error messages and clean up monitor when indexing doc level queries or metadata creation fails

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
@@ -168,7 +168,7 @@ class TransportDeleteMonitorAction @Inject constructor(
             } catch (e: Exception) {
                 // we only log the error and don't fail the request because if monitor document has been deleted,
                 // we cannot retry based on this failure
-                log.error("Failed to delete workflow metadata for monitor ${monitor.id}.", e)
+                log.error("Failed to delete monitor metadata ${deleteRequest.id()}.", e)
             }
         }
 
@@ -234,7 +234,7 @@ class TransportDeleteMonitorAction @Inject constructor(
             } catch (e: Exception) {
                 // we only log the error and don't fail the request because if monitor document has been deleted successfully,
                 // we cannot retry based on this failure
-                log.error("Failed to delete workflow metadata for monitor ${monitor.id}.", e)
+                log.error("Failed to delete doc level queries from query index.", e)
             }
         }
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
@@ -5,9 +5,8 @@
 
 package org.opensearch.alerting.transport
 
-import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.apache.logging.log4j.LogManager
 import org.opensearch.OpenSearchStatusException
@@ -25,6 +24,7 @@ import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.action.support.IndicesOptions
+import org.opensearch.action.support.WriteRequest
 import org.opensearch.action.support.master.AcknowledgedResponse
 import org.opensearch.alerting.MonitorMetadataService
 import org.opensearch.alerting.opensearchapi.suspendUntil
@@ -57,6 +57,7 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 
+private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 private val log = LogManager.getLogger(TransportDeleteMonitorAction::class.java)
 
 class TransportDeleteMonitorAction @Inject constructor(
@@ -87,8 +88,7 @@ class TransportDeleteMonitorAction @Inject constructor(
         if (!validateUserBackendRoles(user, actionListener)) {
             return
         }
-
-        GlobalScope.launch(Dispatchers.IO + CoroutineName("DeleteMonitorAction")) {
+        scope.launch {
             DeleteMonitorHandler(client, actionListener, deleteRequest, user, transformedRequest.monitorId).resolveUserAndStart()
         }
     }
@@ -109,9 +109,7 @@ class TransportDeleteMonitorAction @Inject constructor(
                     checkUserPermissionsWithResource(user, monitor.user, actionListener, "monitor", monitorId)
 
                 if (canDelete) {
-                    val deleteResponse = deleteMonitor(monitor)
-                    deleteDocLevelMonitorQueriesAndIndices(monitor)
-                    deleteMetadata(monitor)
+                    val deleteResponse = deleteAllResourcesForMonitor(client, monitor, deleteRequest, monitorId)
                     actionListener.onResponse(DeleteMonitorResponse(deleteResponse.id, deleteResponse.version))
                 } else {
                     actionListener.onFailure(
@@ -119,6 +117,7 @@ class TransportDeleteMonitorAction @Inject constructor(
                     )
                 }
             } catch (t: Exception) {
+                log.error("Failed to delete monitor ${deleteRequest.id()}", t)
                 actionListener.onFailure(AlertingException.wrap(t))
             }
         }
@@ -140,68 +139,102 @@ class TransportDeleteMonitorAction @Inject constructor(
             )
             return ScheduledJob.parse(xcp, getResponse.id, getResponse.version) as Monitor
         }
+    }
 
-        private suspend fun deleteMonitor(monitor: Monitor): DeleteResponse {
+    companion object {
+        @JvmStatic
+        suspend fun deleteAllResourcesForMonitor(
+            client: Client,
+            monitor: Monitor,
+            deleteRequest: DeleteRequest,
+            monitorId: String,
+        ): DeleteResponse {
+            val deleteResponse = deleteMonitorDocument(client, deleteRequest)
+            deleteMetadata(client, monitor)
+            deleteDocLevelMonitorQueriesAndIndices(client, monitor, monitorId)
+            return deleteResponse
+        }
+
+        private suspend fun deleteMonitorDocument(client: Client, deleteRequest: DeleteRequest): DeleteResponse {
             return client.suspendUntil { delete(deleteRequest, it) }
         }
 
-        private suspend fun deleteMetadata(monitor: Monitor) {
+        suspend fun deleteMetadata(client: Client, monitor: Monitor) {
             val deleteRequest = DeleteRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, "${monitor.id}-metadata")
-            val deleteResponse: DeleteResponse = client.suspendUntil { delete(deleteRequest, it) }
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            try {
+                val deleteResponse: DeleteResponse = client.suspendUntil { delete(deleteRequest, it) }
+                log.debug("Monitor metadata: ${deleteResponse.id} deletion result: ${deleteResponse.result}")
+            } catch (e: Exception) {
+                // we only log the error and don't fail the request because if monitor document has been deleted,
+                // we cannot retry based on this failure
+                log.error("Failed to delete workflow metadata for monitor ${monitor.id}.", e)
+            }
         }
 
-        private suspend fun deleteDocLevelMonitorQueriesAndIndices(monitor: Monitor) {
-            val clusterState = clusterService.state()
-            val metadata = MonitorMetadataService.getMetadata(monitor)
-            metadata?.sourceToQueryIndexMapping?.forEach { (_, queryIndex) ->
+        suspend fun deleteDocLevelMonitorQueriesAndIndices(
+            client: Client,
+            monitor: Monitor,
+            monitorId: String,
+        ) {
+            try {
+                val metadata = MonitorMetadataService.getMetadata(monitor)
+                metadata?.sourceToQueryIndexMapping?.forEach { (_, queryIndex) ->
 
-                val indicesExistsResponse: IndicesExistsResponse =
-                    client.suspendUntil {
-                        client.admin().indices().exists(IndicesExistsRequest(queryIndex), it)
+                    val indicesExistsResponse: IndicesExistsResponse =
+                        client.suspendUntil {
+                            client.admin().indices().exists(IndicesExistsRequest(queryIndex), it)
+                        }
+                    if (indicesExistsResponse.isExists == false) {
+                        return
                     }
-                if (indicesExistsResponse.isExists == false) {
-                    return
-                }
-                // Check if there's any queries from other monitors in this queryIndex,
-                // to avoid unnecessary doc deletion, if we could just delete index completely
-                val searchResponse: SearchResponse = client.suspendUntil {
-                    search(
-                        SearchRequest(queryIndex).source(
-                            SearchSourceBuilder()
-                                .size(0)
-                                .query(
-                                    QueryBuilders.boolQuery().mustNot(
-                                        QueryBuilders.matchQuery("monitor_id", monitorId)
+                    // Check if there's any queries from other monitors in this queryIndex,
+                    // to avoid unnecessary doc deletion, if we could just delete index completely
+                    val searchResponse: SearchResponse = client.suspendUntil {
+                        search(
+                            SearchRequest(queryIndex).source(
+                                SearchSourceBuilder()
+                                    .size(0)
+                                    .query(
+                                        QueryBuilders.boolQuery().mustNot(
+                                            QueryBuilders.matchQuery("monitor_id", monitorId)
+                                        )
                                     )
-                                )
-                        ).indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_HIDDEN),
-                        it
-                    )
-                }
-                if (searchResponse.hits.totalHits.value == 0L) {
-                    val ack: AcknowledgedResponse = client.suspendUntil {
-                        client.admin().indices().delete(
-                            DeleteIndexRequest(queryIndex).indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_HIDDEN), it
+                            ).indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_HIDDEN),
+                            it
                         )
                     }
-                    if (ack.isAcknowledged == false) {
-                        log.error("Deletion of concrete queryIndex:$queryIndex is not ack'd!")
-                    }
-                } else {
-                    // Delete all queries added by this monitor
-                    val response: BulkByScrollResponse = suspendCoroutine { cont ->
-                        DeleteByQueryRequestBuilder(client, DeleteByQueryAction.INSTANCE)
-                            .source(queryIndex)
-                            .filter(QueryBuilders.matchQuery("monitor_id", monitorId))
-                            .refresh(true)
-                            .execute(
-                                object : ActionListener<BulkByScrollResponse> {
-                                    override fun onResponse(response: BulkByScrollResponse) = cont.resume(response)
-                                    override fun onFailure(t: Exception) = cont.resumeWithException(t)
-                                }
+                    if (searchResponse.hits.totalHits.value == 0L) {
+                        val ack: AcknowledgedResponse = client.suspendUntil {
+                            client.admin().indices().delete(
+                                DeleteIndexRequest(queryIndex).indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_HIDDEN), it
                             )
+                        }
+                        if (ack.isAcknowledged == false) {
+                            log.error("Deletion of concrete queryIndex:$queryIndex is not ack'd!")
+                        }
+                    } else {
+                        // Delete all queries added by this monitor
+                        val response: BulkByScrollResponse = suspendCoroutine { cont ->
+                            DeleteByQueryRequestBuilder(client, DeleteByQueryAction.INSTANCE)
+                                .source(queryIndex)
+                                .filter(QueryBuilders.matchQuery("monitor_id", monitorId))
+                                .refresh(true)
+                                .execute(
+                                    object : ActionListener<BulkByScrollResponse> {
+                                        override fun onResponse(response: BulkByScrollResponse) = cont.resume(response)
+                                        override fun onFailure(t: Exception) {
+                                            cont.resumeWithException(t)
+                                        }
+                                    }
+                                )
+                        }
                     }
                 }
+            } catch (e: Exception) {
+                // we only log the error and don't fail the request because if monitor document has been deleted successfully,
+                // we cannot retry based on this failure
+                log.error("Failed to delete workflow metadata for monitor ${monitor.id}.", e)
             }
         }
     }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
@@ -7,6 +7,7 @@ package org.opensearch.alerting
 
 import org.junit.Assert
 import org.opensearch.action.admin.cluster.state.ClusterStateRequest
+import org.opensearch.action.admin.indices.alias.Alias
 import org.opensearch.action.admin.indices.close.CloseIndexRequest
 import org.opensearch.action.admin.indices.create.CreateIndexRequest
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest
@@ -753,6 +754,59 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
         assertEquals("Findings saved for test monitor", 1, findings.size)
         assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("2"))
         assertEquals("Didn't match all 4 queries", 1, findings[0].docLevelQueries.size)
+    }
+
+    fun `test cleanup monitor on partial create monitor failure`() {
+        val docQuery = DocLevelQuery(query = "dnbkjndsfkjbnds:\"us-west-2\"", name = "3")
+        val docLevelInput = DocLevelMonitorInput("description", listOf(index), listOf(docQuery))
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val customQueryIndex = "custom_alerts_index"
+        val analyzer = "dfbdfbafd"
+        val testDoc = """{
+            "rule": {"title": "some_title"},
+            "message": "msg 1 2 3 4"
+        }"""
+        indexDoc(index, "2", testDoc)
+        client().admin().indices()
+            .create(
+                CreateIndexRequest(customQueryIndex + "-000001").alias(Alias(customQueryIndex))
+                    .mapping(
+                        """
+                        {
+                          "_meta": {
+                            "schema_version": 1
+                          },
+                          "properties": {
+                            "query": {
+                              "type": "percolator_ext"
+                            },
+                            "monitor_id": {
+                              "type": "text"
+                            },
+                            "index": {
+                              "type": "text"
+                            }
+                          }
+                        }
+                        """.trimIndent()
+                    )
+            ).get()
+
+        client().admin().indices().close(CloseIndexRequest(customQueryIndex + "-000001")).get()
+        var monitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger),
+            dataSources = DataSources(
+                queryIndex = customQueryIndex,
+                queryIndexMappingsByType = mapOf(Pair("text", mapOf(Pair("analyzer", analyzer)))),
+            )
+        )
+        try {
+            createMonitor(monitor)
+            fail("monitor creation should fail due to incorrect analyzer name in test setup")
+        } catch (e: Exception) {
+            Assert.assertEquals(client().search(SearchRequest(SCHEDULED_JOBS_INDEX)).get().hits.hits.size, 0)
+        }
     }
 
     fun `test execute monitor without create when no monitors exists`() {


### PR DESCRIPTION
In Monitor creation flow adds logic to log correct error message and clean up monitor when there is failure in indexing doc level queries or in monitor metadata creation.
Secure test run
```
alerting git:(secure-test) ✗ ./gradlew :alerting:integTest -xktlint -Dtest.debug=1  -Dcluster.debug=1 -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=docker-cluster -Dsecurity=true -Dhttps=true -Duser=admin -Dpassword=admin --stacktrace --tests "org.opensearch.alerting.resthandler.SecureMonitorRestApiIT.test create monitor failure clean up with a user without delete monitor access"
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 7.4.2
  OS Info               : Mac OS X 13.3 (x86_64)
  JDK Version           : 17 (Amazon Corretto JDK)
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/amazon-corretto-17.jdk/Contents/Home
  Random Testing Seed   : 82E40402A23AE806
  In FIPS 140 mode      : false
=======================================

> Task :alerting:integTest
OpenJDK 64-Bit Server VM warning: Ignoring option --illegal-access=warn; support was removed in 17.0

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.4.2/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 49s
```


*Issue #, if available:*
#897 
*Description of changes:*

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).