### PR TITLE
Backports #900 clean up monitor when indexing doc level queries or metadata creation fails 

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
@@ -5,9 +5,8 @@
 
 package org.opensearch.alerting.transport
 
-import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.apache.logging.log4j.LogManager
 import org.opensearch.OpenSearchStatusException
@@ -25,6 +24,7 @@ import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.action.support.IndicesOptions
+import org.opensearch.action.support.WriteRequest
 import org.opensearch.action.support.master.AcknowledgedResponse
 import org.opensearch.alerting.MonitorMetadataService
 import org.opensearch.alerting.opensearchapi.suspendUntil
@@ -57,6 +57,7 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 
+private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 private val log = LogManager.getLogger(TransportDeleteMonitorAction::class.java)
 
 class TransportDeleteMonitorAction @Inject constructor(
@@ -90,8 +91,7 @@ class TransportDeleteMonitorAction @Inject constructor(
         if (!validateUserBackendRoles(user, actionListener)) {
             return
         }
-
-        GlobalScope.launch(Dispatchers.IO + CoroutineName("DeleteMonitorAction")) {
+        scope.launch {
             DeleteMonitorHandler(client, actionListener, deleteRequest, user, transformedRequest.monitorId).resolveUserAndStart()
         }
     }
@@ -112,9 +112,7 @@ class TransportDeleteMonitorAction @Inject constructor(
                     checkUserPermissionsWithResource(user, monitor.user, actionListener, "monitor", monitorId)
 
                 if (canDelete) {
-                    val deleteResponse = deleteMonitor(monitor)
-                    deleteDocLevelMonitorQueriesAndIndices(monitor)
-                    deleteMetadata(monitor)
+                    val deleteResponse = deleteAllResourcesForMonitor(client, monitor, deleteRequest, monitorId)
                     actionListener.onResponse(DeleteMonitorResponse(deleteResponse.id, deleteResponse.version))
                 } else {
                     actionListener.onFailure(
@@ -122,6 +120,7 @@ class TransportDeleteMonitorAction @Inject constructor(
                     )
                 }
             } catch (t: Exception) {
+                log.error("Failed to delete monitor ${deleteRequest.id()}", t)
                 actionListener.onFailure(AlertingException.wrap(t))
             }
         }
@@ -145,69 +144,102 @@ class TransportDeleteMonitorAction @Inject constructor(
             )
             return ScheduledJob.parse(xcp, getResponse.id, getResponse.version) as Monitor
         }
+    }
 
