### PR TITLE
revert to deleting monitor metadata after deleting doc level queries to fix delete monitor regression.

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
@@ -150,8 +150,8 @@ class TransportDeleteMonitorAction @Inject constructor(
             monitorId: String,
         ): DeleteResponse {
             val deleteResponse = deleteMonitorDocument(client, deleteRequest)
-            deleteMetadata(client, monitor)
             deleteDocLevelMonitorQueriesAndIndices(client, monitor, monitorId)
+            deleteMetadata(client, monitor)
             return deleteResponse
         }
 


### PR DESCRIPTION
 *Description of changes:*
Metadata is required for correct query index clean up during monitor deletion. Reverted to deleting monitor metadata after deleting doc level queries to fix regression.

