### PR TITLE
DocLevelMonitor Error Alert - rework (#892)

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt
@@ -13,6 +13,7 @@ import org.opensearch.action.bulk.BulkRequest
 import org.opensearch.action.bulk.BulkResponse
 import org.opensearch.action.delete.DeleteRequest
 import org.opensearch.action.index.IndexRequest
+import org.opensearch.action.index.IndexResponse
 import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.WriteRequest
@@ -40,6 +41,7 @@ import org.opensearch.commons.alerting.model.Alert
 import org.opensearch.commons.alerting.model.BucketLevelTrigger
 import org.opensearch.commons.alerting.model.DataSources
 import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.NoOpTrigger
 import org.opensearch.commons.alerting.model.Trigger
 import org.opensearch.commons.alerting.model.action.AlertCategory
 import org.opensearch.core.xcontent.NamedXContentRegistry
@@ -47,6 +49,7 @@ import org.opensearch.core.xcontent.XContentParser
 import org.opensearch.index.query.QueryBuilders
 import org.opensearch.rest.RestStatus
 import org.opensearch.search.builder.SearchSourceBuilder
+import org.opensearch.search.sort.SortOrder
 import java.time.Instant
 import java.util.UUID
 
@@ -193,6 +196,19 @@ class AlertService(
         )
     }
 
+    fun composeMonitorErrorAlert(
+        id: String,
+        monitor: Monitor,
+        alertError: AlertError
+    ): Alert {
+        val currentTime = Instant.now()
+        return Alert(
+            id = id, monitor = monitor, trigger = NoOpTrigger(), startTime = currentTime,
+            lastNotificationTime = currentTime, state = Alert.State.ERROR, errorMessage = alertError?.message,
+            schemaVersion = IndexUtils.alertIndexSchemaVersion
+        )
+    }
+
     fun updateActionResultsForBucketLevelAlert(
         currentAlert: Alert,
         actionResults: Map<String, ActionRunResult>,
@@ -287,6 +303,60 @@ class AlertService(
                 schemaVersion = IndexUtils.alertIndexSchemaVersion
             )
         } ?: listOf()