-        private suspend fun deleteMonitor(monitor: Monitor): DeleteResponse {
+    companion object {
+        @JvmStatic
+        suspend fun deleteAllResourcesForMonitor(
+            client: Client,
+            monitor: Monitor,
+            deleteRequest: DeleteRequest,
+            monitorId: String,
+        ): DeleteResponse {
+            val deleteResponse = deleteMonitorDocument(client, deleteRequest)
+            deleteMetadata(client, monitor)
+            deleteDocLevelMonitorQueriesAndIndices(client, monitor, monitorId)
+            return deleteResponse
+        }
+
+        private suspend fun deleteMonitorDocument(client: Client, deleteRequest: DeleteRequest): DeleteResponse {
             return client.suspendUntil { delete(deleteRequest, it) }
         }
 
-        private suspend fun deleteMetadata(monitor: Monitor) {
+        suspend fun deleteMetadata(client: Client, monitor: Monitor) {
             val deleteRequest = DeleteRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, "${monitor.id}-metadata")
-            val deleteResponse: DeleteResponse = client.suspendUntil { delete(deleteRequest, it) }
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            try {
+                val deleteResponse: DeleteResponse = client.suspendUntil { delete(deleteRequest, it) }
+                log.debug("Monitor metadata: ${deleteResponse.id} deletion result: ${deleteResponse.result}")
+            } catch (e: Exception) {
+                // we only log the error and don't fail the request because if monitor document has been deleted,
+                // we cannot retry based on this failure
+                log.error("Failed to delete monitor metadata ${deleteRequest.id()}.", e)
+            }
         }
 
-        private suspend fun deleteDocLevelMonitorQueriesAndIndices(monitor: Monitor) {
-            val clusterState = clusterService.state()
-            val metadata = MonitorMetadataService.getMetadata(monitor)
-            metadata?.sourceToQueryIndexMapping?.forEach { (_, queryIndex) ->
+        suspend fun deleteDocLevelMonitorQueriesAndIndices(
+            client: Client,
+            monitor: Monitor,
+            monitorId: String,
+        ) {
+            try {
+                val metadata = MonitorMetadataService.getMetadata(monitor)
+                metadata?.sourceToQueryIndexMapping?.forEach { (_, queryIndex) ->
 
-                val indicesExistsResponse: IndicesExistsResponse =
-                    client.suspendUntil {
-                        client.admin().indices().exists(IndicesExistsRequest(queryIndex), it)
+                    val indicesExistsResponse: IndicesExistsResponse =
+                        client.suspendUntil {
+                            client.admin().indices().exists(IndicesExistsRequest(queryIndex), it)
+                        }
+                    if (indicesExistsResponse.isExists == false) {
+                        return
                     }
-                if (indicesExistsResponse.isExists == false) {
-                    return
-                }
-                // Check if there's any queries from other monitors in this queryIndex,
-                // to avoid unnecessary doc deletion, if we could just delete index completely
-                val searchResponse: SearchResponse = client.suspendUntil {
-                    search(
-                        SearchRequest(queryIndex).source(
-                            SearchSourceBuilder()
-                                .size(0)
-                                .query(
-                                    QueryBuilders.boolQuery().mustNot(
-                                        QueryBuilders.matchQuery("monitor_id", monitorId)
+                    // Check if there's any queries from other monitors in this queryIndex,
+                    // to avoid unnecessary doc deletion, if we could just delete index completely
+                    val searchResponse: SearchResponse = client.suspendUntil {
+                        search(
+                            SearchRequest(queryIndex).source(
+                                SearchSourceBuilder()
+                                    .size(0)
+                                    .query(
+                                        QueryBuilders.boolQuery().mustNot(
+                                            QueryBuilders.matchQuery("monitor_id", monitorId)
+                                        )
                                     )
-                                )
-                        ).indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_HIDDEN),
-                        it
-                    )
-                }
-                if (searchResponse.hits.totalHits.value == 0L) {
-                    val ack: AcknowledgedResponse = client.suspendUntil {
-                        client.admin().indices().delete(
-                            DeleteIndexRequest(queryIndex).indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_HIDDEN),
+                            ).indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_HIDDEN),
                             it
                         )
                     }
-                    if (ack.isAcknowledged == false) {
-                        log.error("Deletion of concrete queryIndex:$queryIndex is not ack'd!")
-                    }
-                } else {
-                    // Delete all queries added by this monitor
-                    val response: BulkByScrollResponse = suspendCoroutine { cont ->
-                        DeleteByQueryRequestBuilder(client, DeleteByQueryAction.INSTANCE)
-                            .source(queryIndex)
-                            .filter(QueryBuilders.matchQuery("monitor_id", monitorId))
-                            .refresh(true)
-                            .execute(
-                                object : ActionListener<BulkByScrollResponse> {
-                                    override fun onResponse(response: BulkByScrollResponse) = cont.resume(response)
-                                    override fun onFailure(t: Exception) = cont.resumeWithException(t)
-                                }
+                    if (searchResponse.hits.totalHits.value == 0L) {
+                        val ack: AcknowledgedResponse = client.suspendUntil {
+                            client.admin().indices().delete(
+                                DeleteIndexRequest(queryIndex).indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_HIDDEN), it
                             )
+                        }
+                        if (ack.isAcknowledged == false) {
+                            log.error("Deletion of concrete queryIndex:$queryIndex is not ack'd!")
+                        }
+                    } else {
+                        // Delete all queries added by this monitor
+                        val response: BulkByScrollResponse = suspendCoroutine { cont ->
+                            DeleteByQueryRequestBuilder(client, DeleteByQueryAction.INSTANCE)
+                                .source(queryIndex)
+                                .filter(QueryBuilders.matchQuery("monitor_id", monitorId))
+                                .refresh(true)
+                                .execute(
+                                    object : ActionListener<BulkByScrollResponse> {
+                                        override fun onResponse(response: BulkByScrollResponse) = cont.resume(response)
+                                        override fun onFailure(t: Exception) {
+                                            cont.resumeWithException(t)
+                                        }
+                                    }
+                                )
+                        }
                     }
                 }
+            } catch (e: Exception) {
+                // we only log the error and don't fail the request because if monitor document has been deleted successfully,
+                // we cannot retry based on this failure
+                log.error("Failed to delete doc level queries from query index.", e)
             }
         }
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -20,6 +20,7 @@ import org.opensearch.action.admin.cluster.health.ClusterHealthAction
 import org.opensearch.action.admin.cluster.health.ClusterHealthRequest
 import org.opensearch.action.admin.cluster.health.ClusterHealthResponse
 import org.opensearch.action.admin.indices.create.CreateIndexResponse
+import org.opensearch.action.delete.DeleteRequest
 import org.opensearch.action.get.GetRequest
 import org.opensearch.action.get.GetResponse
 import org.opensearch.action.index.IndexRequest
@@ -186,7 +187,7 @@ class TransportIndexMonitorAction @Inject constructor(
         client: Client,
         actionListener: ActionListener<IndexMonitorResponse>,
         request: IndexMonitorRequest,
-        user: User?
+        user: User?,
     ) {
         val indices = mutableListOf<String>()
         // todo: for doc level alerting: check if index is present before monitor is created.
@@ -239,7 +240,7 @@ class TransportIndexMonitorAction @Inject constructor(
         client: Client,
         actionListener: ActionListener<IndexMonitorResponse>,
         request: IndexMonitorRequest,
-        user: User?
+        user: User?,
     ) {
         client.threadPool().threadContext.stashContext().use {
             IndexMonitorHandler(client, actionListener, request, user).resolveUserAndStartForAD()
@@ -250,7 +251,7 @@ class TransportIndexMonitorAction @Inject constructor(
         private val client: Client,
         private val actionListener: ActionListener<IndexMonitorResponse>,
         private val request: IndexMonitorRequest,
-        private val user: User?
+        private val user: User?,
     ) {
 
         fun resolveUserAndStart() {
@@ -503,16 +504,30 @@ class TransportIndexMonitorAction @Inject constructor(
                     )
                     return
                 }
-                request.monitor = request.monitor.copy(id = indexResponse.id)
-                var (metadata, created) = MonitorMetadataService.getOrCreateMetadata(request.monitor)
-                if (created == false) {
-                    log.warn("Metadata doc id:${metadata.id} exists, but it shouldn't!")
+                var metadata: MonitorMetadata?
+                try { // delete monitor if metadata creation fails, log the right error and re-throw the error to fail listener
+                    request.monitor = request.monitor.copy(id = indexResponse.id)
+                    var (monitorMetadata: MonitorMetadata, created: Boolean) = MonitorMetadataService.getOrCreateMetadata(request.monitor)
+                    if (created == false) {
+                        log.warn("Metadata doc id:${monitorMetadata.id} exists, but it shouldn't!")
+                    }
+                    metadata = monitorMetadata
+                } catch (t: Exception) {
+                    log.error("failed to create metadata for monitor ${indexResponse.id}. deleting monitor")
+                    cleanupMonitorAfterPartialFailure(request.monitor, indexResponse)
+                    throw t
                 }
-                if (request.monitor.monitorType == Monitor.MonitorType.DOC_LEVEL_MONITOR) {
-                    indexDocLevelMonitorQueries(request.monitor, indexResponse.id, metadata, request.refreshPolicy)
+                try {
+                    if (request.monitor.monitorType == Monitor.MonitorType.DOC_LEVEL_MONITOR) {
+                        indexDocLevelMonitorQueries(request.monitor, indexResponse.id, metadata, request.refreshPolicy)
+                    }
+                    // When inserting queries in queryIndex we could update sourceToQueryIndexMapping
+                    MonitorMetadataService.upsertMetadata(metadata, updating = true)
+                } catch (t: Exception) {
+                    log.error("failed to index doc level queries monitor ${indexResponse.id}. deleting monitor", t)
+                    cleanupMonitorAfterPartialFailure(request.monitor, indexResponse)
+                    throw t
                 }
-                // When inserting queries in queryIndex we could update sourceToQueryIndexMapping
-                MonitorMetadataService.upsertMetadata(metadata, updating = true)
 
                 actionListener.onResponse(
                     IndexMonitorResponse(
@@ -525,6 +540,24 @@ class TransportIndexMonitorAction @Inject constructor(
                 )
             } catch (t: Exception) {
                 actionListener.onFailure(AlertingException.wrap(t))
+            }
+        }
+
+        private suspend fun cleanupMonitorAfterPartialFailure(monitor: Monitor, indexMonitorResponse: IndexResponse) {
+            // we simply log the success (debug log) or failure (error log) when we try clean up partially failed monitor creation request
+            try {
+                TransportDeleteMonitorAction.deleteAllResourcesForMonitor(
+                    client,
+                    monitor = monitor,
+                    DeleteRequest(SCHEDULED_JOBS_INDEX, indexMonitorResponse.id).setRefreshPolicy(RefreshPolicy.IMMEDIATE),
+                    indexMonitorResponse.id
+                )
+                log.debug(
+                    "Cleaned up monitor related resources after monitor creation request partial failure. " +
+                        "Monitor id : ${indexMonitorResponse.id}"
+                )
+            } catch (e: Exception) {
+                log.error("Failed to clean up monitor after monitor creation request partial failure", e)
             }
         }
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -39,17 +39,20 @@ import org.opensearch.alerting.randomAction
 import org.opensearch.alerting.randomAlert
 import org.opensearch.alerting.randomBucketLevelMonitor
 import org.opensearch.alerting.randomBucketLevelTrigger
+import org.opensearch.alerting.randomDocumentLevelMonitor
 import org.opensearch.alerting.randomQueryLevelMonitor
 import org.opensearch.alerting.randomQueryLevelTrigger
 import org.opensearch.alerting.randomTemplateScript
 import org.opensearch.client.Response
 import org.opensearch.client.ResponseException
 import org.opensearch.client.RestClient
+import org.opensearch.common.settings.Settings
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.common.xcontent.json.JsonXContent
 import org.opensearch.commons.alerting.aggregation.bucketselectorext.BucketSelectorExtAggregationBuilder
 import org.opensearch.commons.alerting.model.Alert
+import org.opensearch.commons.alerting.model.DocLevelMonitorInput
 import org.opensearch.commons.alerting.model.SearchInput
 import org.opensearch.commons.authuser.User
 import org.opensearch.commons.rest.SecureRestClientBuilder
@@ -1462,6 +1465,68 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             assertEquals("Incorrect number of alerts", 1, alerts.size)
         } finally {
             deleteRoleAndRoleMapping(TEST_HR_ROLE)
+        }
+    }
+
+    /**
+     * We want to verify that user roles/permissions do not affect clean up of monitors during partial monitor creation failure
+     */
+    fun `test create monitor failure clean up with a user without delete monitor access`() {
+        enableFilterBy()
+        createUser(user, user, listOf(TEST_HR_BACKEND_ROLE, "role2").toTypedArray())
+        createTestIndex(TEST_HR_INDEX)
+        createCustomIndexRole(
+            ALERTING_INDEX_MONITOR_ACCESS,
+            TEST_HR_INDEX,
+            getClusterPermissionsFromCustomRole(ALERTING_INDEX_MONITOR_ACCESS)
+        )
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_INDEX_MONITOR_ACCESS, READALL_AND_MONITOR_ROLE),
+            listOf(TEST_HR_BACKEND_ROLE, "role2"),
+            false
+        )
+        val docLevelQueryIndex = ".opensearch-alerting-queries-000001"
+        createIndex(
+            docLevelQueryIndex, Settings.EMPTY,
+            """
+                 "properties" : {
+                  "query": {
+                              "type": "percolator_ext"
+                            },
+                            "monitor_id": {
+                              "type": "text"
+                            },
+                            "index": {
+                              "type": "text"
+                            }
+                }
+                }
+            """.trimIndent(),
+            ".opensearch-alerting-queries"
+        )
+        closeIndex(docLevelQueryIndex) // close index to simulate doc level query indexing failure
+        try {
+            val monitor = randomDocumentLevelMonitor(
+                withMetadata = false,
+                triggers = listOf(),
+                inputs = listOf(DocLevelMonitorInput("description", listOf(TEST_HR_INDEX), emptyList()))
+            )
+            userClient?.makeRequest("POST", ALERTING_BASE_URI, emptyMap(), monitor.toHttpEntity())
+            fail("Monitor creation should have failed due to error in indexing doc level queries")
+        } catch (e: ResponseException) {
+            val search = SearchSourceBuilder().query(QueryBuilders.matchAllQuery()).size(10).toString()
+            val searchResponse = client().makeRequest(
+                "GET", "$ALERTING_BASE_URI/_search",
+                emptyMap(),
+                StringEntity(search, ContentType.APPLICATION_JSON)
+            )
+            val xcp = createParser(XContentType.JSON.xContent(), searchResponse.entity.content)
+            val hits = xcp.map()["hits"]!! as Map<String, Map<String, Any>>
+            val numberDocsFound = hits["total"]?.get("value")
+            assertEquals("Monitors found. Clean up unsuccessful", 0, numberDocsFound)
+        } finally {
+            deleteRoleAndRoleMapping(ALERTING_INDEX_MONITOR_ACCESS)
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
#897
*Description of changes:*
In Monitor creation flow adds logic to log correct error message and clean up monitor when there is failure in indexing doc level queries or in monitor metadata creation.

*CheckList:*
[x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).