+    }
+
+    suspend fun upsertMonitorErrorAlert(monitor: Monitor, errorMessage: String) {
+        val errorAlertIdPrefix = "error-alert"
+        val newErrorAlertId = "$errorAlertIdPrefix-${monitor.id}-${UUID.randomUUID()}"
+
+        val searchRequest = SearchRequest("${monitor.dataSources.alertsIndex}*")
+            .source(
+                SearchSourceBuilder()
+                    .sort(Alert.START_TIME_FIELD, SortOrder.DESC)
+                    .query(
+                        QueryBuilders.boolQuery()
+                            .must(QueryBuilders.queryStringQuery("${Alert.ALERT_ID_FIELD}:$errorAlertIdPrefix*"))
+                            .must(QueryBuilders.termQuery(Alert.MONITOR_ID_FIELD, monitor.id))
+                            .must(QueryBuilders.termQuery(Alert.STATE_FIELD, Alert.State.ERROR))
+                    )
+            )
+        val searchResponse: SearchResponse = client.suspendUntil { search(searchRequest, it) }
+
+        var alert = composeMonitorErrorAlert(newErrorAlertId, monitor, AlertError(Instant.now(), errorMessage))
+
+        if (searchResponse.hits.totalHits.value > 0L) {
+            if (searchResponse.hits.totalHits.value > 1L) {
+                logger.warn("There are [${searchResponse.hits.totalHits.value}] error alerts for monitor [${monitor.id}]")
+            }
+            // Deserialize first/latest Alert
+            val hit = searchResponse.hits.hits[0]
+            val xcp = contentParser(hit.sourceRef)
+            val existingErrorAlert = Alert.parse(xcp, hit.id, hit.version)
+
+            val currentTime = Instant.now()
+            alert = if (alert.errorMessage != existingErrorAlert.errorMessage) {
+                var newErrorHistory = existingErrorAlert.errorHistory.update(
+                    AlertError(existingErrorAlert.startTime, existingErrorAlert.errorMessage!!)
+                )
+                alert.copy(
+                    id = existingErrorAlert.id,
+                    errorHistory = newErrorHistory,
+                    startTime = currentTime,
+                    lastNotificationTime = currentTime
+                )
+            } else {
+                existingErrorAlert.copy(startTime = Instant.now(), lastNotificationTime = currentTime)
+            }
+        }
+
+        val alertIndexRequest = IndexRequest(monitor.dataSources.alertsIndex)
+            .routing(alert.monitorId)
+            .source(alert.toXContentWithUser(XContentFactory.jsonBuilder()))
+            .opType(DocWriteRequest.OpType.INDEX)
+            .id(alert.id)
+
+        val indexResponse: IndexResponse = client.suspendUntil { index(alertIndexRequest, it) }
+        logger.debug("Monitor error Alert successfully upserted. Op result: ${indexResponse.result}")
     }
 
     suspend fun saveAlerts(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
@@ -137,23 +137,18 @@ class AlertIndices(
     }
 
     @Volatile private var alertHistoryEnabled = AlertingSettings.ALERT_HISTORY_ENABLED.get(settings)
-
     @Volatile private var findingHistoryEnabled = AlertingSettings.FINDING_HISTORY_ENABLED.get(settings)
 
     @Volatile private var alertHistoryMaxDocs = AlertingSettings.ALERT_HISTORY_MAX_DOCS.get(settings)
-
     @Volatile private var findingHistoryMaxDocs = AlertingSettings.FINDING_HISTORY_MAX_DOCS.get(settings)
 
     @Volatile private var alertHistoryMaxAge = AlertingSettings.ALERT_HISTORY_INDEX_MAX_AGE.get(settings)
-
     @Volatile private var findingHistoryMaxAge = AlertingSettings.FINDING_HISTORY_INDEX_MAX_AGE.get(settings)
 
     @Volatile private var alertHistoryRolloverPeriod = AlertingSettings.ALERT_HISTORY_ROLLOVER_PERIOD.get(settings)
-
     @Volatile private var findingHistoryRolloverPeriod = AlertingSettings.FINDING_HISTORY_ROLLOVER_PERIOD.get(settings)
 
     @Volatile private var alertHistoryRetentionPeriod = AlertingSettings.ALERT_HISTORY_RETENTION_PERIOD.get(settings)
-
     @Volatile private var findingHistoryRetentionPeriod = AlertingSettings.FINDING_HISTORY_RETENTION_PERIOD.get(settings)
 
     @Volatile private var requestTimeout = AlertingSettings.REQUEST_TIMEOUT.get(settings)
@@ -454,25 +449,17 @@ class AlertIndices(
 
     private fun rolloverAlertHistoryIndex() {
         rolloverIndex(
-            alertHistoryIndexInitialized,
-            ALERT_HISTORY_WRITE_INDEX,
-            ALERT_HISTORY_INDEX_PATTERN,
-            alertMapping(),
-            alertHistoryMaxDocs,
-            alertHistoryMaxAge,
-            ALERT_HISTORY_WRITE_INDEX
+            alertHistoryIndexInitialized, ALERT_HISTORY_WRITE_INDEX,
+            ALERT_HISTORY_INDEX_PATTERN, alertMapping(),
+            alertHistoryMaxDocs, alertHistoryMaxAge, ALERT_HISTORY_WRITE_INDEX
         )
     }
 
     private fun rolloverFindingHistoryIndex() {
         rolloverIndex(
-            findingHistoryIndexInitialized,
-            FINDING_HISTORY_WRITE_INDEX,
-            FINDING_HISTORY_INDEX_PATTERN,
-            findingMapping(),
-            findingHistoryMaxDocs,
-            findingHistoryMaxAge,
-            FINDING_HISTORY_WRITE_INDEX
+            findingHistoryIndexInitialized, FINDING_HISTORY_WRITE_INDEX,
+            FINDING_HISTORY_INDEX_PATTERN, findingMapping(),
+            findingHistoryMaxDocs, findingHistoryMaxAge, FINDING_HISTORY_WRITE_INDEX
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
@@ -283,6 +283,7 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
                 )
             indexRequests.add(indexRequest)
         }
+        log.debug("bulk inserting percolate [${queries.size}] queries")
         if (indexRequests.isNotEmpty()) {
             val bulkResponse: BulkResponse = client.suspendUntil {
                 client.bulk(

--- a/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
@@ -7,12 +7,14 @@ package org.opensearch.alerting
 
 import org.junit.Assert
 import org.opensearch.action.admin.cluster.state.ClusterStateRequest
+import org.opensearch.action.admin.indices.close.CloseIndexRequest
 import org.opensearch.action.admin.indices.create.CreateIndexRequest
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest
 import org.opensearch.action.admin.indices.get.GetIndexRequest
 import org.opensearch.action.admin.indices.get.GetIndexResponse
 import org.opensearch.action.admin.indices.mapping.get.GetMappingsRequest
 import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest
+import org.opensearch.action.admin.indices.open.OpenIndexRequest
 import org.opensearch.action.admin.indices.refresh.RefreshRequest
 import org.opensearch.action.fieldcaps.FieldCapabilitiesRequest
 import org.opensearch.action.search.SearchRequest
@@ -24,6 +26,7 @@ import org.opensearch.alerting.core.ScheduledJobIndices
 import org.opensearch.alerting.model.DocumentLevelTriggerRunResult
 import org.opensearch.alerting.transport.AlertingSingleNodeTestCase
 import org.opensearch.alerting.util.DocLevelMonitorQueries
+import org.opensearch.alerting.util.DocLevelMonitorQueries.Companion.INDEX_PATTERN_SUFFIX
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.alerting.action.AcknowledgeAlertRequest
@@ -41,6 +44,7 @@ import org.opensearch.commons.alerting.model.Table
 import org.opensearch.index.mapper.MapperService
 import org.opensearch.index.query.MatchQueryBuilder
 import org.opensearch.index.query.QueryBuilders
+import org.opensearch.script.Script
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.test.OpenSearchTestCase
 import java.time.ZonedDateTime
@@ -513,6 +517,109 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
         assertEquals("Findings saved for test monitor", 1, findings.size)
         assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("1"))
         assertEquals("Didn't match all 7 queries", 7, findings[0].docLevelQueries.size)
+    }
+
+    fun `test monitor error alert created and updated with new error`() {
+        val docQuery = DocLevelQuery(query = "source:12345", name = "1")
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(docQuery)
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        var monitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger)
+        )
+
+        val testDoc = """{
+            "message" : "This is an error from IAD region"
+        }"""
+
+        val monitorResponse = createMonitor(monitor)
+        assertFalse(monitorResponse?.id.isNullOrEmpty())
+
+        monitor = monitorResponse!!.monitor
+        val id = monitorResponse.id
+
+        // Close index to force error alert
+        client().admin().indices().close(CloseIndexRequest(index)).get()
+
+        var executeMonitorResponse = executeMonitor(monitor, id, false)
+        Assert.assertEquals(executeMonitorResponse!!.monitorRunResult.monitorName, monitor.name)
+        Assert.assertEquals(executeMonitorResponse.monitorRunResult.triggerResults.size, 0)
+        searchAlerts(id)
+        var table = Table("asc", "id", null, 1, 0, "")
+        var getAlertsResponse = client()
+            .execute(AlertingActions.GET_ALERTS_ACTION_TYPE, GetAlertsRequest(table, "ALL", "ALL", null, null))
+            .get()
+        Assert.assertTrue(getAlertsResponse != null)
+        Assert.assertTrue(getAlertsResponse.alerts.size == 1)
+        Assert.assertTrue(getAlertsResponse.alerts[0].errorMessage == "IndexClosedException[closed]")
+        // Reopen index
+        client().admin().indices().open(OpenIndexRequest(index)).get()
+        // Close queryIndex
+        client().admin().indices().close(CloseIndexRequest(DOC_LEVEL_QUERIES_INDEX + INDEX_PATTERN_SUFFIX)).get()
+
+        indexDoc(index, "1", testDoc)
+
+        executeMonitorResponse = executeMonitor(monitor, id, false)
+        Assert.assertEquals(executeMonitorResponse!!.monitorRunResult.monitorName, monitor.name)
+        Assert.assertEquals(executeMonitorResponse.monitorRunResult.triggerResults.size, 0)
+        searchAlerts(id)
+        table = Table("asc", "id", null, 10, 0, "")
+        getAlertsResponse = client()
+            .execute(AlertingActions.GET_ALERTS_ACTION_TYPE, GetAlertsRequest(table, "ALL", "ALL", null, null))
+            .get()
+        Assert.assertTrue(getAlertsResponse != null)
+        Assert.assertTrue(getAlertsResponse.alerts.size == 1)
+        Assert.assertTrue(getAlertsResponse.alerts[0].errorHistory[0].message == "IndexClosedException[closed]")
+        Assert.assertEquals(1, getAlertsResponse.alerts[0].errorHistory.size)
+        Assert.assertTrue(getAlertsResponse.alerts[0].errorMessage!!.contains("Failed to run percolate search"))
+    }
+
+    fun `test monitor error alert created trigger run errored 2 times same error`() {
+        val docQuery = DocLevelQuery(query = "source:12345", name = "1")
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(docQuery)
+        )
+        val trigger = randomDocumentLevelTrigger(condition = Script("invalid script code"))
+        var monitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger)
+        )
+
+        val monitorResponse = createMonitor(monitor)
+        assertFalse(monitorResponse?.id.isNullOrEmpty())
+
+        monitor = monitorResponse!!.monitor
+        val id = monitorResponse.id
+
+        var executeMonitorResponse = executeMonitor(monitor, id, false)
+        Assert.assertEquals(executeMonitorResponse!!.monitorRunResult.monitorName, monitor.name)
+        Assert.assertEquals(executeMonitorResponse.monitorRunResult.triggerResults.size, 1)
+        searchAlerts(id)
+        var table = Table("asc", "id", null, 1, 0, "")
+        var getAlertsResponse = client()
+            .execute(AlertingActions.GET_ALERTS_ACTION_TYPE, GetAlertsRequest(table, "ALL", "ALL", null, null))
+            .get()
+        Assert.assertTrue(getAlertsResponse != null)
+        Assert.assertTrue(getAlertsResponse.alerts.size == 1)
+        Assert.assertTrue(getAlertsResponse.alerts[0].errorMessage!!.contains("Trigger errors"))
+
+        val oldAlertStartTime = getAlertsResponse.alerts[0].startTime
+
+        executeMonitorResponse = executeMonitor(monitor, id, false)
+        Assert.assertEquals(executeMonitorResponse!!.monitorRunResult.monitorName, monitor.name)
+        Assert.assertEquals(executeMonitorResponse.monitorRunResult.triggerResults.size, 1)
+        searchAlerts(id)
+        table = Table("asc", "id", null, 10, 0, "")
+        getAlertsResponse = client()
+            .execute(AlertingActions.GET_ALERTS_ACTION_TYPE, GetAlertsRequest(table, "ALL", "ALL", null, null))
+            .get()
+        Assert.assertTrue(getAlertsResponse != null)
+        Assert.assertTrue(getAlertsResponse.alerts.size == 1)
+        Assert.assertEquals(0, getAlertsResponse.alerts[0].errorHistory.size)
+        Assert.assertTrue(getAlertsResponse.alerts[0].errorMessage!!.contains("Trigger errors"))
+        Assert.assertTrue(getAlertsResponse.alerts[0].startTime.isAfter(oldAlertStartTime))
     }
 
     fun `test execute monitor with custom query index and nested mappings`() {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/alerts/AlertIndicesIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/alerts/AlertIndicesIT.kt
@@ -216,6 +216,9 @@ class AlertIndicesIT : AlertingRestTestCase() {
         // Check if alert is active and alert index is created
         val activeAlert = searchAlerts(monitor)
         assertEquals("1 alert should be active", 1, activeAlert.size)
+
+        waitUntil { return@waitUntil getAlertIndices().size == 2 }
+
         assertEquals("Did not find 2 alert indices", 2, getAlertIndices().size)
         // History index is created but is empty
         assertEquals(0, getAlertHistoryDocCount())
@@ -273,6 +276,9 @@ class AlertIndicesIT : AlertingRestTestCase() {
         // Check if alert is active and alert index is created
         val activeAlert = searchAlerts(monitor)
         assertEquals("1 alert should be active", 1, activeAlert.size)
+
+        waitUntil { return@waitUntil getAlertIndices().size == 2 }
+
         assertEquals("Did not find 2 alert indices", 2, getAlertIndices().size)
         // History index is created but is empty
         assertEquals(0, getAlertHistoryDocCount())


### PR DESCRIPTION
Specific "Error Alert" is created for a monitor, when error happens during monitor run. State of alert is ERROR and subsequent errors would upsert this "Error Alert". If error message is different then previous one, errorMessage field would be overwritten and previous error would be added to errorHistory rolling array(10 elements). ---------

Signed-off-by: Petar Dzepina <petar.dzepina@gmail.com>
(cherry picked from commit 461e95f38bd55268e3ac17026e283ac9f18d911b)

*Issue #, if available:*

*Description of changes:*

*CheckList:*
[ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).