### PR TITLE
Adds transport layer actions for CRUD workflows

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -114,6 +114,8 @@ dependencies {
     testImplementation "org.mockito:mockito-core:${versions.mockito}"
     testImplementation "org.opensearch.plugin:reindex-client:${opensearch_version}"
     testImplementation "org.opensearch.plugin:parent-join-client:${opensearch_version}"
+    testImplementation "org.opensearch.plugin:lang-painless:${opensearch_version}"
+    testImplementation "org.opensearch.plugin:lang-mustache-client:${opensearch_version}"
 }
 
 javadoc.enabled = false // turn off javadoc as it barfs on Kotlin code

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -44,6 +44,7 @@ import org.opensearch.alerting.settings.LegacyOpenDistroAlertingSettings
 import org.opensearch.alerting.settings.LegacyOpenDistroDestinationSettings
 import org.opensearch.alerting.transport.TransportAcknowledgeAlertAction
 import org.opensearch.alerting.transport.TransportDeleteMonitorAction
+import org.opensearch.alerting.transport.TransportDeleteWorkflowAction
 import org.opensearch.alerting.transport.TransportExecuteMonitorAction
 import org.opensearch.alerting.transport.TransportGetAlertsAction
 import org.opensearch.alerting.transport.TransportGetDestinationsAction
@@ -51,6 +52,7 @@ import org.opensearch.alerting.transport.TransportGetEmailAccountAction
 import org.opensearch.alerting.transport.TransportGetEmailGroupAction
 import org.opensearch.alerting.transport.TransportGetFindingsSearchAction
 import org.opensearch.alerting.transport.TransportGetMonitorAction
+import org.opensearch.alerting.transport.TransportGetWorkflowAction
 import org.opensearch.alerting.transport.TransportIndexMonitorAction
 import org.opensearch.alerting.transport.TransportIndexWorkflowAction
 import org.opensearch.alerting.transport.TransportSearchEmailAccountAction
@@ -194,7 +196,9 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             ActionPlugin.ActionHandler(GetDestinationsAction.INSTANCE, TransportGetDestinationsAction::class.java),
             ActionPlugin.ActionHandler(AlertingActions.GET_ALERTS_ACTION_TYPE, TransportGetAlertsAction::class.java),
             ActionPlugin.ActionHandler(AlertingActions.GET_FINDINGS_ACTION_TYPE, TransportGetFindingsSearchAction::class.java),
-            ActionPlugin.ActionHandler(AlertingActions.INDEX_WORKFLOW_ACTION_TYPE, TransportIndexWorkflowAction::class.java)
+            ActionPlugin.ActionHandler(AlertingActions.INDEX_WORKFLOW_ACTION_TYPE, TransportIndexWorkflowAction::class.java),
+            ActionPlugin.ActionHandler(AlertingActions.GET_WORKFLOW_ACTION_TYPE, TransportGetWorkflowAction::class.java),
+            ActionPlugin.ActionHandler(AlertingActions.DELETE_WORKFLOW_ACTION_TYPE, TransportDeleteWorkflowAction::class.java)
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -40,6 +40,7 @@ import org.opensearch.alerting.resthandler.RestSearchEmailAccountAction
 import org.opensearch.alerting.resthandler.RestSearchEmailGroupAction
 import org.opensearch.alerting.resthandler.RestSearchMonitorAction
 import org.opensearch.alerting.script.TriggerScript
+import org.opensearch.alerting.service.DeleteMonitorService
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.settings.DestinationSettings
 import org.opensearch.alerting.settings.LegacyOpenDistroAlertingSettings
@@ -290,6 +291,8 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             xContentRegistry,
             settings
         )
+
+        DeleteMonitorService.initialize(client)
 
         return listOf(sweeper, scheduler, runner, scheduledJobIndices, docLevelMonitorQueries, destinationMigrationCoordinator)
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -52,6 +52,7 @@ import org.opensearch.alerting.transport.TransportGetEmailGroupAction
 import org.opensearch.alerting.transport.TransportGetFindingsSearchAction
 import org.opensearch.alerting.transport.TransportGetMonitorAction
 import org.opensearch.alerting.transport.TransportIndexMonitorAction
+import org.opensearch.alerting.transport.TransportIndexWorkflowAction
 import org.opensearch.alerting.transport.TransportSearchEmailAccountAction
 import org.opensearch.alerting.transport.TransportSearchEmailGroupAction
 import org.opensearch.alerting.transport.TransportSearchMonitorAction
@@ -80,6 +81,7 @@ import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.model.SearchInput
 import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.core.xcontent.XContentParser
+import org.opensearch.commons.alerting.model.Workflow
 import org.opensearch.env.Environment
 import org.opensearch.env.NodeEnvironment
 import org.opensearch.index.IndexModule
@@ -119,7 +121,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
         @JvmField val UI_METADATA_EXCLUDE = arrayOf("monitor.${Monitor.UI_METADATA_FIELD}")
 
         @JvmField val MONITOR_BASE_URI = "/_plugins/_alerting/monitors"
-
+        @JvmField val WORKFLOW_BASE_URI = "/_plugins/_alerting/workflows"
         @JvmField val DESTINATION_BASE_URI = "/_plugins/_alerting/destinations"
 
         @JvmField val LEGACY_OPENDISTRO_MONITOR_BASE_URI = "/_opendistro/_alerting/monitors"
@@ -191,8 +193,8 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             ActionPlugin.ActionHandler(SearchEmailGroupAction.INSTANCE, TransportSearchEmailGroupAction::class.java),
             ActionPlugin.ActionHandler(GetDestinationsAction.INSTANCE, TransportGetDestinationsAction::class.java),
             ActionPlugin.ActionHandler(AlertingActions.GET_ALERTS_ACTION_TYPE, TransportGetAlertsAction::class.java),
-            ActionPlugin.ActionHandler(AlertingActions.GET_FINDINGS_ACTION_TYPE, TransportGetFindingsSearchAction::class.java)
-
+            ActionPlugin.ActionHandler(AlertingActions.GET_FINDINGS_ACTION_TYPE, TransportGetFindingsSearchAction::class.java),
+            ActionPlugin.ActionHandler(AlertingActions.INDEX_WORKFLOW_ACTION_TYPE, TransportIndexWorkflowAction::class.java)
         )
     }
 
@@ -204,7 +206,8 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             QueryLevelTrigger.XCONTENT_REGISTRY,
             BucketLevelTrigger.XCONTENT_REGISTRY,
             ClusterMetricsInput.XCONTENT_REGISTRY,
-            DocumentLevelTrigger.XCONTENT_REGISTRY
+            DocumentLevelTrigger.XCONTENT_REGISTRY,
+            Workflow.XCONTENT_REGISTRY
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -79,9 +79,9 @@ import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.QueryLevelTrigger
 import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.model.SearchInput
+import org.opensearch.commons.alerting.model.Workflow
 import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.core.xcontent.XContentParser
-import org.opensearch.commons.alerting.model.Workflow
 import org.opensearch.env.Environment
 import org.opensearch.env.NodeEnvironment
 import org.opensearch.index.IndexModule

--- a/alerting/src/main/kotlin/org/opensearch/alerting/BucketLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/BucketLevelMonitorRunner.kt
@@ -25,6 +25,7 @@ import org.opensearch.alerting.util.defaultToPerExecutionAction
 import org.opensearch.alerting.util.getActionExecutionPolicy
 import org.opensearch.alerting.util.getBucketKeysHash
 import org.opensearch.alerting.util.getCombinedTriggerRunResult
+import org.opensearch.alerting.workflow.WorkflowRunContext
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.alerting.model.Alert
@@ -59,7 +60,8 @@ object BucketLevelMonitorRunner : MonitorRunner() {
         monitorCtx: MonitorRunnerExecutionContext,
         periodStart: Instant,
         periodEnd: Instant,
-        dryrun: Boolean
+        dryrun: Boolean,
+        workflowRunContext: WorkflowRunContext?
     ): MonitorRunResult<BucketLevelTriggerRunResult> {
         val roles = MonitorRunnerService.getRolesForMonitor(monitor)
         logger.debug("Running monitor: ${monitor.name} with roles: $roles Thread: ${Thread.currentThread().name}")
@@ -118,7 +120,8 @@ object BucketLevelMonitorRunner : MonitorRunner() {
                     monitor,
                     periodStart,
                     periodEnd,
-                    monitorResult.inputResults
+                    monitorResult.inputResults,
+                    workflowRunContext
                 )
                 if (firstIteration) {
                     firstPageOfInputResults = inputResults
@@ -154,7 +157,8 @@ object BucketLevelMonitorRunner : MonitorRunner() {
                             monitorCtx,
                             periodStart,
                             periodEnd,
-                            !dryrun && monitor.id != Monitor.NO_ID
+                            !dryrun && monitor.id != Monitor.NO_ID,
+                            workflowRunContext
                         )
                     } else {
                         emptyList()
@@ -350,7 +354,8 @@ object BucketLevelMonitorRunner : MonitorRunner() {
         monitorCtx: MonitorRunnerExecutionContext,
         periodStart: Instant,
         periodEnd: Instant,
-        shouldCreateFinding: Boolean
+        shouldCreateFinding: Boolean,
+        workflowRunContext: WorkflowRunContext? = null
     ): List<String> {
         monitor.inputs.forEach { input ->
             if (input is SearchInput) {
@@ -361,14 +366,14 @@ object BucketLevelMonitorRunner : MonitorRunner() {
                 for (aggFactory in (query.aggregations() as AggregatorFactories.Builder).aggregatorFactories) {
                     when (aggFactory) {
                         is CompositeAggregationBuilder -> {
-                            var grouByFields = 0 // if number of fields used to group by > 1 we won't calculate findings
+                            var groupByFields = 0 // if number of fields used to group by > 1 we won't calculate findings
                             val sources = aggFactory.sources()
                             for (source in sources) {
-                                if (grouByFields > 0) {
+                                if (groupByFields > 0) {
                                     logger.error("grouByFields > 0. not generating findings for bucket level monitor ${monitor.id}")
                                     return listOf()
                                 }
-                                grouByFields++
+                                groupByFields++
                                 fieldName = source.field()
                             }
                         }
@@ -409,7 +414,7 @@ object BucketLevelMonitorRunner : MonitorRunner() {
                             sr.source().query(queryBuilder)
                         }
                     val searchResponse: SearchResponse = monitorCtx.client!!.suspendUntil { monitorCtx.client!!.search(sr, it) }
-                    return createFindingPerIndex(searchResponse, monitor, monitorCtx, shouldCreateFinding)
+                    return createFindingPerIndex(searchResponse, monitor, monitorCtx, shouldCreateFinding, workflowRunContext?.executionId)
                 } else {
                     logger.error("Couldn't resolve groupBy field. Not generating bucket level monitor findings for monitor %${monitor.id}")
                 }
@@ -422,7 +427,8 @@ object BucketLevelMonitorRunner : MonitorRunner() {
         searchResponse: SearchResponse,
         monitor: Monitor,
         monitorCtx: MonitorRunnerExecutionContext,
-        shouldCreateFinding: Boolean
+        shouldCreateFinding: Boolean,
+        workflowExecutionId: String? = null
     ): List<String> {
         val docIdsByIndexName: MutableMap<String, MutableList<String>> = mutableMapOf()
         for (hit in searchResponse.hits.hits) {
@@ -441,7 +447,8 @@ object BucketLevelMonitorRunner : MonitorRunner() {
                     monitorName = monitor.name,
                     index = it.key,
                     timestamp = Instant.now(),
-                    docLevelQueries = listOf()
+                    docLevelQueries = listOf(),
+                    executionId = workflowExecutionId
                 )
 
                 val findingStr = finding.toXContent(XContentBuilder.builder(XContentType.JSON.xContent()), ToXContent.EMPTY_PARAMS).string()

--- a/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
@@ -27,6 +27,7 @@ import org.opensearch.alerting.util.AlertingException
 import org.opensearch.alerting.util.IndexUtils
 import org.opensearch.alerting.util.defaultToPerExecutionAction
 import org.opensearch.alerting.util.getActionExecutionPolicy
+import org.opensearch.alerting.workflow.WorkflowRunContext
 import org.opensearch.client.Client
 import org.opensearch.client.node.NodeClient
 import org.opensearch.cluster.metadata.IndexMetadata
@@ -70,7 +71,8 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
         monitorCtx: MonitorRunnerExecutionContext,
         periodStart: Instant,
         periodEnd: Instant,
-        dryrun: Boolean
+        dryrun: Boolean,
+        workflowRunContext: WorkflowRunContext?
     ): MonitorRunResult<DocumentLevelTriggerRunResult> {
         logger.debug("Document-level-monitor is running ...")
         val isTempMonitor = dryrun || monitor.id == Monitor.NO_ID
@@ -96,7 +98,8 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
         var (monitorMetadata, _) = MonitorMetadataService.getOrCreateMetadata(
             monitor = monitor,
             createWithRunContext = false,
-            skipIndex = isTempMonitor
+            skipIndex = isTempMonitor,
+            workflowRunContext?.workflowMetadataId
         )
 
         val docLevelMonitorInput = monitor.inputs[0] as DocLevelMonitorInput
@@ -135,6 +138,9 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
                 }
             }
 
+            // Map of document ids per index when monitor is workflow delegate and has chained findings
+            val matchingDocIdsPerIndex = workflowRunContext?.matchingDocIdsPerIndex
+
             indices.forEach { indexName ->
                 // Prepare lastRunContext for each index
                 val indexLastRunContext = lastRunContext.getOrPut(indexName) {
@@ -169,7 +175,13 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
                 // Prepare DocumentExecutionContext for each index
                 val docExecutionContext = DocumentExecutionContext(queries, indexLastRunContext, indexUpdatedRunContext)
 
-                val matchingDocs = getMatchingDocs(monitor, monitorCtx, docExecutionContext, indexName)
+                val matchingDocs = getMatchingDocs(
+                    monitor,
+                    monitorCtx,
+                    docExecutionContext,
+                    indexName,
+                    matchingDocIdsPerIndex?.get(indexName)
+                )
 
                 if (matchingDocs.isNotEmpty()) {
                     val matchedQueriesForDocs = getMatchedQueries(
@@ -226,7 +238,8 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
                         idQueryMap,
                         docsToQueries,
                         queryToDocIds,
-                        dryrun
+                        dryrun,
+                        workflowRunContext?.executionId
                     )
                 }
             }
@@ -298,7 +311,8 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
         idQueryMap: Map<String, DocLevelQuery>,
         docsToQueries: Map<String, List<String>>,
         queryToDocIds: Map<DocLevelQuery, Set<String>>,
-        dryrun: Boolean
+        dryrun: Boolean,
+        workflowExecutionId: String? = null
     ): DocumentLevelTriggerRunResult {
         val triggerCtx = DocumentLevelTriggerExecutionContext(monitor, trigger)
         val triggerResult = monitorCtx.triggerService!!.runDocLevelTrigger(monitor, trigger, queryToDocIds)
@@ -309,7 +323,14 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
         // TODO: Implement throttling for findings
         docsToQueries.forEach {
             val triggeredQueries = it.value.map { queryId -> idQueryMap[queryId]!! }
-            val findingId = createFindings(monitor, monitorCtx, triggeredQueries, it.key, !dryrun && monitor.id != Monitor.NO_ID)
+            val findingId = createFindings(
+                monitor,
+                monitorCtx,
+                triggeredQueries,
+                it.key,
+                !dryrun && monitor.id != Monitor.NO_ID,
+                workflowExecutionId
+            )
             findings.add(findingId)
 
             if (triggerResult.triggeredDocs.contains(it.key)) {
@@ -379,7 +400,8 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
         monitorCtx: MonitorRunnerExecutionContext,
         docLevelQueries: List<DocLevelQuery>,
         matchingDocId: String,
-        shouldCreateFinding: Boolean
+        shouldCreateFinding: Boolean,
+        workflowExecutionId: String? = null,
     ): String {
         // Before the "|" is the doc id and after the "|" is the index
         val docIndex = matchingDocId.split("|")
@@ -392,7 +414,8 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
             monitorName = monitor.name,
             index = docIndex[1],
             docLevelQueries = docLevelQueries,
-            timestamp = Instant.now()
+            timestamp = Instant.now(),
+            executionId = workflowExecutionId
         )
 
         val findingStr = finding.toXContent(XContentBuilder.builder(XContentType.JSON.xContent()), ToXContent.EMPTY_PARAMS).string()
@@ -514,7 +537,8 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
         monitor: Monitor,
         monitorCtx: MonitorRunnerExecutionContext,
         docExecutionCtx: DocumentExecutionContext,
-        index: String
+        index: String,
+        docIds: List<String>? = null
     ): List<Pair<String, BytesReference>> {
         val count: Int = docExecutionCtx.updatedLastRunContext["shards_count"] as Int
         val matchingDocs = mutableListOf<Pair<String, BytesReference>>()
@@ -530,7 +554,8 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
                     shard,
                     prevSeqNo,
                     maxSeqNo,
-                    null
+                    null,
+                    docIds
                 )
 
                 if (hits.hits.isNotEmpty()) {
@@ -549,7 +574,8 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
         shard: String,
         prevSeqNo: Long?,
         maxSeqNo: Long,
-        query: String?
+        query: String?,
+        docIds: List<String>? = null
     ): SearchHits {
         if (prevSeqNo?.equals(maxSeqNo) == true && maxSeqNo != 0L) {
             return SearchHits.empty()
@@ -559,6 +585,10 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
 
         if (query != null) {
             boolQueryBuilder.must(QueryBuilders.queryStringQuery(query))
+        }
+
+        if (!docIds.isNullOrEmpty()) {
+            boolQueryBuilder.filter(QueryBuilders.termsQuery("_id", docIds))
         }
 
         val request: SearchRequest = SearchRequest()

--- a/alerting/src/main/kotlin/org/opensearch/alerting/InputService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/InputService.kt
@@ -16,6 +16,7 @@ import org.opensearch.alerting.util.AggregationQueryRewriter
 import org.opensearch.alerting.util.addUserBackendRolesFilter
 import org.opensearch.alerting.util.executeTransportAction
 import org.opensearch.alerting.util.toMap
+import org.opensearch.alerting.workflow.WorkflowRunContext
 import org.opensearch.client.Client
 import org.opensearch.common.io.stream.BytesStreamOutput
 import org.opensearch.common.io.stream.NamedWriteableAwareStreamInput
@@ -26,6 +27,11 @@ import org.opensearch.commons.alerting.model.ClusterMetricsInput
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.SearchInput
 import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.index.query.BoolQueryBuilder
+import org.opensearch.index.query.MatchQueryBuilder
+import org.opensearch.index.query.QueryBuilder
+import org.opensearch.index.query.QueryBuilders
+import org.opensearch.index.query.TermsQueryBuilder
 import org.opensearch.script.Script
 import org.opensearch.script.ScriptService
 import org.opensearch.script.ScriptType
@@ -47,11 +53,15 @@ class InputService(
         monitor: Monitor,
         periodStart: Instant,
         periodEnd: Instant,
-        prevResult: InputRunResults? = null
+        prevResult: InputRunResults? = null,
+        workflowRunContext: WorkflowRunContext? = null
     ): InputRunResults {
         return try {
             val results = mutableListOf<Map<String, Any>>()
             val aggTriggerAfterKey: MutableMap<String, TriggerAfterKey> = mutableMapOf()
+
+            // If monitor execution is triggered from a workflow
+            val matchingDocIdsPerIndex = workflowRunContext?.matchingDocIdsPerIndex
 
             // TODO: If/when multiple input queries are supported for Bucket-Level Monitor execution, aggTriggerAfterKeys will
             //  need to be updated to account for it
@@ -63,9 +73,17 @@ class InputService(
                             "period_start" to periodStart.toEpochMilli(),
                             "period_end" to periodEnd.toEpochMilli()
                         )
+
                         // Deep copying query before passing it to rewriteQuery since otherwise, the monitor.input is modified directly
                         // which causes a strange bug where the rewritten query persists on the Monitor across executions
                         val rewrittenQuery = AggregationQueryRewriter.rewriteQuery(deepCopyQuery(input.query), prevResult, monitor.triggers)
+
+                        // Rewrite query to consider the doc ids per given index
+                        if (chainedFindingExist(matchingDocIdsPerIndex) && rewrittenQuery.query() != null) {
+                            val updatedSourceQuery = updateInputQueryWithFindingDocIds(rewrittenQuery.query(), matchingDocIdsPerIndex!!)
+                            rewrittenQuery.query(updatedSourceQuery)
+                        }
+
                         val searchSource = scriptService.compile(
                             Script(
                                 ScriptType.INLINE,
@@ -106,6 +124,35 @@ class InputService(
             InputRunResults(emptyList(), e)
         }
     }
+
+    /**
+     * Extends the given query builder with query that filters the given indices with the given doc ids per index
+     * Used whenever we want to select the documents that were found in chained delegate execution of the current workflow run
+     *
+     * @param query Original bucket monitor query
+     * @param matchingDocIdsPerIndex Map of finding doc ids grouped by index
+     */
+    private fun updateInputQueryWithFindingDocIds(
+        query: QueryBuilder,
+        matchingDocIdsPerIndex: Map<String, List<String>>,
+    ): QueryBuilder {
+        val queryBuilder = QueryBuilders.boolQuery().must(query)
+        val shouldQuery = QueryBuilders.boolQuery()
+
+        matchingDocIdsPerIndex.forEach { entry ->
+            shouldQuery
+                .should()
+                .add(
+                    BoolQueryBuilder()
+                        .must(MatchQueryBuilder("_index", entry.key))
+                        .must(TermsQueryBuilder("_id", entry.value))
+                )
+        }
+        return queryBuilder.must(shouldQuery)
+    }
+
+    private fun chainedFindingExist(indexToDocIds: Map<String, List<String>>?) =
+        !indexToDocIds.isNullOrEmpty()
 
     private fun deepCopyQuery(query: SearchSourceBuilder): SearchSourceBuilder {
         val out = BytesStreamOutput()

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt
@@ -186,7 +186,11 @@ object MonitorMetadataService :
         }
     }
 
-    private suspend fun createNewMetadata(monitor: Monitor, createWithRunContext: Boolean, workflowMetadataId: String? = null): MonitorMetadata {
+    private suspend fun createNewMetadata(
+        monitor: Monitor,
+        createWithRunContext: Boolean,
+        workflowMetadataId: String? = null,
+    ): MonitorMetadata {
         val monitorIndex = if (monitor.monitorType == Monitor.MonitorType.DOC_LEVEL_MONITOR) {
             (monitor.inputs[0] as DocLevelMonitorInput).indices[0]
         } else null

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt
@@ -110,18 +110,24 @@ object MonitorMetadataService :
         }
     }
 
+    /**
+     * Document monitors are keeping the context of the last run.
+     * Since one monitor can be part of multiple workflows we need to be sure that execution of the current workflow
+     * doesn't interfere with the other workflows that are dependent on the given monitor
+     */
     suspend fun getOrCreateMetadata(
         monitor: Monitor,
         createWithRunContext: Boolean = true,
-        skipIndex: Boolean = false
+        skipIndex: Boolean = false,
+        workflowMetadataId: String? = null
     ): Pair<MonitorMetadata, Boolean> {
         try {
             val created = true
-            val metadata = getMetadata(monitor)
+            val metadata = getMetadata(monitor, workflowMetadataId)
             return if (metadata != null) {
                 metadata to !created
             } else {
-                val newMetadata = createNewMetadata(monitor, createWithRunContext = createWithRunContext)
+                val newMetadata = createNewMetadata(monitor, createWithRunContext = createWithRunContext, workflowMetadataId)
                 if (skipIndex) {
                     newMetadata to created
                 } else {
@@ -133,9 +139,9 @@ object MonitorMetadataService :
         }
     }
 
-    suspend fun getMetadata(monitor: Monitor): MonitorMetadata? {
+    suspend fun getMetadata(monitor: Monitor, workflowMetadataId: String? = null): MonitorMetadata? {
         try {
-            val metadataId = MonitorMetadata.getId(monitor)
+            val metadataId = MonitorMetadata.getId(monitor, workflowMetadataId)
             val getRequest = GetRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, metadataId).routing(monitor.id)
 
             val getResponse: GetResponse = client.suspendUntil { get(getRequest, it) }
@@ -168,19 +174,19 @@ object MonitorMetadataService :
             val runContext = if (monitor.monitorType == Monitor.MonitorType.DOC_LEVEL_MONITOR) {
                 createFullRunContext(monitorIndex, metadata.lastRunContext as MutableMap<String, MutableMap<String, Any>>)
             } else null
-            if (runContext != null) {
-                return metadata.copy(
+            return if (runContext != null) {
+                metadata.copy(
                     lastRunContext = runContext
                 )
             } else {
-                return metadata
+                metadata
             }
         } catch (e: Exception) {
             throw AlertingException.wrap(e)
         }
     }
 
-    private suspend fun createNewMetadata(monitor: Monitor, createWithRunContext: Boolean): MonitorMetadata {
+    private suspend fun createNewMetadata(monitor: Monitor, createWithRunContext: Boolean, workflowMetadataId: String? = null): MonitorMetadata {
         val monitorIndex = if (monitor.monitorType == Monitor.MonitorType.DOC_LEVEL_MONITOR) {
             (monitor.inputs[0] as DocLevelMonitorInput).indices[0]
         } else null
@@ -189,7 +195,7 @@ object MonitorMetadataService :
                 createFullRunContext(monitorIndex)
             } else emptyMap()
         return MonitorMetadata(
-            id = "${monitor.id}-metadata",
+            id = MonitorMetadata.getId(monitor, workflowMetadataId),
             seqNo = SequenceNumbers.UNASSIGNED_SEQ_NO,
             primaryTerm = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
             monitorId = monitor.id,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
@@ -24,6 +24,7 @@ import org.opensearch.alerting.util.destinationmigration.publishLegacyNotificati
 import org.opensearch.alerting.util.destinationmigration.sendNotification
 import org.opensearch.alerting.util.isAllowed
 import org.opensearch.alerting.util.isTestAction
+import org.opensearch.alerting.workflow.WorkflowRunContext
 import org.opensearch.client.node.NodeClient
 import org.opensearch.common.Strings
 import org.opensearch.commons.alerting.model.Monitor
@@ -39,7 +40,8 @@ abstract class MonitorRunner {
         monitorCtx: MonitorRunnerExecutionContext,
         periodStart: Instant,
         periodEnd: Instant,
-        dryRun: Boolean
+        dryRun: Boolean,
+        workflowRunContext: WorkflowRunContext? = null
     ): MonitorRunResult<*>
 
     suspend fun runAction(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunnerExecutionContext.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunnerExecutionContext.kt
@@ -35,6 +35,7 @@ data class MonitorRunnerExecutionContext(
     var triggerService: TriggerService? = null,
     var alertService: AlertService? = null,
     var docLevelMonitorQueries: DocLevelMonitorQueries? = null,
+    var workflowService: WorkflowService? = null,
 
     @Volatile var retryPolicy: BackoffPolicy? = null,
     @Volatile var moveAlertsRetryPolicy: BackoffPolicy? = null,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/QueryLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/QueryLevelMonitorRunner.kt
@@ -12,6 +12,7 @@ import org.opensearch.alerting.opensearchapi.InjectorContextElement
 import org.opensearch.alerting.opensearchapi.withClosableContext
 import org.opensearch.alerting.script.QueryLevelTriggerExecutionContext
 import org.opensearch.alerting.util.isADMonitor
+import org.opensearch.alerting.workflow.WorkflowRunContext
 import org.opensearch.commons.alerting.model.Alert
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.QueryLevelTrigger
@@ -25,7 +26,8 @@ object QueryLevelMonitorRunner : MonitorRunner() {
         monitorCtx: MonitorRunnerExecutionContext,
         periodStart: Instant,
         periodEnd: Instant,
-        dryrun: Boolean
+        dryrun: Boolean,
+        workflowRunContext: WorkflowRunContext?
     ): MonitorRunResult<QueryLevelTriggerRunResult> {
         val roles = MonitorRunnerService.getRolesForMonitor(monitor)
         logger.debug("Running monitor: ${monitor.name} with roles: $roles Thread: ${Thread.currentThread().name}")
@@ -48,7 +50,7 @@ object QueryLevelMonitorRunner : MonitorRunner() {
         if (!isADMonitor(monitor)) {
             withClosableContext(InjectorContextElement(monitor.id, monitorCtx.settings!!, monitorCtx.threadPool!!.threadContext, roles)) {
                 monitorResult = monitorResult.copy(
-                    inputResults = monitorCtx.inputService!!.collectInputResults(monitor, periodStart, periodEnd)
+                    inputResults = monitorCtx.inputService!!.collectInputResults(monitor, periodStart, periodEnd, null, workflowRunContext)
                 )
             }
         } else {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/WorkflowMetadataService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/WorkflowMetadataService.kt
@@ -98,7 +98,10 @@ object WorkflowMetadataService :
         } catch (e: Exception) {
             // If the update is set to false and id is set conflict exception will be thrown
             if (e is OpenSearchException && e.status() == RestStatus.CONFLICT && !updating) {
-                log.debug("Metadata with ${metadata.id} for workflow ${metadata.workflowId} already exist. Instead of creating new, updating existing metadata will be performed")
+                log.debug(
+                    "Metadata with ${metadata.id} for workflow ${metadata.workflowId} already exist." +
+                        " Instead of creating new, updating existing metadata will be performed"
+                )
                 return upsertWorkflowMetadata(metadata, true)
             }
             log.error("Error saving metadata", e)
@@ -157,6 +160,8 @@ object WorkflowMetadataService :
     }
 
     private fun createNewWorkflowMetadata(workflow: Workflow, executionId: String, isTempWorkflow: Boolean): WorkflowMetadata {
+        // In the case of temp workflow (ie. workflow is in dry-run) use timestampWithUUID-metadata format
+        // In the case of regular workflow execution, use the workflowId-metadata format
         val id = if (isTempWorkflow) "${LocalDateTime.now(ZoneOffset.UTC)}${UUID.randomUUID()}" else workflow.id
         return WorkflowMetadata(
             id = WorkflowMetadata.getId(id),

--- a/alerting/src/main/kotlin/org/opensearch/alerting/WorkflowMetadataService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/WorkflowMetadataService.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting
+
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import org.apache.logging.log4j.LogManager
+import org.opensearch.OpenSearchException
+import org.opensearch.action.DocWriteRequest
+import org.opensearch.action.DocWriteResponse
+import org.opensearch.action.get.GetRequest
+import org.opensearch.action.get.GetResponse
+import org.opensearch.action.index.IndexRequest
+import org.opensearch.action.index.IndexResponse
+import org.opensearch.action.support.WriteRequest
+import org.opensearch.alerting.model.WorkflowMetadata
+import org.opensearch.alerting.opensearchapi.suspendUntil
+import org.opensearch.alerting.settings.AlertingSettings
+import org.opensearch.alerting.util.AlertingException
+import org.opensearch.client.Client
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.unit.TimeValue
+import org.opensearch.common.xcontent.LoggingDeprecationHandler
+import org.opensearch.common.xcontent.XContentFactory
+import org.opensearch.common.xcontent.XContentHelper
+import org.opensearch.common.xcontent.XContentParserUtils
+import org.opensearch.common.xcontent.XContentType
+import org.opensearch.commons.alerting.model.CompositeInput
+import org.opensearch.commons.alerting.model.ScheduledJob
+import org.opensearch.commons.alerting.model.Workflow
+import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.core.xcontent.XContentParser
+import org.opensearch.rest.RestStatus
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+object WorkflowMetadataService :
+    CoroutineScope by CoroutineScope(SupervisorJob() + Dispatchers.Default + CoroutineName("WorkflowMetadataService")) {
+    private val log = LogManager.getLogger(this::class.java)
+
+    private lateinit var client: Client
+    private lateinit var xContentRegistry: NamedXContentRegistry
+    private lateinit var clusterService: ClusterService
+    private lateinit var settings: Settings
+
+    @Volatile private lateinit var indexTimeout: TimeValue
+
+    fun initialize(
+        client: Client,
+        clusterService: ClusterService,
+        xContentRegistry: NamedXContentRegistry,
+        settings: Settings
+    ) {
+        this.clusterService = clusterService
+        this.client = client
+        this.xContentRegistry = xContentRegistry
+        this.settings = settings
+        this.indexTimeout = AlertingSettings.INDEX_TIMEOUT.get(settings)
+        this.clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.INDEX_TIMEOUT) { indexTimeout = it }
+    }
+
+    @Suppress("ComplexMethod", "ReturnCount")
+    suspend fun upsertWorkflowMetadata(metadata: WorkflowMetadata, updating: Boolean): WorkflowMetadata {
+        try {
+            val indexRequest = IndexRequest(ScheduledJob.SCHEDULED_JOBS_INDEX)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                .source(metadata.toXContent(XContentFactory.jsonBuilder(), ToXContent.MapParams(mapOf("with_type" to "true"))))
+                .id(metadata.id)
+                .routing(metadata.workflowId)
+                .timeout(indexTimeout)
+
+            if (updating) {
+                indexRequest.id(metadata.id)
+            } else {
+                indexRequest.opType(DocWriteRequest.OpType.CREATE)
+            }
+            val response: IndexResponse = client.suspendUntil { index(indexRequest, it) }
+            when (response.result) {
+                DocWriteResponse.Result.DELETED, DocWriteResponse.Result.NOOP, DocWriteResponse.Result.NOT_FOUND, null -> {
+                    val failureReason = "The upsert metadata call failed with a ${response.result?.lowercase} result"
+                    log.error(failureReason)
+                    throw AlertingException(failureReason, RestStatus.INTERNAL_SERVER_ERROR, IllegalStateException(failureReason))
+                }
+                DocWriteResponse.Result.CREATED, DocWriteResponse.Result.UPDATED -> {
+                    log.debug("Successfully upserted WorkflowMetadata:${metadata.id} ")
+                }
+            }
+            return metadata
+        } catch (e: Exception) {
+            // If the update is set to false and id is set conflict exception will be thrown
+            if (e is OpenSearchException && e.status() == RestStatus.CONFLICT && !updating) {
+                log.debug("Metadata with ${metadata.id} for workflow ${metadata.workflowId} already exist. Instead of creating new, updating existing metadata will be performed")
+                return upsertWorkflowMetadata(metadata, true)
+            }
+            log.error("Error saving metadata", e)
+            throw AlertingException.wrap(e)
+        }
+    }
+
+    suspend fun getOrCreateWorkflowMetadata(
+        workflow: Workflow,
+        skipIndex: Boolean = false,
+        executionId: String
+    ): Pair<WorkflowMetadata, Boolean> {
+        try {
+            val created = true
+            val metadata = getWorkflowMetadata(workflow)
+            return if (metadata != null) {
+                metadata to !created
+            } else {
+                val newMetadata = createNewWorkflowMetadata(workflow, executionId, skipIndex)
+                if (skipIndex) {
+                    newMetadata to created
+                } else {
+                    upsertWorkflowMetadata(newMetadata, updating = false) to created
+                }
+            }
+        } catch (e: Exception) {
+            throw AlertingException.wrap(e)
+        }
+    }
+
+    private suspend fun getWorkflowMetadata(workflow: Workflow): WorkflowMetadata? {
+        try {
+            val metadataId = WorkflowMetadata.getId(workflow.id)
+            val getRequest = GetRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, metadataId).routing(workflow.id)
+
+            val getResponse: GetResponse = client.suspendUntil { get(getRequest, it) }
+            return if (getResponse.isExists) {
+                val xcp = XContentHelper.createParser(
+                    xContentRegistry,
+                    LoggingDeprecationHandler.INSTANCE,
+                    getResponse.sourceAsBytesRef,
+                    XContentType.JSON
+                )
+                XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp)
+                WorkflowMetadata.parse(xcp)
+            } else {
+                null
+            }
+        } catch (e: Exception) {
+            if (e.message?.contains("no such index") == true) {
+                return null
+            } else {
+                throw AlertingException.wrap(e)
+            }
+        }
+    }
+
+    private fun createNewWorkflowMetadata(workflow: Workflow, executionId: String, isTempWorkflow: Boolean): WorkflowMetadata {
+        val id = if (isTempWorkflow) "${LocalDateTime.now(ZoneOffset.UTC)}${UUID.randomUUID()}" else workflow.id
+        return WorkflowMetadata(
+            id = WorkflowMetadata.getId(id),
+            workflowId = workflow.id,
+            monitorIds = (workflow.inputs[0] as CompositeInput).getMonitorIds(),
+            latestRunTime = Instant.now(),
+            latestExecutionId = executionId
+        )
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/WorkflowService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/WorkflowService.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting
+
+import org.apache.logging.log4j.LogManager
+import org.opensearch.OpenSearchException
+import org.opensearch.action.search.SearchRequest
+import org.opensearch.action.search.SearchResponse
+import org.opensearch.alerting.opensearchapi.suspendUntil
+import org.opensearch.alerting.util.AlertingException
+import org.opensearch.client.Client
+import org.opensearch.common.xcontent.LoggingDeprecationHandler
+import org.opensearch.common.xcontent.XContentFactory
+import org.opensearch.common.xcontent.XContentParserUtils
+import org.opensearch.common.xcontent.XContentType
+import org.opensearch.commons.alerting.model.Finding
+import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.ScheduledJob
+import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.core.xcontent.XContentParser
+import org.opensearch.index.query.QueryBuilders
+import org.opensearch.search.builder.SearchSourceBuilder
+
+private val log = LogManager.getLogger(WorkflowService::class.java)
+
+/**
+ * Contains util methods used in workflow execution
+ */
+class WorkflowService(
+    val client: Client,
+    val xContentRegistry: NamedXContentRegistry,
+) {
+    /**
+     * Returns finding doc ids per index for the given workflow execution
+     * Used for pre-filtering the dataset in the case of creating a workflow with chained findings
+     *
+     * @param chainedMonitor Monitor that is previously executed
+     * @param workflowExecutionId Execution id of the current workflow
+     */
+    suspend fun getFindingDocIdsByExecutionId(chainedMonitor: Monitor, workflowExecutionId: String): Map<String, List<String>> {
+        try {
+            // Search findings index per monitor and workflow execution id
+            val bqb = QueryBuilders.boolQuery().filter(QueryBuilders.termQuery(Finding.MONITOR_ID_FIELD, chainedMonitor.id))
+                .filter(QueryBuilders.termQuery(Finding.EXECUTION_ID_FIELD, workflowExecutionId))
+            val searchRequest = SearchRequest()
+                .source(
+                    SearchSourceBuilder()
+                        .query(bqb)
+                        .version(true)
+                        .seqNoAndPrimaryTerm(true)
+                )
+                .indices(chainedMonitor.dataSources.findingsIndex)
+            val searchResponse: SearchResponse = client.suspendUntil { client.search(searchRequest, it) }
+
+            // Get the findings docs
+            val findings = mutableListOf<Finding>()
+            for (hit in searchResponse.hits) {
+                val xcp = XContentFactory.xContent(XContentType.JSON)
+                    .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, hit.sourceAsString)
+                XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp)
+                val finding = Finding.parse(xcp)
+                findings.add(finding)
+            }
+            // Based on the findings get the document ids
+            val indexToRelatedDocIdsMap = mutableMapOf<String, MutableList<String>>()
+            for (finding in findings) {
+                indexToRelatedDocIdsMap.getOrPut(finding.index) { mutableListOf() }.addAll(finding.relatedDocIds)
+            }
+            return indexToRelatedDocIdsMap
+        } catch (t: Exception) {
+            log.error("Error getting finding doc ids: ${t.message}", t)
+            throw AlertingException.wrap(t)
+        }
+    }
+
+    /**
+     * Returns the list of monitors for the given ids
+     * Used in workflow execution in order to figure out the monitor type
+     *
+     * @param monitors List of monitor ids
+     * @param size Expected number of monitors
+     */
+    suspend fun getMonitorsById(monitors: List<String>, size: Int): List<Monitor> {
+        try {
+            val bqb = QueryBuilders.boolQuery().filter(QueryBuilders.termsQuery("_id", monitors))
+
+            val searchRequest = SearchRequest()
+                .source(
+                    SearchSourceBuilder()
+                        .query(bqb)
+                        .version(true)
+                        .seqNoAndPrimaryTerm(true)
+                        .size(size)
+                )
+                .indices(ScheduledJob.SCHEDULED_JOBS_INDEX)
+
+            val searchResponse: SearchResponse = client.suspendUntil { client.search(searchRequest, it) }
+            return parseMonitors(searchResponse)
+        } catch (e: Exception) {
+            log.error("Error getting monitors: ${e.message}", e)
+            throw AlertingException.wrap(e)
+        }
+    }
+
+    private fun parseMonitors(response: SearchResponse): List<Monitor> {
+        if (response.isTimedOut) {
+            log.error("Request for getting monitors timeout")
+            throw OpenSearchException("Cannot determine that the ${ScheduledJob.SCHEDULED_JOBS_INDEX} index is healthy")
+        }
+        val monitors = mutableListOf<Monitor>()
+        try {
+            for (hit in response.hits) {
+                XContentType.JSON.xContent().createParser(
+                    xContentRegistry,
+                    LoggingDeprecationHandler.INSTANCE, hit.sourceAsString
+                ).use { hitsParser ->
+                    val monitor = ScheduledJob.parse(hitsParser, hit.id, hit.version) as Monitor
+                    monitors.add(monitor)
+                }
+            }
+        } catch (e: Exception) {
+            log.error("Error parsing monitors: ${e.message}", e)
+            throw AlertingException.wrap(e)
+        }
+        return monitors
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/action/ExecuteWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/action/ExecuteWorkflowAction.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.action
+
+import org.opensearch.action.ActionType
+
+class ExecuteWorkflowAction private constructor() : ActionType<ExecuteWorkflowResponse>(NAME, ::ExecuteWorkflowResponse) {
+    companion object {
+        val INSTANCE = ExecuteWorkflowAction()
+        const val NAME = "cluster:admin/opensearch/alerting/workflow/execute"
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/action/ExecuteWorkflowRequest.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/action/ExecuteWorkflowRequest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.action
+
+import org.opensearch.action.ActionRequest
+import org.opensearch.action.ActionRequestValidationException
+import org.opensearch.action.ValidateActions
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.common.unit.TimeValue
+import org.opensearch.commons.alerting.model.Workflow
+import java.io.IOException
+
+/**
+ * A class containing workflow details.
+ */
+class ExecuteWorkflowRequest : ActionRequest {
+    val dryrun: Boolean
+    val requestEnd: TimeValue
+    val workflowId: String?
+    val workflow: Workflow?
+
+    constructor(
+        dryrun: Boolean,
+        requestEnd: TimeValue,
+        workflowId: String?,
+        workflow: Workflow?,
+    ) : super() {
+        this.dryrun = dryrun
+        this.requestEnd = requestEnd
+        this.workflowId = workflowId
+        this.workflow = workflow
+    }
+
+    @Throws(IOException::class)
+    constructor(sin: StreamInput) : this(
+        sin.readBoolean(),
+        sin.readTimeValue(),
+        sin.readOptionalString(),
+        if (sin.readBoolean()) {
+            Workflow.readFrom(sin)
+        } else null
+    )
+
+    override fun validate(): ActionRequestValidationException? {
+        var validationException: ActionRequestValidationException? = null
+        if (workflowId == null && workflow == null) {
+            validationException = ValidateActions.addValidationError(
+                "Both workflow and workflow id are missing", validationException
+            )
+        }
+        return validationException
+    }
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        out.writeBoolean(dryrun)
+        out.writeTimeValue(requestEnd)
+        out.writeOptionalString(workflowId)
+        if (workflow != null) {
+            out.writeBoolean(true)
+            workflow.writeTo(out)
+        } else {
+            out.writeBoolean(false)
+        }
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/action/ExecuteWorkflowResponse.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/action/ExecuteWorkflowResponse.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.action
+
+import org.opensearch.action.ActionResponse
+import org.opensearch.alerting.model.WorkflowRunResult
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.core.xcontent.ToXContentObject
+import org.opensearch.core.xcontent.XContentBuilder
+import java.io.IOException
+
+class ExecuteWorkflowResponse : ActionResponse, ToXContentObject {
+    val workflowRunResult: WorkflowRunResult
+    constructor(
+        workflowRunResult: WorkflowRunResult
+    ) : super() {
+        this.workflowRunResult = workflowRunResult
+    }
+
+    @Throws(IOException::class)
+    constructor(sin: StreamInput) : this(
+        WorkflowRunResult(sin)
+    )
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        workflowRunResult.writeTo(out)
+    }
+
+    @Throws(IOException::class)
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        return workflowRunResult.toXContent(builder, params)
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
@@ -137,18 +137,23 @@ class AlertIndices(
     }
 
     @Volatile private var alertHistoryEnabled = AlertingSettings.ALERT_HISTORY_ENABLED.get(settings)
+
     @Volatile private var findingHistoryEnabled = AlertingSettings.FINDING_HISTORY_ENABLED.get(settings)
 
     @Volatile private var alertHistoryMaxDocs = AlertingSettings.ALERT_HISTORY_MAX_DOCS.get(settings)
+
     @Volatile private var findingHistoryMaxDocs = AlertingSettings.FINDING_HISTORY_MAX_DOCS.get(settings)
 
     @Volatile private var alertHistoryMaxAge = AlertingSettings.ALERT_HISTORY_INDEX_MAX_AGE.get(settings)
+
     @Volatile private var findingHistoryMaxAge = AlertingSettings.FINDING_HISTORY_INDEX_MAX_AGE.get(settings)
 
     @Volatile private var alertHistoryRolloverPeriod = AlertingSettings.ALERT_HISTORY_ROLLOVER_PERIOD.get(settings)
+
     @Volatile private var findingHistoryRolloverPeriod = AlertingSettings.FINDING_HISTORY_ROLLOVER_PERIOD.get(settings)
 
     @Volatile private var alertHistoryRetentionPeriod = AlertingSettings.ALERT_HISTORY_RETENTION_PERIOD.get(settings)
+
     @Volatile private var findingHistoryRetentionPeriod = AlertingSettings.FINDING_HISTORY_RETENTION_PERIOD.get(settings)
 
     @Volatile private var requestTimeout = AlertingSettings.REQUEST_TIMEOUT.get(settings)
@@ -449,17 +454,25 @@ class AlertIndices(
 
     private fun rolloverAlertHistoryIndex() {
         rolloverIndex(
-            alertHistoryIndexInitialized, ALERT_HISTORY_WRITE_INDEX,
-            ALERT_HISTORY_INDEX_PATTERN, alertMapping(),
-            alertHistoryMaxDocs, alertHistoryMaxAge, ALERT_HISTORY_WRITE_INDEX
+            alertHistoryIndexInitialized,
+            ALERT_HISTORY_WRITE_INDEX,
+            ALERT_HISTORY_INDEX_PATTERN,
+            alertMapping(),
+            alertHistoryMaxDocs,
+            alertHistoryMaxAge,
+            ALERT_HISTORY_WRITE_INDEX
         )
     }
 
     private fun rolloverFindingHistoryIndex() {
         rolloverIndex(
-            findingHistoryIndexInitialized, FINDING_HISTORY_WRITE_INDEX,
-            FINDING_HISTORY_INDEX_PATTERN, findingMapping(),
-            findingHistoryMaxDocs, findingHistoryMaxAge, FINDING_HISTORY_WRITE_INDEX
+            findingHistoryIndexInitialized,
+            FINDING_HISTORY_WRITE_INDEX,
+            FINDING_HISTORY_INDEX_PATTERN,
+            findingMapping(),
+            findingHistoryMaxDocs,
+            findingHistoryMaxAge,
+            FINDING_HISTORY_WRITE_INDEX
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/MonitorMetadata.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/MonitorMetadata.kt
@@ -120,8 +120,9 @@ data class MonitorMetadata(
             return MonitorMetadata(sin)
         }
 
-        fun getId(monitor: Monitor): String {
-            return monitor.id + "-metadata"
+        fun getId(monitor: Monitor, workflowId: String? = null): String {
+            return if (workflowId.isNullOrEmpty()) "${monitor.id}-metadata"
+            else "${monitor.id}-$workflowId-metadata"
         }
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/MonitorMetadata.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/MonitorMetadata.kt
@@ -120,9 +120,17 @@ data class MonitorMetadata(
             return MonitorMetadata(sin)
         }
 
-        fun getId(monitor: Monitor, workflowId: String? = null): String {
-            return if (workflowId.isNullOrEmpty()) "${monitor.id}-metadata"
-            else "${monitor.id}-$workflowId-metadata"
+        /** workflowMetadataId is used as key for monitor metadata in the case when the workflow execution happens
+         so the monitor lastRunContext (in the case of doc level monitor) is not interfering with the monitor execution
+         WorkflowMetadataId will be either workflowId-metadata (when executing the workflow as it is scheduled)
+         or timestampWithUUID-metadata (when a workflow is executed in a dry-run mode)
+         In the case of temp workflow, doc level monitors must have lastRunContext created from scratch
+         That's why we are using workflowMetadataId - in order to ensure that the doc level monitor metadata is created from scratch
+         **/
+        fun getId(monitor: Monitor, workflowMetadataId: String? = null): String {
+            return if (workflowMetadataId.isNullOrEmpty()) "${monitor.id}-metadata"
+            // WorkflowMetadataId already contains -metadata suffix
+            else "$workflowMetadataId-${monitor.id}-metadata"
         }
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/WorkflowMetadata.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/WorkflowMetadata.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.model
+
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.common.io.stream.Writeable
+import org.opensearch.common.xcontent.XContentParserUtils
+import org.opensearch.commons.alerting.util.instant
+import org.opensearch.commons.alerting.util.optionalTimeField
+import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.core.xcontent.XContentBuilder
+import org.opensearch.core.xcontent.XContentParser
+import java.io.IOException
+import java.time.Instant
+
+data class WorkflowMetadata(
+    val id: String,
+    val workflowId: String,
+    val monitorIds: List<String>,
+    val latestRunTime: Instant,
+    val latestExecutionId: String
+) : Writeable, ToXContent {
+
+    @Throws(IOException::class)
+    constructor(sin: StreamInput) : this(
+        id = sin.readString(),
+        workflowId = sin.readString(),
+        monitorIds = sin.readStringList(),
+        latestRunTime = sin.readInstant(),
+        latestExecutionId = sin.readString()
+    )
+
+    override fun writeTo(out: StreamOutput) {
+        out.writeString(id)
+        out.writeString(workflowId)
+        out.writeStringCollection(monitorIds)
+        out.writeInstant(latestRunTime)
+        out.writeString(latestExecutionId)
+    }
+
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        builder.startObject()
+        if (params.paramAsBoolean("with_type", false)) builder.startObject(METADATA)
+        builder.field(WORKFLOW_ID_FIELD, workflowId)
+            .field(MONITOR_IDS_FIELD, monitorIds)
+            .optionalTimeField(LATEST_RUN_TIME, latestRunTime)
+            .field(LATEST_EXECUTION_ID, latestExecutionId)
+        if (params.paramAsBoolean("with_type", false)) builder.endObject()
+        return builder.endObject()
+    }
+
+    companion object {
+        const val METADATA = "workflow_metadata"
+        const val WORKFLOW_ID_FIELD = "workflow_id"
+        const val MONITOR_IDS_FIELD = "monitor_ids"
+        const val LATEST_RUN_TIME = "latest_run_time"
+        const val LATEST_EXECUTION_ID = "latest_execution_id"
+
+        @JvmStatic @JvmOverloads
+        @Throws(IOException::class)
+        fun parse(xcp: XContentParser): WorkflowMetadata {
+            lateinit var workflowId: String
+            var monitorIds = mutableListOf<String>()
+            lateinit var latestRunTime: Instant
+            lateinit var latestExecutionId: String
+
+            XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
+            while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
+                val fieldName = xcp.currentName()
+                xcp.nextToken()
+
+                when (fieldName) {
+                    WORKFLOW_ID_FIELD -> workflowId = xcp.text()
+                    MONITOR_IDS_FIELD -> {
+                        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, xcp.currentToken(), xcp)
+                        while (xcp.nextToken() != XContentParser.Token.END_ARRAY) {
+                            monitorIds.add(xcp.text())
+                        }
+                    }
+                    LATEST_RUN_TIME -> latestRunTime = xcp.instant()!!
+                    LATEST_EXECUTION_ID -> latestExecutionId = xcp.text()
+                }
+            }
+            return WorkflowMetadata(
+                id = "$workflowId-metadata",
+                workflowId = workflowId,
+                monitorIds = monitorIds,
+                latestRunTime = latestRunTime,
+                latestExecutionId = latestExecutionId
+            )
+        }
+
+        @JvmStatic
+        @Throws(IOException::class)
+        fun readFrom(sin: StreamInput): WorkflowMetadata {
+            return WorkflowMetadata(sin)
+        }
+
+        fun getId(workflowId: String? = null) = "$workflowId-metadata"
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/WorkflowRunResult.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/WorkflowRunResult.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.model
+
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.common.io.stream.Writeable
+import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.core.xcontent.XContentBuilder
+import java.io.IOException
+import java.lang.Exception
+import java.time.Instant
+
+data class WorkflowRunResult(
+    val workflowRunResult: List<MonitorRunResult<*>> = mutableListOf(),
+    val executionStartTime: Instant,
+    val executionEndTime: Instant? = null,
+    val executionId: String,
+    val error: Exception? = null
+) : Writeable, ToXContent {
+
+    @Throws(IOException::class)
+    @Suppress("UNCHECKED_CAST")
+    constructor(sin: StreamInput) : this(
+        sin.readList<MonitorRunResult<*>> { s: StreamInput -> MonitorRunResult.readFrom(s) },
+        sin.readInstant(),
+        sin.readInstant(),
+        sin.readString(),
+        sin.readException()
+    )
+
+    override fun writeTo(out: StreamOutput) {
+        out.writeList(workflowRunResult)
+        out.writeInstant(executionStartTime)
+        out.writeInstant(executionEndTime)
+        out.writeString(executionId)
+        out.writeException(error)
+    }
+
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        builder.startObject().startArray("workflow_run_result")
+        for (monitorResult in workflowRunResult) {
+            monitorResult.toXContent(builder, ToXContent.EMPTY_PARAMS)
+        }
+        builder.endArray().field("execution_start_time", executionStartTime)
+            .field("execution_end_time", executionEndTime)
+            .field("error", error?.message).endObject()
+        return builder
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestExecuteWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestExecuteWorkflowAction.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.resthandler
+
+import org.apache.logging.log4j.LogManager
+import org.opensearch.alerting.AlertingPlugin
+import org.opensearch.alerting.action.ExecuteWorkflowAction
+import org.opensearch.alerting.action.ExecuteWorkflowRequest
+import org.opensearch.client.node.NodeClient
+import org.opensearch.common.unit.TimeValue
+import org.opensearch.common.xcontent.XContentParserUtils
+import org.opensearch.commons.alerting.model.Workflow
+import org.opensearch.core.xcontent.XContentParser
+import org.opensearch.rest.BaseRestHandler
+import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestRequest
+import org.opensearch.rest.action.RestToXContentListener
+import java.time.Instant
+
+private val log = LogManager.getLogger(RestExecuteWorkflowAction::class.java)
+
+class RestExecuteWorkflowAction : BaseRestHandler() {
+
+    override fun getName(): String = "execute_workflow_action"
+
+    override fun routes(): List<RestHandler.Route> {
+        return listOf(
+            RestHandler.Route(RestRequest.Method.POST, "${AlertingPlugin.WORKFLOW_BASE_URI}/{workflowID}/_execute")
+        )
+    }
+
+    override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
+        log.debug("${request.method()} ${AlertingPlugin.WORKFLOW_BASE_URI}/_execute")
+
+        return RestChannelConsumer { channel ->
+            val dryrun = request.paramAsBoolean("dryrun", false)
+            val requestEnd = request.paramAsTime("period_end", TimeValue(Instant.now().toEpochMilli()))
+
+            if (request.hasParam("workflowID")) {
+                val workflowId = request.param("workflowID")
+                val execWorkflowRequest = ExecuteWorkflowRequest(dryrun, requestEnd, workflowId, null)
+                client.execute(ExecuteWorkflowAction.INSTANCE, execWorkflowRequest, RestToXContentListener(channel))
+            } else {
+                val xcp = request.contentParser()
+                XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp)
+                val workflow = Workflow.parse(xcp, Workflow.NO_ID, Workflow.NO_VERSION)
+                val execWorkflowRequest = ExecuteWorkflowRequest(dryrun, requestEnd, null, workflow)
+                client.execute(ExecuteWorkflowAction.INSTANCE, execWorkflowRequest, RestToXContentListener(channel))
+            }
+        }
+    }
+
+    override fun responseParams(): Set<String> {
+        return setOf("dryrun", "period_end", "workflowID")
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/DeleteMonitorService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/DeleteMonitorService.kt
@@ -1,0 +1,186 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.service
+
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import org.apache.logging.log4j.LogManager
+import org.apache.lucene.search.join.ScoreMode
+import org.opensearch.action.ActionListener
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest
+import org.opensearch.action.admin.indices.exists.indices.IndicesExistsRequest
+import org.opensearch.action.admin.indices.exists.indices.IndicesExistsResponse
+import org.opensearch.action.delete.DeleteRequest
+import org.opensearch.action.delete.DeleteResponse
+import org.opensearch.action.search.SearchRequest
+import org.opensearch.action.search.SearchResponse
+import org.opensearch.action.support.IndicesOptions
+import org.opensearch.action.support.WriteRequest.RefreshPolicy
+import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.alerting.MonitorMetadataService
+import org.opensearch.alerting.opensearchapi.suspendUntil
+import org.opensearch.alerting.transport.TransportDeleteWorkflowAction.Companion.WORKFLOW_DELEGATE_PATH
+import org.opensearch.alerting.transport.TransportDeleteWorkflowAction.Companion.WORKFLOW_MONITOR_PATH
+import org.opensearch.alerting.util.AlertingException
+import org.opensearch.client.Client
+import org.opensearch.commons.alerting.action.DeleteMonitorResponse
+import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.ScheduledJob
+import org.opensearch.index.query.QueryBuilders
+import org.opensearch.index.reindex.BulkByScrollResponse
+import org.opensearch.index.reindex.DeleteByQueryAction
+import org.opensearch.index.reindex.DeleteByQueryRequestBuilder
+import org.opensearch.search.builder.SearchSourceBuilder
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * Component used when deleting the monitors
+ */
+object DeleteMonitorService :
+    CoroutineScope by CoroutineScope(SupervisorJob() + Dispatchers.Default + CoroutineName("WorkflowMetadataService")) {
+    private val log = LogManager.getLogger(this.javaClass)
+
+    private lateinit var client: Client
+
+    fun initialize(
+        client: Client,
+    ) {
+        DeleteMonitorService.client = client
+    }
+
+    /**
+     * Deletes the monitor, docLevelQueries and monitor metadata
+     * @param monitor monitor to be deleted
+     * @param refreshPolicy
+     */
+    suspend fun deleteMonitor(monitor: Monitor, refreshPolicy: RefreshPolicy): DeleteMonitorResponse {
+        val deleteResponse = deleteMonitor(monitor.id, refreshPolicy)
+        deleteDocLevelMonitorQueriesAndIndices(monitor)
+        deleteMetadata(monitor)
+        return DeleteMonitorResponse(deleteResponse.id, deleteResponse.version)
+    }
+
+    private suspend fun deleteMonitor(monitorId: String, refreshPolicy: RefreshPolicy): DeleteResponse {
+        val deleteMonitorRequest = DeleteRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, monitorId)
+            .setRefreshPolicy(refreshPolicy)
+        return client.suspendUntil { delete(deleteMonitorRequest, it) }
+    }
+
+    private suspend fun deleteMetadata(monitor: Monitor) {
+        val deleteRequest = DeleteRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, "${monitor.id}-metadata")
+            .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+        try {
+            val deleteResponse: DeleteResponse = client.suspendUntil { delete(deleteRequest, it) }
+            log.debug("Monitor metadata: ${deleteResponse.id} deletion result: ${deleteResponse.result}")
+        } catch (e: Exception) {
+            // we only log the error and don't fail the request because if monitor document has been deleted,
+            // we cannot retry based on this failure
+            log.error("Failed to delete monitor metadata ${deleteRequest.id()}.", e)
+        }
+    }
+
+    private suspend fun deleteDocLevelMonitorQueriesAndIndices(monitor: Monitor) {
+        try {
+            val metadata = MonitorMetadataService.getMetadata(monitor)
+            metadata?.sourceToQueryIndexMapping?.forEach { (_, queryIndex) ->
+
+                val indicesExistsResponse: IndicesExistsResponse =
+                    client.suspendUntil {
+                        client.admin().indices().exists(IndicesExistsRequest(queryIndex), it)
+                    }
+                if (indicesExistsResponse.isExists == false) {
+                    return
+                }
+                // Check if there's any queries from other monitors in this queryIndex,
+                // to avoid unnecessary doc deletion, if we could just delete index completely
+                val searchResponse: SearchResponse = client.suspendUntil {
+                    search(
+                        SearchRequest(queryIndex).source(
+                            SearchSourceBuilder()
+                                .size(0)
+                                .query(
+                                    QueryBuilders.boolQuery().mustNot(
+                                        QueryBuilders.matchQuery("monitor_id", monitor.id)
+                                    )
+                                )
+                        ).indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_HIDDEN),
+                        it
+                    )
+                }
+                if (searchResponse.hits.totalHits.value == 0L) {
+                    val ack: AcknowledgedResponse = client.suspendUntil {
+                        client.admin().indices().delete(
+                            DeleteIndexRequest(queryIndex).indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_HIDDEN),
+                            it
+                        )
+                    }
+                    if (ack.isAcknowledged == false) {
+                        log.error("Deletion of concrete queryIndex:$queryIndex is not ack'd!")
+                    }
+                } else {
+                    // Delete all queries added by this monitor
+                    val response: BulkByScrollResponse = suspendCoroutine { cont ->
+                        DeleteByQueryRequestBuilder(client, DeleteByQueryAction.INSTANCE)
+                            .source(queryIndex)
+                            .filter(QueryBuilders.matchQuery("monitor_id", monitor.id))
+                            .refresh(true)
+                            .execute(
+                                object : ActionListener<BulkByScrollResponse> {
+                                    override fun onResponse(response: BulkByScrollResponse) = cont.resume(response)
+                                    override fun onFailure(t: Exception) = cont.resumeWithException(t)
+                                }
+                            )
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            // we only log the error and don't fail the request because if monitor document has been deleted successfully,
+            // we cannot retry based on this failure
+            log.error("Failed to delete doc level queries from query index.", e)
+        }
+    }
+
+    /**
+     * Checks if the monitor is part of the workflow
+     *
+     * @param monitorId id of monitor that is checked if it is a workflow delegate
+     */
+    suspend fun monitorIsWorkflowDelegate(monitorId: String): Boolean {
+        val queryBuilder = QueryBuilders.nestedQuery(
+            WORKFLOW_DELEGATE_PATH,
+            QueryBuilders.boolQuery().must(
+                QueryBuilders.matchQuery(
+                    WORKFLOW_MONITOR_PATH,
+                    monitorId
+                )
+            ),
+            ScoreMode.None
+        )
+        try {
+            val searchRequest = SearchRequest()
+                .indices(ScheduledJob.SCHEDULED_JOBS_INDEX)
+                .source(SearchSourceBuilder().query(queryBuilder))
+
+            client.threadPool().threadContext.stashContext().use {
+                val searchResponse: SearchResponse = client.suspendUntil { search(searchRequest, it) }
+                if (searchResponse.hits.totalHits?.value == 0L) {
+                    return false
+                }
+
+                val workflowIds = searchResponse.hits.hits.map { it.id }.joinToString()
+                log.info("Monitor $monitorId can't be deleted since it belongs to $workflowIds")
+                return true
+            }
+        } catch (ex: Exception) {
+            log.error("Error getting the monitor workflows", ex)
+            throw AlertingException.wrap(ex)
+        }
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
@@ -81,8 +81,7 @@ interface SecureTransportAction {
                 actionListener.onFailure(
                     AlertingException.wrap(
                         OpenSearchStatusException(
-                            "Filter by user backend roles is enabled with security disabled.",
-                            RestStatus.FORBIDDEN
+                            "Filter by user backend roles is enabled with security disabled.", RestStatus.FORBIDDEN
                         )
                     )
                 )

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
@@ -9,26 +9,16 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.apache.logging.log4j.LogManager
-import org.apache.lucene.search.join.ScoreMode
 import org.opensearch.OpenSearchStatusException
 import org.opensearch.action.ActionListener
 import org.opensearch.action.ActionRequest
-import org.opensearch.action.admin.indices.delete.DeleteIndexRequest
-import org.opensearch.action.admin.indices.exists.indices.IndicesExistsRequest
-import org.opensearch.action.admin.indices.exists.indices.IndicesExistsResponse
-import org.opensearch.action.delete.DeleteRequest
-import org.opensearch.action.delete.DeleteResponse
 import org.opensearch.action.get.GetRequest
 import org.opensearch.action.get.GetResponse
-import org.opensearch.action.search.SearchRequest
-import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
-import org.opensearch.action.support.IndicesOptions
-import org.opensearch.action.support.WriteRequest
-import org.opensearch.action.support.master.AcknowledgedResponse
-import org.opensearch.alerting.MonitorMetadataService
+import org.opensearch.action.support.WriteRequest.RefreshPolicy
 import org.opensearch.alerting.opensearchapi.suspendUntil
+import org.opensearch.alerting.service.DeleteMonitorService
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.util.AlertingException
 import org.opensearch.client.Client
@@ -43,21 +33,12 @@ import org.opensearch.commons.alerting.action.DeleteMonitorRequest
 import org.opensearch.commons.alerting.action.DeleteMonitorResponse
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.ScheduledJob
-import org.opensearch.commons.alerting.model.Workflow
 import org.opensearch.commons.authuser.User
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.xcontent.NamedXContentRegistry
-import org.opensearch.index.query.QueryBuilders
-import org.opensearch.index.reindex.BulkByScrollResponse
-import org.opensearch.index.reindex.DeleteByQueryAction
-import org.opensearch.index.reindex.DeleteByQueryRequestBuilder
 import org.opensearch.rest.RestStatus
-import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
-import kotlin.coroutines.suspendCoroutine
 
 private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 private val log = LogManager.getLogger(TransportDeleteMonitorAction::class.java)
@@ -87,83 +68,53 @@ class TransportDeleteMonitorAction @Inject constructor(
         val transformedRequest = request as? DeleteMonitorRequest
             ?: recreateObject(request) { DeleteMonitorRequest(it) }
         val user = readUserFromThreadContext(client)
-        val deleteRequest = DeleteRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, transformedRequest.monitorId)
-            .setRefreshPolicy(transformedRequest.refreshPolicy)
 
         if (!validateUserBackendRoles(user, actionListener)) {
             return
         }
         scope.launch {
-            DeleteMonitorHandler(client, actionListener, deleteRequest, user, transformedRequest.monitorId).resolveUserAndStart()
+            DeleteMonitorHandler(
+                client,
+                actionListener,
+                user,
+                transformedRequest.monitorId
+            ).resolveUserAndStart(transformedRequest.refreshPolicy)
         }
     }
 
     inner class DeleteMonitorHandler(
         private val client: Client,
         private val actionListener: ActionListener<DeleteMonitorResponse>,
-        private val deleteRequest: DeleteRequest,
         private val user: User?,
         private val monitorId: String
     ) {
-        suspend fun resolveUserAndStart() {
+        suspend fun resolveUserAndStart(refreshPolicy: RefreshPolicy) {
             try {
                 val monitor = getMonitor()
-                if (monitorIsWorkflowDelegate(monitor.id)) {
-                    actionListener.onFailure(
-                        AlertingException("Monitor can't be deleted because it is a part of workflow(s)", RestStatus.FORBIDDEN, IllegalStateException())
-                    )
-                }
+
                 val canDelete = user == null || !doFilterForUser(user) ||
                     checkUserPermissionsWithResource(user, monitor.user, actionListener, "monitor", monitorId)
 
-                if (canDelete) {
-                    val deleteResponse = deleteAllResourcesForMonitor(client, monitor, deleteRequest, monitorId)
-                    actionListener.onResponse(DeleteMonitorResponse(deleteResponse.id, deleteResponse.version))
+                if (DeleteMonitorService.monitorIsWorkflowDelegate(monitor.id)) {
+                    actionListener.onFailure(
+                        AlertingException(
+                            "Monitor can't be deleted because it is a part of workflow(s)",
+                            RestStatus.FORBIDDEN,
+                            IllegalStateException()
+                        )
+                    )
+                } else if (canDelete) {
+                    actionListener.onResponse(
+                        DeleteMonitorService.deleteMonitor(monitor, refreshPolicy)
+                    )
                 } else {
                     actionListener.onFailure(
                         AlertingException("Not allowed to delete this monitor!", RestStatus.FORBIDDEN, IllegalStateException())
                     )
                 }
             } catch (t: Exception) {
-                log.error("Failed to delete monitor ${deleteRequest.id()}", t)
+                log.error("Failed to delete monitor $monitorId", t)
                 actionListener.onFailure(AlertingException.wrap(t))
-            }
-        }
-
-        /**
-         * Checks if the monitor is part of the workflow
-         *
-         * @param monitorId id of monitor that is checked if it is a workflow delegate
-         */
-        private suspend fun monitorIsWorkflowDelegate(monitorId: String): Boolean {
-            val queryBuilder = QueryBuilders.nestedQuery(
-                Workflow.WORKFLOW_DELEGATE_PATH,
-                QueryBuilders.boolQuery().must(
-                    QueryBuilders.matchQuery(
-                        Workflow.WORKFLOW_MONITOR_PATH,
-                        monitorId
-                    )
-                ),
-                ScoreMode.None
-            )
-            try {
-                val searchRequest = SearchRequest()
-                    .indices(ScheduledJob.SCHEDULED_JOBS_INDEX)
-                    .source(SearchSourceBuilder().query(queryBuilder))
-
-                client.threadPool().threadContext.stashContext().use {
-                    val searchResponse: SearchResponse = client.suspendUntil { search(searchRequest, it) }
-                    if (searchResponse.hits.totalHits?.value == 0L) {
-                        return false
-                    }
-
-                    val workflowIds = searchResponse.hits.hits.map { it.id }.joinToString()
-                    log.info("Monitor $monitorId can't be deleted since it belongs to $workflowIds")
-                    return true
-                }
-            } catch (ex: Exception) {
-                log.error("Error getting the monitor workflows", ex)
-                throw AlertingException.wrap(ex)
             }
         }
 
@@ -185,104 +136,6 @@ class TransportDeleteMonitorAction @Inject constructor(
                 XContentType.JSON
             )
             return ScheduledJob.parse(xcp, getResponse.id, getResponse.version) as Monitor
-        }
-    }
-
-    companion object {
-        @JvmStatic
-        suspend fun deleteAllResourcesForMonitor(
-            client: Client,
-            monitor: Monitor,
-            deleteRequest: DeleteRequest,
-            monitorId: String,
-        ): DeleteResponse {
-            val deleteResponse = deleteMonitorDocument(client, deleteRequest)
-            deleteMetadata(client, monitor)
-            deleteDocLevelMonitorQueriesAndIndices(client, monitor, monitorId)
-            return deleteResponse
-        }
-
-        private suspend fun deleteMonitorDocument(client: Client, deleteRequest: DeleteRequest): DeleteResponse {
-            return client.suspendUntil { delete(deleteRequest, it) }
-        }
-
-        suspend fun deleteMetadata(client: Client, monitor: Monitor) {
-            val deleteRequest = DeleteRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, "${monitor.id}-metadata")
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-            try {
-                val deleteResponse: DeleteResponse = client.suspendUntil { delete(deleteRequest, it) }
-                log.debug("Monitor metadata: ${deleteResponse.id} deletion result: ${deleteResponse.result}")
-            } catch (e: Exception) {
-                // we only log the error and don't fail the request because if monitor document has been deleted,
-                // we cannot retry based on this failure
-                log.error("Failed to delete monitor metadata ${deleteRequest.id()}.", e)
-            }
-        }
-
-        suspend fun deleteDocLevelMonitorQueriesAndIndices(
-            client: Client,
-            monitor: Monitor,
-            monitorId: String,
-        ) {
-            try {
-                val metadata = MonitorMetadataService.getMetadata(monitor)
-                metadata?.sourceToQueryIndexMapping?.forEach { (_, queryIndex) ->
-
-                    val indicesExistsResponse: IndicesExistsResponse =
-                        client.suspendUntil {
-                            client.admin().indices().exists(IndicesExistsRequest(queryIndex), it)
-                        }
-                    if (indicesExistsResponse.isExists == false) {
-                        return
-                    }
-                    // Check if there's any queries from other monitors in this queryIndex,
-                    // to avoid unnecessary doc deletion, if we could just delete index completely
-                    val searchResponse: SearchResponse = client.suspendUntil {
-                        search(
-                            SearchRequest(queryIndex).source(
-                                SearchSourceBuilder()
-                                    .size(0)
-                                    .query(
-                                        QueryBuilders.boolQuery().mustNot(
-                                            QueryBuilders.matchQuery("monitor_id", monitorId)
-                                        )
-                                    )
-                            ).indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_HIDDEN),
-                            it
-                        )
-                    }
-                    if (searchResponse.hits.totalHits.value == 0L) {
-                        val ack: AcknowledgedResponse = client.suspendUntil {
-                            client.admin().indices().delete(
-                                DeleteIndexRequest(queryIndex).indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_HIDDEN), it
-                            )
-                        }
-                        if (ack.isAcknowledged == false) {
-                            log.error("Deletion of concrete queryIndex:$queryIndex is not ack'd!")
-                        }
-                    } else {
-                        // Delete all queries added by this monitor
-                        val response: BulkByScrollResponse = suspendCoroutine { cont ->
-                            DeleteByQueryRequestBuilder(client, DeleteByQueryAction.INSTANCE)
-                                .source(queryIndex)
-                                .filter(QueryBuilders.matchQuery("monitor_id", monitorId))
-                                .refresh(true)
-                                .execute(
-                                    object : ActionListener<BulkByScrollResponse> {
-                                        override fun onResponse(response: BulkByScrollResponse) = cont.resume(response)
-                                        override fun onFailure(t: Exception) {
-                                            cont.resumeWithException(t)
-                                        }
-                                    }
-                                )
-                        }
-                    }
-                }
-            } catch (e: Exception) {
-                // we only log the error and don't fail the request because if monitor document has been deleted successfully,
-                // we cannot retry based on this failure
-                log.error("Failed to delete doc level queries from query index.", e)
-            }
         }
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt
@@ -1,0 +1,268 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.transport
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.apache.logging.log4j.LogManager
+import org.apache.lucene.search.join.ScoreMode
+import org.opensearch.OpenSearchStatusException
+import org.opensearch.action.ActionListener
+import org.opensearch.action.ActionRequest
+import org.opensearch.action.delete.DeleteRequest
+import org.opensearch.action.delete.DeleteResponse
+import org.opensearch.action.get.GetRequest
+import org.opensearch.action.get.GetResponse
+import org.opensearch.action.search.SearchRequest
+import org.opensearch.action.search.SearchResponse
+import org.opensearch.action.support.ActionFilters
+import org.opensearch.action.support.HandledTransportAction
+import org.opensearch.action.support.WriteRequest.RefreshPolicy
+import org.opensearch.alerting.opensearchapi.addFilter
+import org.opensearch.alerting.opensearchapi.suspendUntil
+import org.opensearch.alerting.settings.AlertingSettings
+import org.opensearch.alerting.util.AlertingException
+import org.opensearch.client.Client
+import org.opensearch.client.node.NodeClient
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.inject.Inject
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.xcontent.LoggingDeprecationHandler
+import org.opensearch.common.xcontent.XContentHelper
+import org.opensearch.common.xcontent.XContentType
+import org.opensearch.commons.alerting.AlertingPluginInterface
+import org.opensearch.commons.alerting.action.AlertingActions
+import org.opensearch.commons.alerting.action.DeleteMonitorRequest
+import org.opensearch.commons.alerting.action.DeleteMonitorResponse
+import org.opensearch.commons.alerting.action.DeleteWorkflowRequest
+import org.opensearch.commons.alerting.action.DeleteWorkflowResponse
+import org.opensearch.commons.alerting.model.CompositeInput
+import org.opensearch.commons.alerting.model.ScheduledJob
+import org.opensearch.commons.alerting.model.Workflow
+import org.opensearch.commons.authuser.User
+import org.opensearch.commons.utils.recreateObject
+import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.core.xcontent.XContentParser
+import org.opensearch.index.IndexNotFoundException
+import org.opensearch.index.query.QueryBuilders
+import org.opensearch.rest.RestStatus
+import org.opensearch.search.builder.SearchSourceBuilder
+import org.opensearch.tasks.Task
+import org.opensearch.transport.TransportService
+
+private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+/**
+ * Transport class that deletes the workflow.
+ * If the deleteDelegateMonitor flag is set to true, deletes the workflow delegates that are not part of another workflow
+ */
+class TransportDeleteWorkflowAction @Inject constructor(
+    transportService: TransportService,
+    val client: Client,
+    actionFilters: ActionFilters,
+    val clusterService: ClusterService,
+    settings: Settings,
+    val xContentRegistry: NamedXContentRegistry
+) : HandledTransportAction<ActionRequest, DeleteWorkflowResponse>(
+    AlertingActions.DELETE_WORKFLOW_ACTION_NAME, transportService, actionFilters, ::DeleteWorkflowRequest
+),
+    SecureTransportAction {
+
+    private val log = LogManager.getLogger(javaClass)
+
+    @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+
+    init {
+        listenFilterBySettingChange(clusterService)
+    }
+
+    override fun doExecute(task: Task, request: ActionRequest, actionListener: ActionListener<DeleteWorkflowResponse>) {
+        val transformedRequest = request as? DeleteWorkflowRequest
+            ?: recreateObject(request) { DeleteWorkflowRequest(it) }
+
+        val user = readUserFromThreadContext(client)
+        val deleteRequest = DeleteRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, transformedRequest.workflowId)
+            .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+
+        if (!validateUserBackendRoles(user, actionListener)) {
+            return
+        }
+
+        scope.launch {
+            DeleteWorkflowHandler(
+                client,
+                actionListener,
+                deleteRequest,
+                transformedRequest.deleteDelegateMonitors,
+                user,
+                transformedRequest.workflowId
+            ).resolveUserAndStart()
+        }
+    }
+
+    inner class DeleteWorkflowHandler(
+        private val client: Client,
+        private val actionListener: ActionListener<DeleteWorkflowResponse>,
+        private val deleteRequest: DeleteRequest,
+        private val deleteDelegateMonitors: Boolean?,
+        private val user: User?,
+        private val workflowId: String
+    ) {
+        suspend fun resolveUserAndStart() {
+            try {
+                val workflow = getWorkflow()
+
+                val canDelete = user == null ||
+                    !doFilterForUser(user) ||
+                    checkUserPermissionsWithResource(
+                        user,
+                        workflow.user,
+                        actionListener,
+                        "workflow",
+                        workflowId
+                    )
+
+                if (canDelete) {
+                    val delegateMonitorIds = (workflow.inputs[0] as CompositeInput).getMonitorIds()
+
+                    // User can only delete the delegate monitors only in the case if all monitors can be deleted
+                    // Partial monitor deletion is not available
+                    if (deleteDelegateMonitors == true) {
+                        val monitorIdsToBeDeleted = getDeletableDelegates(workflowId, delegateMonitorIds, user)
+                        val monitorsDiff = delegateMonitorIds.toMutableList()
+                        monitorsDiff.removeAll(monitorIdsToBeDeleted)
+
+                        if (monitorsDiff.isNotEmpty()) {
+                            actionListener.onFailure(
+                                AlertingException(
+                                    "Not allowed to delete ${monitorsDiff.joinToString()} monitors",
+                                    RestStatus.FORBIDDEN,
+                                    IllegalStateException()
+                                )
+                            )
+                            return
+                        }
+                    }
+
+                    val deleteResponse = deleteWorkflow(workflow)
+                    if (deleteDelegateMonitors == true) {
+                        deleteMonitors(delegateMonitorIds, RefreshPolicy.IMMEDIATE)
+                    }
+                    actionListener.onResponse(DeleteWorkflowResponse(deleteResponse.id, deleteResponse.version))
+                } else {
+                    actionListener.onFailure(
+                        AlertingException(
+                            "Not allowed to delete this workflow!",
+                            RestStatus.FORBIDDEN,
+                            IllegalStateException()
+                        )
+                    )
+                }
+            } catch (t: Exception) {
+                if (t is IndexNotFoundException) {
+                    actionListener.onFailure(
+                        OpenSearchStatusException(
+                            "Workflow not found.",
+                            RestStatus.NOT_FOUND
+                        )
+                    )
+                } else {
+                    actionListener.onFailure(AlertingException.wrap(t))
+                }
+            }
+        }
+
+        private suspend fun deleteMonitors(monitorIds: List<String>, refreshPolicy: RefreshPolicy) {
+            if (monitorIds.isEmpty())
+                return
+
+            for (monitorId in monitorIds) {
+                val deleteRequest = DeleteMonitorRequest(monitorId, refreshPolicy)
+                val searchResponse: DeleteMonitorResponse = client.suspendUntil {
+                    AlertingPluginInterface.deleteMonitor(this as NodeClient, deleteRequest, it)
+                }
+            }
+        }
+
+        /**
+         * Returns lit of monitor ids belonging only to a given workflow
+         * @param workflowIdToBeDeleted Id of the workflow that should be deleted
+         * @param monitorIds List of delegate monitor ids (underlying monitor ids)
+         */
+        private suspend fun getDeletableDelegates(workflowIdToBeDeleted: String, monitorIds: List<String>, user: User?): List<String> {
+            // Retrieve monitors belonging to another workflows
+            val queryBuilder = QueryBuilders.boolQuery().mustNot(QueryBuilders.termQuery("_id", workflowIdToBeDeleted)).filter(
+                QueryBuilders.nestedQuery(
+                    Workflow.WORKFLOW_DELEGATE_PATH,
+                    QueryBuilders.boolQuery().must(
+                        QueryBuilders.termsQuery(
+                            Workflow.WORKFLOW_MONITOR_PATH,
+                            monitorIds
+                        )
+                    ),
+                    ScoreMode.None
+                )
+            )
+
+            val searchRequest = SearchRequest()
+                .indices(ScheduledJob.SCHEDULED_JOBS_INDEX)
+                .source(SearchSourceBuilder().query(queryBuilder))
+
+            // Check if user can access the monitors(since the monitors could get modified later and the user might not have the backend roles to access the monitors)
+            if (user != null && filterByEnabled) {
+                addFilter(user, searchRequest.source(), "monitor.user.backend_roles.keyword")
+            }
+
+            val searchResponse: SearchResponse = client.suspendUntil { search(searchRequest, it) }
+
+            val workflows = searchResponse.hits.hits.map { hit ->
+                val xcp = XContentHelper.createParser(
+                    xContentRegistry, LoggingDeprecationHandler.INSTANCE,
+                    hit.sourceRef, XContentType.JSON
+                ).also { it.nextToken() }
+                lateinit var workflow: Workflow
+                while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
+                    xcp.nextToken()
+                    when (xcp.currentName()) {
+                        "workflow" -> workflow = Workflow.parse(xcp)
+                    }
+                }
+                workflow.copy(id = hit.id, version = hit.version)
+            }
+            val workflowMonitors = workflows.filter { it.id != workflowIdToBeDeleted }.flatMap { (it.inputs[0] as CompositeInput).getMonitorIds() }.distinct()
+            // Monitors that can be deleted -> all workflow delegates - monitors belonging to different workflows
+            return monitorIds.minus(workflowMonitors.toSet())
+        }
+
+        private suspend fun getWorkflow(): Workflow {
+            val getRequest = GetRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, workflowId)
+
+            val getResponse: GetResponse = client.suspendUntil { get(getRequest, it) }
+            if (getResponse.isExists == false) {
+                actionListener.onFailure(
+                    AlertingException.wrap(
+                        OpenSearchStatusException("Workflow not found.", RestStatus.NOT_FOUND)
+                    )
+                )
+            }
+            val xcp = XContentHelper.createParser(
+                xContentRegistry, LoggingDeprecationHandler.INSTANCE,
+                getResponse.sourceAsBytesRef, XContentType.JSON
+            )
+            return ScheduledJob.parse(xcp, getResponse.id, getResponse.version) as Workflow
+        }
+
+        private suspend fun deleteWorkflow(workflow: Workflow): DeleteResponse {
+            log.debug("Deleting the workflow with id ${deleteRequest.id()}")
+            return client.suspendUntil { delete(deleteRequest, it) }
+        }
+        // TODO - use once the workflow metadata concept is introduced
+        private suspend fun deleteMetadata(workflow: Workflow) {
+            val deleteRequest = DeleteRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, "${workflow.id}-metadata")
+            val deleteResponse: DeleteResponse = client.suspendUntil { delete(deleteRequest, it) }
+        }
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt
@@ -152,9 +152,7 @@ class TransportDeleteWorkflowAction @Inject constructor(
 
                     val deleteResponse = deleteWorkflow(workflow)
                     if (deleteDelegateMonitors == true) {
-                        if (user == null) {
-                            deleteMonitors(delegateMonitorIds, RefreshPolicy.IMMEDIATE)
-                        } else {
+                        if (user != null && filterByEnabled) {
                             // Un-stash the context
                             withClosableContext(
                                 InjectorContextElement(
@@ -167,6 +165,8 @@ class TransportDeleteWorkflowAction @Inject constructor(
                             ) {
                                 deleteMonitors(delegateMonitorIds, RefreshPolicy.IMMEDIATE)
                             }
+                        } else {
+                            deleteMonitors(delegateMonitorIds, RefreshPolicy.IMMEDIATE)
                         }
                     }
                     actionListener.onResponse(DeleteWorkflowResponse(deleteResponse.id, deleteResponse.version))

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.apache.logging.log4j.LogManager
 import org.apache.lucene.search.join.ScoreMode
+import org.opensearch.OpenSearchException
 import org.opensearch.OpenSearchStatusException
 import org.opensearch.action.ActionListener
 import org.opensearch.action.ActionRequest
@@ -22,27 +23,25 @@ import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.action.support.WriteRequest.RefreshPolicy
-import org.opensearch.alerting.opensearchapi.InjectorContextElement
+import org.opensearch.alerting.model.MonitorMetadata
+import org.opensearch.alerting.model.WorkflowMetadata
 import org.opensearch.alerting.opensearchapi.addFilter
 import org.opensearch.alerting.opensearchapi.suspendUntil
-import org.opensearch.alerting.opensearchapi.withClosableContext
+import org.opensearch.alerting.service.DeleteMonitorService
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.util.AlertingException
 import org.opensearch.client.Client
-import org.opensearch.client.node.NodeClient
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
-import org.opensearch.commons.alerting.AlertingPluginInterface
 import org.opensearch.commons.alerting.action.AlertingActions
-import org.opensearch.commons.alerting.action.DeleteMonitorRequest
-import org.opensearch.commons.alerting.action.DeleteMonitorResponse
 import org.opensearch.commons.alerting.action.DeleteWorkflowRequest
 import org.opensearch.commons.alerting.action.DeleteWorkflowResponse
 import org.opensearch.commons.alerting.model.CompositeInput
+import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.model.Workflow
 import org.opensearch.commons.authuser.User
@@ -51,11 +50,13 @@ import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.core.xcontent.XContentParser
 import org.opensearch.index.IndexNotFoundException
 import org.opensearch.index.query.QueryBuilders
+import org.opensearch.index.reindex.BulkByScrollResponse
+import org.opensearch.index.reindex.DeleteByQueryAction
+import org.opensearch.index.reindex.DeleteByQueryRequestBuilder
 import org.opensearch.rest.RestStatus
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService
-import java.util.UUID
 
 private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 /**
@@ -68,12 +69,11 @@ class TransportDeleteWorkflowAction @Inject constructor(
     actionFilters: ActionFilters,
     val clusterService: ClusterService,
     val settings: Settings,
-    val xContentRegistry: NamedXContentRegistry
+    val xContentRegistry: NamedXContentRegistry,
 ) : HandledTransportAction<ActionRequest, DeleteWorkflowResponse>(
     AlertingActions.DELETE_WORKFLOW_ACTION_NAME, transportService, actionFilters, ::DeleteWorkflowRequest
 ),
     SecureTransportAction {
-
     private val log = LogManager.getLogger(javaClass)
 
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
@@ -112,7 +112,7 @@ class TransportDeleteWorkflowAction @Inject constructor(
         private val deleteRequest: DeleteRequest,
         private val deleteDelegateMonitors: Boolean?,
         private val user: User?,
-        private val workflowId: String
+        private val workflowId: String,
     ) {
         suspend fun resolveUserAndStart() {
             try {
@@ -130,13 +130,14 @@ class TransportDeleteWorkflowAction @Inject constructor(
 
                 if (canDelete) {
                     val delegateMonitorIds = (workflow.inputs[0] as CompositeInput).getMonitorIds()
-
+                    var deletableMonitors = listOf<Monitor>()
                     // User can only delete the delegate monitors only in the case if all monitors can be deleted
-                    // Partial monitor deletion is not available
+                    // if there are monitors in this workflow that are referenced in other workflows, we cannot delete the monitors.
+                    // We will not partially delete monitors. we delete them all or fail the request.
                     if (deleteDelegateMonitors == true) {
-                        val monitorIdsToBeDeleted = getDeletableDelegates(workflowId, delegateMonitorIds, user)
+                        deletableMonitors = getDeletableDelegates(workflowId, delegateMonitorIds, user)
                         val monitorsDiff = delegateMonitorIds.toMutableList()
-                        monitorsDiff.removeAll(monitorIdsToBeDeleted)
+                        monitorsDiff.removeAll(deletableMonitors.map { it.id })
 
                         if (monitorsDiff.isNotEmpty()) {
                             actionListener.onFailure(
@@ -150,26 +151,33 @@ class TransportDeleteWorkflowAction @Inject constructor(
                         }
                     }
 
-                    val deleteResponse = deleteWorkflow(workflow)
+                    val deleteResponse = deleteWorkflow(deleteRequest)
+                    var deleteWorkflowResponse = DeleteWorkflowResponse(deleteResponse.id, deleteResponse.version)
+
+                    val workflowMetadataId = WorkflowMetadata.getId(workflow.id)
+
+                    val metadataIdsToDelete = mutableListOf(workflowMetadataId)
+
                     if (deleteDelegateMonitors == true) {
-                        if (user != null && filterByEnabled) {
-                            // Un-stash the context
-                            withClosableContext(
-                                InjectorContextElement(
-                                    user.name.plus(UUID.randomUUID().toString()),
-                                    settings,
-                                    client.threadPool().threadContext,
-                                    user.roles,
-                                    user
-                                )
-                            ) {
-                                deleteMonitors(delegateMonitorIds, RefreshPolicy.IMMEDIATE)
-                            }
-                        } else {
-                            deleteMonitors(delegateMonitorIds, RefreshPolicy.IMMEDIATE)
-                        }
+                        val failedMonitorIds = tryDeletingMonitors(deletableMonitors, RefreshPolicy.IMMEDIATE)
+                        // Update delete workflow response
+                        deleteWorkflowResponse.nonDeletedMonitors = failedMonitorIds
+                        // Delete monitors workflow metadata
+                        // Monitor metadata will be in workflowId-monitorId-metadata format
+                        metadataIdsToDelete.addAll(deletableMonitors.map { MonitorMetadata.getId(it, workflowMetadataId) })
                     }
-                    actionListener.onResponse(DeleteWorkflowResponse(deleteResponse.id, deleteResponse.version))
+                    try {
+                        // Delete the monitors workflow metadata
+                        val deleteMonitorWorkflowMetadataResponse: BulkByScrollResponse = client.suspendUntil {
+                            DeleteByQueryRequestBuilder(this, DeleteByQueryAction.INSTANCE)
+                                .source(ScheduledJob.SCHEDULED_JOBS_INDEX)
+                                .filter(QueryBuilders.idsQuery().addIds(*metadataIdsToDelete.toTypedArray()))
+                                .execute(it)
+                        }
+                    } catch (t: Exception) {
+                        log.error("Failed to delete delegate monitor metadata. But proceeding with workflow deletion $workflowId", t)
+                    }
+                    actionListener.onResponse(deleteWorkflowResponse)
                 } else {
                     actionListener.onFailure(
                         AlertingException(
@@ -188,36 +196,45 @@ class TransportDeleteWorkflowAction @Inject constructor(
                         )
                     )
                 } else {
+                    log.error("Failed to delete workflow $workflowId", t)
                     actionListener.onFailure(AlertingException.wrap(t))
                 }
             }
         }
 
-        private suspend fun deleteMonitors(monitorIds: List<String>, refreshPolicy: RefreshPolicy) {
-            if (monitorIds.isEmpty())
-                return
-
-            for (monitorId in monitorIds) {
-                val deleteRequest = DeleteMonitorRequest(monitorId, refreshPolicy)
-                val searchResponse: DeleteMonitorResponse = client.suspendUntil {
-                    AlertingPluginInterface.deleteMonitor(this as NodeClient, deleteRequest, it)
+        /**
+         * Tries to delete the given list of the monitors. Return value contains all the monitorIds for which deletion failed
+         * @param monitorIds list of monitor ids to be deleted
+         * @param refreshPolicy
+         * @return list of the monitors that were not deleted
+         */
+        private suspend fun tryDeletingMonitors(monitors: List<Monitor>, refreshPolicy: RefreshPolicy): List<String> {
+            val nonDeletedMonitorIds = mutableListOf<String>()
+            for (monitor in monitors) {
+                try {
+                    DeleteMonitorService.deleteMonitor(monitor, refreshPolicy)
+                } catch (ex: Exception) {
+                    log.error("failed to delete delegate monitor ${monitor.id} for $workflowId")
+                    nonDeletedMonitorIds.add(monitor.id)
                 }
             }
+            return nonDeletedMonitorIds
         }
 
         /**
-         * Returns lit of monitor ids belonging only to a given workflow
+         * Returns lit of monitor ids belonging only to a given workflow.
+         * if filterBy is enabled, it filters and returns only those monitors which user has permission to delete.
          * @param workflowIdToBeDeleted Id of the workflow that should be deleted
          * @param monitorIds List of delegate monitor ids (underlying monitor ids)
          */
-        private suspend fun getDeletableDelegates(workflowIdToBeDeleted: String, monitorIds: List<String>, user: User?): List<String> {
+        private suspend fun getDeletableDelegates(workflowIdToBeDeleted: String, monitorIds: List<String>, user: User?): List<Monitor> {
             // Retrieve monitors belonging to another workflows
             val queryBuilder = QueryBuilders.boolQuery().mustNot(QueryBuilders.termQuery("_id", workflowIdToBeDeleted)).filter(
                 QueryBuilders.nestedQuery(
-                    Workflow.WORKFLOW_DELEGATE_PATH,
+                    WORKFLOW_DELEGATE_PATH,
                     QueryBuilders.boolQuery().must(
                         QueryBuilders.termsQuery(
-                            Workflow.WORKFLOW_MONITOR_PATH,
+                            WORKFLOW_MONITOR_PATH,
                             monitorIds
                         )
                     ),
@@ -228,11 +245,6 @@ class TransportDeleteWorkflowAction @Inject constructor(
             val searchRequest = SearchRequest()
                 .indices(ScheduledJob.SCHEDULED_JOBS_INDEX)
                 .source(SearchSourceBuilder().query(queryBuilder))
-
-            // Check if user can access the monitors(since the monitors could get modified later and the user might not have the backend roles to access the monitors)
-            if (user != null && filterByEnabled) {
-                addFilter(user, searchRequest.source(), "monitor.user.backend_roles.keyword")
-            }
 
             val searchResponse: SearchResponse = client.suspendUntil { search(searchRequest, it) }
 
@@ -250,9 +262,35 @@ class TransportDeleteWorkflowAction @Inject constructor(
                 }
                 workflow.copy(id = hit.id, version = hit.version)
             }
-            val workflowMonitors = workflows.filter { it.id != workflowIdToBeDeleted }.flatMap { (it.inputs[0] as CompositeInput).getMonitorIds() }.distinct()
+            val workflowMonitors = workflows.flatMap { (it.inputs[0] as CompositeInput).getMonitorIds() }.distinct()
             // Monitors that can be deleted -> all workflow delegates - monitors belonging to different workflows
-            return monitorIds.minus(workflowMonitors.toSet())
+            val deletableMonitorIds = monitorIds.minus(workflowMonitors.toSet())
+
+            // filtering further to get the list of monitors that user has permission to delete if filterby is enabled and user is not null
+            val query = QueryBuilders.boolQuery().filter(QueryBuilders.termsQuery("_id", deletableMonitorIds))
+            val searchSource = SearchSourceBuilder().query(query)
+            val monitorSearchRequest = SearchRequest(ScheduledJob.SCHEDULED_JOBS_INDEX).source(searchSource)
+
+            if (user != null && filterByEnabled) {
+                addFilter(user, monitorSearchRequest.source(), "monitor.user.backend_roles.keyword")
+            }
+
+            val searchMonitorResponse: SearchResponse = client.suspendUntil { search(monitorSearchRequest, it) }
+            if (searchMonitorResponse.isTimedOut) {
+                throw OpenSearchException("Cannot determine that the ${ScheduledJob.SCHEDULED_JOBS_INDEX} index is healthy")
+            }
+            val deletableMonitors = mutableListOf<Monitor>()
+            for (hit in searchMonitorResponse.hits) {
+                XContentType.JSON.xContent().createParser(
+                    xContentRegistry,
+                    LoggingDeprecationHandler.INSTANCE, hit.sourceAsString
+                ).use { hitsParser ->
+                    val monitor = ScheduledJob.parse(hitsParser, hit.id, hit.version) as Monitor
+                    deletableMonitors.add(monitor)
+                }
+            }
+
+            return deletableMonitors
         }
 
         private suspend fun getWorkflow(): Workflow {
@@ -273,14 +311,19 @@ class TransportDeleteWorkflowAction @Inject constructor(
             return ScheduledJob.parse(xcp, getResponse.id, getResponse.version) as Workflow
         }
 
-        private suspend fun deleteWorkflow(workflow: Workflow): DeleteResponse {
+        private suspend fun deleteWorkflow(deleteRequest: DeleteRequest): DeleteResponse {
             log.debug("Deleting the workflow with id ${deleteRequest.id()}")
             return client.suspendUntil { delete(deleteRequest, it) }
         }
-        // TODO - use once the workflow metadata concept is introduced
-        private suspend fun deleteMetadata(workflow: Workflow) {
-            val deleteRequest = DeleteRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, "${workflow.id}-metadata")
+
+        private suspend fun deleteWorkflowMetadata(workflow: Workflow) {
+            val deleteRequest = DeleteRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, WorkflowMetadata.getId(workflow.id))
             val deleteResponse: DeleteResponse = client.suspendUntil { delete(deleteRequest, it) }
         }
+    }
+
+    companion object {
+        const val WORKFLOW_DELEGATE_PATH = "workflow.inputs.composite_input.sequence.delegates"
+        const val WORKFLOW_MONITOR_PATH = "workflow.inputs.composite_input.sequence.delegates.monitor_id"
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteWorkflowAction.kt
@@ -47,7 +47,11 @@ class TransportExecuteWorkflowAction @Inject constructor(
 ) : HandledTransportAction<ExecuteWorkflowRequest, ExecuteWorkflowResponse>(
     ExecuteWorkflowAction.NAME, transportService, actionFilters, ::ExecuteWorkflowRequest
 ) {
-    override fun doExecute(task: Task, execWorkflowRequest: ExecuteWorkflowRequest, actionListener: ActionListener<ExecuteWorkflowResponse>) {
+    override fun doExecute(
+        task: Task,
+        execWorkflowRequest: ExecuteWorkflowRequest,
+        actionListener: ActionListener<ExecuteWorkflowResponse>,
+    ) {
         val userStr = client.threadPool().threadContext.getTransient<String>(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT)
         log.debug("User and roles string from thread context: $userStr")
         val user: User? = User.parse(userStr)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteWorkflowAction.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.transport
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.apache.logging.log4j.LogManager
+import org.opensearch.OpenSearchStatusException
+import org.opensearch.action.ActionListener
+import org.opensearch.action.get.GetRequest
+import org.opensearch.action.get.GetResponse
+import org.opensearch.action.support.ActionFilters
+import org.opensearch.action.support.HandledTransportAction
+import org.opensearch.alerting.MonitorRunnerService
+import org.opensearch.alerting.action.ExecuteWorkflowAction
+import org.opensearch.alerting.action.ExecuteWorkflowRequest
+import org.opensearch.alerting.action.ExecuteWorkflowResponse
+import org.opensearch.alerting.util.AlertingException
+import org.opensearch.alerting.workflow.WorkflowRunnerService
+import org.opensearch.client.Client
+import org.opensearch.common.inject.Inject
+import org.opensearch.common.xcontent.LoggingDeprecationHandler
+import org.opensearch.common.xcontent.XContentHelper
+import org.opensearch.common.xcontent.XContentType
+import org.opensearch.commons.ConfigConstants
+import org.opensearch.commons.alerting.model.ScheduledJob
+import org.opensearch.commons.alerting.model.Workflow
+import org.opensearch.commons.authuser.User
+import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.rest.RestStatus
+import org.opensearch.tasks.Task
+import org.opensearch.transport.TransportService
+import java.time.Instant
+
+private val log = LogManager.getLogger(TransportExecuteWorkflowAction::class.java)
+
+class TransportExecuteWorkflowAction @Inject constructor(
+    transportService: TransportService,
+    private val client: Client,
+    private val runner: MonitorRunnerService,
+    actionFilters: ActionFilters,
+    val xContentRegistry: NamedXContentRegistry
+) : HandledTransportAction<ExecuteWorkflowRequest, ExecuteWorkflowResponse>(
+    ExecuteWorkflowAction.NAME, transportService, actionFilters, ::ExecuteWorkflowRequest
+) {
+    override fun doExecute(task: Task, execWorkflowRequest: ExecuteWorkflowRequest, actionListener: ActionListener<ExecuteWorkflowResponse>) {
+        val userStr = client.threadPool().threadContext.getTransient<String>(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT)
+        log.debug("User and roles string from thread context: $userStr")
+        val user: User? = User.parse(userStr)
+
+        client.threadPool().threadContext.stashContext().use {
+            val executeWorkflow = fun(workflow: Workflow) {
+                runner.launch {
+                    val (periodStart, periodEnd) =
+                        workflow.schedule.getPeriodEndingAt(Instant.ofEpochMilli(execWorkflowRequest.requestEnd.millis))
+                    try {
+                        val workflowRunResult =
+                            WorkflowRunnerService.runJob(workflow, periodStart, periodEnd, execWorkflowRequest.dryrun)
+                        withContext(Dispatchers.IO) {
+                            actionListener.onResponse(
+                                ExecuteWorkflowResponse(
+                                    workflowRunResult
+                                )
+                            )
+                        }
+                    } catch (e: Exception) {
+                        log.error("Unexpected error running workflow", e)
+                        withContext(Dispatchers.IO) {
+                            actionListener.onFailure(AlertingException.wrap(e))
+                        }
+                    }
+                }
+            }
+
+            if (execWorkflowRequest.workflowId != null) {
+                val getRequest = GetRequest(ScheduledJob.SCHEDULED_JOBS_INDEX).id(execWorkflowRequest.workflowId)
+                client.get(
+                    getRequest,
+                    object : ActionListener<GetResponse> {
+                        override fun onResponse(response: GetResponse) {
+                            if (!response.isExists) {
+                                log.error("Can't find workflow with id: ${response.id}")
+                                actionListener.onFailure(
+                                    AlertingException.wrap(
+                                        OpenSearchStatusException(
+                                            "Can't find workflow with id: ${response.id}",
+                                            RestStatus.NOT_FOUND
+                                        )
+                                    )
+                                )
+                                return
+                            }
+                            if (!response.isSourceEmpty) {
+                                XContentHelper.createParser(
+                                    xContentRegistry, LoggingDeprecationHandler.INSTANCE,
+                                    response.sourceAsBytesRef, XContentType.JSON
+                                ).use { xcp ->
+                                    val workflow = ScheduledJob.parse(xcp, response.id, response.version) as Workflow
+                                    executeWorkflow(workflow)
+                                }
+                            }
+                        }
+
+                        override fun onFailure(t: Exception) {
+                            log.error("Error getting workflow ${execWorkflowRequest.workflowId}", t)
+                            actionListener.onFailure(AlertingException.wrap(t))
+                        }
+                    }
+                )
+            } else {
+                val workflow = when (user?.name.isNullOrEmpty()) {
+                    true -> execWorkflowRequest.workflow as Workflow
+                    false -> (execWorkflowRequest.workflow as Workflow).copy(user = user)
+                }
+
+                executeWorkflow(workflow)
+            }
+        }
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAction.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.transport
+
+import org.apache.logging.log4j.LogManager
+import org.opensearch.OpenSearchStatusException
+import org.opensearch.action.ActionListener
+import org.opensearch.action.get.GetRequest
+import org.opensearch.action.get.GetResponse
+import org.opensearch.action.support.ActionFilters
+import org.opensearch.action.support.HandledTransportAction
+import org.opensearch.alerting.settings.AlertingSettings
+import org.opensearch.alerting.util.AlertingException
+import org.opensearch.client.Client
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.inject.Inject
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.xcontent.LoggingDeprecationHandler
+import org.opensearch.common.xcontent.XContentHelper
+import org.opensearch.common.xcontent.XContentType
+import org.opensearch.commons.alerting.action.AlertingActions
+import org.opensearch.commons.alerting.action.GetWorkflowRequest
+import org.opensearch.commons.alerting.action.GetWorkflowResponse
+import org.opensearch.commons.alerting.model.ScheduledJob
+import org.opensearch.commons.alerting.model.Workflow
+import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.index.IndexNotFoundException
+import org.opensearch.rest.RestStatus
+import org.opensearch.tasks.Task
+import org.opensearch.transport.TransportService
+
+class TransportGetWorkflowAction @Inject constructor(
+    transportService: TransportService,
+    val client: Client,
+    actionFilters: ActionFilters,
+    val xContentRegistry: NamedXContentRegistry,
+    val clusterService: ClusterService,
+    settings: Settings
+) : HandledTransportAction<GetWorkflowRequest, GetWorkflowResponse>(
+    AlertingActions.GET_WORKFLOW_ACTION_NAME, transportService, actionFilters, ::GetWorkflowRequest
+),
+    SecureTransportAction {
+
+    private val log = LogManager.getLogger(javaClass)
+
+    @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+
+    init {
+        listenFilterBySettingChange(clusterService)
+    }
+
+    override fun doExecute(task: Task, getWorkflowRequest: GetWorkflowRequest, actionListener: ActionListener<GetWorkflowResponse>) {
+        val user = readUserFromThreadContext(client)
+
+        val getRequest = GetRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, getWorkflowRequest.workflowId)
+
+        if (!validateUserBackendRoles(user, actionListener)) {
+            return
+        }
+
+        client.threadPool().threadContext.stashContext().use {
+            client.get(
+                getRequest,
+                object : ActionListener<GetResponse> {
+                    override fun onResponse(response: GetResponse) {
+                        if (!response.isExists) {
+                            log.error("Workflow with ${getWorkflowRequest.workflowId} not found")
+                            actionListener.onFailure(
+                                AlertingException.wrap(
+                                    OpenSearchStatusException(
+                                        "Workflow not found.",
+                                        RestStatus.NOT_FOUND
+                                    )
+                                )
+                            )
+                            return
+                        }
+
+                        var workflow: Workflow? = null
+                        if (!response.isSourceEmpty) {
+                            XContentHelper.createParser(
+                                xContentRegistry, LoggingDeprecationHandler.INSTANCE,
+                                response.sourceAsBytesRef, XContentType.JSON
+                            ).use { xcp ->
+                                workflow = ScheduledJob.parse(xcp, response.id, response.version) as Workflow
+
+                                // security is enabled and filterby is enabled
+                                if (!checkUserPermissionsWithResource(
+                                        user,
+                                        workflow?.user,
+                                        actionListener,
+                                        "workflow",
+                                        getWorkflowRequest.workflowId
+                                    )
+                                ) {
+                                    return
+                                }
+                            }
+                        }
+
+                        actionListener.onResponse(
+                            GetWorkflowResponse(
+                                response.id,
+                                response.version,
+                                response.seqNo,
+                                response.primaryTerm,
+                                RestStatus.OK,
+                                workflow
+                            )
+                        )
+                    }
+
+                    override fun onFailure(t: Exception) {
+                        log.error("Getting the workflow failed", t)
+
+                        if (t is IndexNotFoundException) {
+                            actionListener.onFailure(
+                                OpenSearchStatusException(
+                                    "Workflow not found",
+                                    RestStatus.NOT_FOUND
+                                )
+                            )
+                        } else {
+                            actionListener.onFailure(AlertingException.wrap(t))
+                        }
+                    }
+                }
+            )
+        }
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
@@ -604,7 +604,7 @@ class TransportIndexWorkflowAction @Inject constructor(
         val searchSource = SearchSourceBuilder().query(query)
         val searchRequest = SearchRequest(SCHEDULED_JOBS_INDEX).source(searchSource)
 
-        if (user != null && !isAdmin(user) && filterByEnabled) {
+        if (user != null && filterByEnabled) {
             addFilter(user, searchRequest.source(), "monitor.user.backend_roles.keyword")
         }
 
@@ -647,9 +647,7 @@ class TransportIndexWorkflowAction @Inject constructor(
         val indicesSearchRequest = SearchRequest().indices(*indices.toTypedArray())
             .source(SearchSourceBuilder.searchSource().size(1).query(QueryBuilders.matchAllQuery()))
 
-        if (user == null) {
-            checkIndicesAccess(client, indicesSearchRequest, indices, actionListener)
-        } else {
+        if (user != null && filterByEnabled) {
             // Unstash the context and check if user with specified roles has indices access
             withClosableContext(
                 InjectorContextElement(
@@ -662,6 +660,8 @@ class TransportIndexWorkflowAction @Inject constructor(
             ) {
                 checkIndicesAccess(client, indicesSearchRequest, indices, actionListener)
             }
+        } else {
+            checkIndicesAccess(client, indicesSearchRequest, indices, actionListener)
         }
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
@@ -140,7 +140,8 @@ class TransportIndexWorkflowAction @Inject constructor(
         ) {
             if (transformedRequest.rbacRoles?.stream()?.anyMatch { !user.backendRoles.contains(it) } == true) {
                 log.error(
-                    "User specified backend roles, ${transformedRequest.rbacRoles}, that they don' have access to. User backend roles: ${user.backendRoles}"
+                    "User specified backend roles, ${transformedRequest.rbacRoles}, " +
+                        "that they don' have access to. User backend roles: ${user.backendRoles}"
                 )
                 actionListener.onFailure(
                     AlertingException.wrap(
@@ -153,7 +154,8 @@ class TransportIndexWorkflowAction @Inject constructor(
                 return
             } else if (transformedRequest.rbacRoles?.isEmpty() == true) {
                 log.error(
-                    "Non-admin user are not allowed to specify an empty set of backend roles. Please don't pass in the parameter or pass in at least one backend role."
+                    "Non-admin user are not allowed to specify an empty set of backend roles. " +
+                        "Please don't pass in the parameter or pass in at least one backend role."
                 )
                 actionListener.onFailure(
                     AlertingException.wrap(
@@ -543,7 +545,9 @@ class TransportIndexWorkflowAction @Inject constructor(
                 val chainedMonitorIndices = getMonitorIndices(chainedFindingMonitor)
 
                 if (!delegateMonitorIndices.equalsIgnoreOrder(chainedMonitorIndices)) {
-                    throw AlertingException.wrap(IllegalArgumentException("Delegate monitor and it's chained finding monitor must query the same indices"))
+                    throw AlertingException.wrap(
+                        IllegalArgumentException("Delegate monitor and it's chained finding monitor must query the same indices")
+                    )
                 }
             }
         }
@@ -604,7 +608,7 @@ class TransportIndexWorkflowAction @Inject constructor(
         val searchSource = SearchSourceBuilder().query(query)
         val searchRequest = SearchRequest(SCHEDULED_JOBS_INDEX).source(searchSource)
 
-        if (user != null && filterByEnabled) {
+        if (user != null && !isAdmin(user) && filterByEnabled) {
             addFilter(user, searchRequest.source(), "monitor.user.backend_roles.keyword")
         }
 
@@ -703,7 +707,11 @@ class TransportIndexWorkflowAction @Inject constructor(
         val indices = mutableListOf<String>()
 
         val searchInputs =
-            monitors.flatMap { monitor -> monitor.inputs.filter { it.name() == SearchInput.SEARCH_FIELD || it.name() == DocLevelMonitorInput.DOC_LEVEL_INPUT_FIELD } }
+            monitors.flatMap { monitor ->
+                monitor.inputs.filter {
+                    it.name() == SearchInput.SEARCH_FIELD || it.name() == DocLevelMonitorInput.DOC_LEVEL_INPUT_FIELD
+                }
+            }
         searchInputs.forEach {
             val inputIndices = if (it.name() == SearchInput.SEARCH_FIELD) (it as SearchInput).indices
             else (it as DocLevelMonitorInput).indices

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
@@ -1,0 +1,639 @@
+package org.opensearch.alerting.transport
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.apache.logging.log4j.LogManager
+import org.opensearch.ExceptionsHelper
+import org.opensearch.OpenSearchException
+import org.opensearch.OpenSearchStatusException
+import org.opensearch.ResourceAlreadyExistsException
+import org.opensearch.action.ActionListener
+import org.opensearch.action.ActionRequest
+import org.opensearch.action.admin.cluster.health.ClusterHealthAction
+import org.opensearch.action.admin.cluster.health.ClusterHealthRequest
+import org.opensearch.action.admin.cluster.health.ClusterHealthResponse
+import org.opensearch.action.admin.indices.create.CreateIndexResponse
+import org.opensearch.action.get.GetRequest
+import org.opensearch.action.get.GetResponse
+import org.opensearch.action.index.IndexRequest
+import org.opensearch.action.index.IndexResponse
+import org.opensearch.action.search.SearchRequest
+import org.opensearch.action.search.SearchResponse
+import org.opensearch.action.support.ActionFilters
+import org.opensearch.action.support.HandledTransportAction
+import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.alerting.core.ScheduledJobIndices
+import org.opensearch.alerting.opensearchapi.addFilter
+import org.opensearch.alerting.opensearchapi.suspendUntil
+import org.opensearch.alerting.settings.AlertingSettings
+import org.opensearch.alerting.settings.AlertingSettings.Companion.ALERTING_MAX_MONITORS
+import org.opensearch.alerting.settings.AlertingSettings.Companion.INDEX_TIMEOUT
+import org.opensearch.alerting.settings.AlertingSettings.Companion.MAX_ACTION_THROTTLE_VALUE
+import org.opensearch.alerting.settings.AlertingSettings.Companion.REQUEST_TIMEOUT
+import org.opensearch.alerting.settings.DestinationSettings.Companion.ALLOW_LIST
+import org.opensearch.alerting.util.AlertingException
+import org.opensearch.alerting.util.IndexUtils
+import org.opensearch.alerting.util.isQueryLevelMonitor
+import org.opensearch.client.Client
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.inject.Inject
+import org.opensearch.common.io.stream.NamedWriteableRegistry
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.xcontent.LoggingDeprecationHandler
+import org.opensearch.common.xcontent.NamedXContentRegistry
+import org.opensearch.common.xcontent.ToXContent
+import org.opensearch.common.xcontent.XContentFactory.jsonBuilder
+import org.opensearch.common.xcontent.XContentHelper
+import org.opensearch.common.xcontent.XContentType
+import org.opensearch.commons.alerting.action.AlertingActions
+import org.opensearch.commons.alerting.action.IndexWorkflowRequest
+import org.opensearch.commons.alerting.action.IndexWorkflowResponse
+import org.opensearch.commons.alerting.model.CompositeInput
+import org.opensearch.commons.alerting.model.Delegate
+import org.opensearch.commons.alerting.model.DocLevelMonitorInput
+import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.ScheduledJob
+import org.opensearch.commons.alerting.model.ScheduledJob.Companion.SCHEDULED_JOBS_INDEX
+import org.opensearch.commons.alerting.model.SearchInput
+import org.opensearch.commons.alerting.model.Workflow
+import org.opensearch.commons.authuser.User
+import org.opensearch.commons.utils.recreateObject
+import org.opensearch.index.IndexNotFoundException
+import org.opensearch.index.query.QueryBuilders
+import org.opensearch.rest.RestRequest
+import org.opensearch.rest.RestStatus
+import org.opensearch.search.builder.SearchSourceBuilder
+import org.opensearch.tasks.Task
+import org.opensearch.transport.TransportService
+import java.util.stream.Collectors
+
+private val log = LogManager.getLogger(TransportIndexWorkflowAction::class.java)
+private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+
+class TransportIndexWorkflowAction @Inject constructor(
+    transportService: TransportService,
+    val client: Client,
+    actionFilters: ActionFilters,
+    val scheduledJobIndices: ScheduledJobIndices,
+    val clusterService: ClusterService,
+    val settings: Settings,
+    val xContentRegistry: NamedXContentRegistry,
+    val namedWriteableRegistry: NamedWriteableRegistry,
+) : HandledTransportAction<ActionRequest, IndexWorkflowResponse>(
+    AlertingActions.INDEX_WORKFLOW_ACTION_NAME, transportService, actionFilters, ::IndexWorkflowRequest
+),
+    SecureTransportAction {
+
+    @Volatile
+    private var maxMonitors = ALERTING_MAX_MONITORS.get(settings)
+
+    @Volatile
+    private var requestTimeout = REQUEST_TIMEOUT.get(settings)
+
+    @Volatile
+    private var indexTimeout = INDEX_TIMEOUT.get(settings)
+
+    @Volatile
+    private var maxActionThrottle = MAX_ACTION_THROTTLE_VALUE.get(settings)
+
+    @Volatile
+    private var allowList = ALLOW_LIST.get(settings)
+
+    @Volatile
+    override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+
+    init {
+        clusterService.clusterSettings.addSettingsUpdateConsumer(ALERTING_MAX_MONITORS) { maxMonitors = it }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(REQUEST_TIMEOUT) { requestTimeout = it }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(INDEX_TIMEOUT) { indexTimeout = it }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(MAX_ACTION_THROTTLE_VALUE) { maxActionThrottle = it }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(ALLOW_LIST) { allowList = it }
+        listenFilterBySettingChange(clusterService)
+    }
+
+    override fun doExecute(task: Task, request: ActionRequest, actionListener: ActionListener<IndexWorkflowResponse>) {
+        val transformedRequest = request as? IndexWorkflowRequest
+            ?: recreateObject(request, namedWriteableRegistry) {
+                IndexWorkflowRequest(it)
+            }
+
+        val user = readUserFromThreadContext(client)
+
+        if (!validateUserBackendRoles(user, actionListener)) {
+            return
+        }
+
+        if (
+            user != null &&
+            !isAdmin(user) &&
+            transformedRequest.rbacRoles != null
+        ) {
+            if (transformedRequest.rbacRoles?.stream()?.anyMatch { !user.backendRoles.contains(it) } == true) {
+                log.error(
+                    "User specified backend roles, ${transformedRequest.rbacRoles}, " +
+                        "that they don' have access to. User backend roles: ${user.backendRoles}"
+                )
+                actionListener.onFailure(
+                    AlertingException.wrap(
+                        OpenSearchStatusException(
+                            "User specified backend roles that they don't have access to. Contact administrator",
+                            RestStatus.FORBIDDEN
+                        )
+                    )
+                )
+                return
+            } else if (transformedRequest.rbacRoles?.isEmpty() == true) {
+                log.error(
+                    "Non-admin user are not allowed to specify an empty set of backend roles. " +
+                        "Please don't pass in the parameter or pass in at least one backend role."
+                )
+                actionListener.onFailure(
+                    AlertingException.wrap(
+                        OpenSearchStatusException(
+                            "Non-admin user are not allowed to specify an empty set of backend roles.",
+                            RestStatus.FORBIDDEN
+                        )
+                    )
+                )
+                return
+            }
+        }
+        scope.launch {
+            try {
+                validateRequest(client, transformedRequest, user)
+
+                // If the validation was successful - continue with the execution
+                client.threadPool().threadContext.stashContext().use {
+                    IndexWorkflowHandler(client, actionListener, transformedRequest, user).resolveUserAndStart()
+                }
+            } catch (e: Exception) {
+                log.error("Failed to create workflow", e)
+                if (e is IndexNotFoundException) {
+                    actionListener.onFailure(
+                        OpenSearchStatusException(
+                            "Monitors not found",
+                            RestStatus.NOT_FOUND
+                        )
+                    )
+                } else {
+                    actionListener.onFailure(e)
+                }
+            }
+        }
+    }
+
+    /**
+     * Validates the request in several steps
+     * Checks if the user has appropriate backend roles and if he can access the given monitors and it's indices
+     */
+    private suspend fun validateRequest(client: Client, request: IndexWorkflowRequest, user: User?) {
+        if (request.workflow.inputs.isEmpty())
+            throw AlertingException.wrap(IllegalArgumentException("Input list can not be empty."))
+
+        if (request.workflow.inputs.size > 1)
+            throw AlertingException.wrap(IllegalArgumentException("Input list can contain only one element."))
+
+        if (request.workflow.inputs[0] !is CompositeInput)
+            throw AlertingException.wrap(IllegalArgumentException("When creating a workflow input must be CompositeInput"))
+
+        val compositeInput = request.workflow.inputs[0] as CompositeInput
+        val monitorIds = compositeInput.sequence.delegates.stream().map { it.monitorId }.collect(Collectors.toList())
+
+        if (monitorIds.isNullOrEmpty())
+            throw AlertingException.wrap(IllegalArgumentException("Delegates list can not be empty."))
+
+        validateDuplicateDelegateMonitorReferenceExists(monitorIds)
+        validateSequenceOrdering(compositeInput.sequence.delegates)
+        validateChainedMonitorFindings(compositeInput.sequence.delegates)
+
+        val monitors = getDelegateMonitors(user, monitorIds)
+
+        validateDelegateMonitorsExist(monitorIds, monitors)
+        validateChainedMonitorFindingsMonitors(compositeInput.sequence.delegates, monitors)
+
+        val indices = getMonitorIndices(monitors)
+
+        validateIndicesAccess(indices, client)
+    }
+
+    inner class IndexWorkflowHandler(
+        private val client: Client,
+        private val actionListener: ActionListener<IndexWorkflowResponse>,
+        private val request: IndexWorkflowRequest,
+        private val user: User?
+    ) {
+        fun resolveUserAndStart() {
+            scope.launch {
+                if (user == null) {
+                    // Security is disabled, add empty user to Workflow. user is null for older versions.
+                    request.workflow = request.workflow
+                        .copy(user = User("", listOf(), listOf(), listOf()))
+                    start()
+                } else {
+                    request.workflow = request.workflow
+                        .copy(user = User(user.name, user.backendRoles, user.roles, user.customAttNames))
+                    start()
+                }
+            }
+        }
+
+        fun start() {
+            if (!scheduledJobIndices.scheduledJobIndexExists()) {
+                scheduledJobIndices.initScheduledJobIndex(object : ActionListener<CreateIndexResponse> {
+                    override fun onResponse(response: CreateIndexResponse) {
+                        onCreateMappingsResponse(response.isAcknowledged)
+                    }
+
+                    override fun onFailure(t: Exception) {
+                        // https://github.com/opensearch-project/alerting/issues/646
+                        if (ExceptionsHelper.unwrapCause(t) is ResourceAlreadyExistsException) {
+                            scope.launch {
+                                // Wait for the yellow status
+                                val request = ClusterHealthRequest()
+                                    .indices(SCHEDULED_JOBS_INDEX)
+                                    .waitForYellowStatus()
+                                val response: ClusterHealthResponse = client.suspendUntil {
+                                    execute(ClusterHealthAction.INSTANCE, request, it)
+                                }
+                                if (response.isTimedOut) {
+                                    log.error("Workflow creation timeout", t)
+                                    actionListener.onFailure(
+                                        OpenSearchException("Cannot determine that the $SCHEDULED_JOBS_INDEX index is healthy")
+                                    )
+                                }
+                                // Retry mapping of workflow
+                                onCreateMappingsResponse(true)
+                            }
+                        } else {
+                            log.error("Failed to create workflow", t)
+                            actionListener.onFailure(AlertingException.wrap(t))
+                        }
+                    }
+                })
+            } else if (!IndexUtils.scheduledJobIndexUpdated) {
+                IndexUtils.updateIndexMapping(
+                    SCHEDULED_JOBS_INDEX,
+                    ScheduledJobIndices.scheduledJobMappings(), clusterService.state(), client.admin().indices(),
+                    object : ActionListener<AcknowledgedResponse> {
+                        override fun onResponse(response: AcknowledgedResponse) {
+                            onUpdateMappingsResponse(response)
+                        }
+
+                        override fun onFailure(t: Exception) {
+                            log.error("Failed to create workflow", t)
+                            actionListener.onFailure(AlertingException.wrap(t))
+                        }
+                    }
+                )
+            } else {
+                prepareWorkflowIndexing()
+            }
+        }
+
+        /**
+         * This function prepares for indexing a new workflow.
+         * If this is an update request we can simply update the workflow. Otherwise we first check to see how many monitors already exist,
+         * and compare this to the [maxMonitorCount]. Requests that breach this threshold will be rejected.
+         */
+        private fun prepareWorkflowIndexing() {
+            if (request.method == RestRequest.Method.PUT) {
+                scope.launch {
+                    updateWorkflow()
+                }
+            } else {
+                scope.launch {
+                    indexWorkflow()
+                }
+            }
+        }
+
+        private fun onCreateMappingsResponse(isAcknowledged: Boolean) {
+            if (isAcknowledged) {
+                log.info("Created $SCHEDULED_JOBS_INDEX with mappings.")
+                prepareWorkflowIndexing()
+                IndexUtils.scheduledJobIndexUpdated()
+            } else {
+                log.error("Create $SCHEDULED_JOBS_INDEX mappings call not acknowledged.")
+                actionListener.onFailure(
+                    AlertingException.wrap(
+                        OpenSearchStatusException(
+                            "Create $SCHEDULED_JOBS_INDEX mappings call not acknowledged", RestStatus.INTERNAL_SERVER_ERROR
+                        )
+                    )
+                )
+            }
+        }
+
+        private fun onUpdateMappingsResponse(response: AcknowledgedResponse) {
+            if (response.isAcknowledged) {
+                log.info("Updated  $SCHEDULED_JOBS_INDEX with mappings.")
+                IndexUtils.scheduledJobIndexUpdated()
+                prepareWorkflowIndexing()
+            } else {
+                log.error("Update $SCHEDULED_JOBS_INDEX mappings call not acknowledged.")
+                actionListener.onFailure(
+                    AlertingException.wrap(
+                        OpenSearchStatusException(
+                            "Updated $SCHEDULED_JOBS_INDEX mappings call not acknowledged.",
+                            RestStatus.INTERNAL_SERVER_ERROR
+                        )
+                    )
+                )
+            }
+        }
+
+        private suspend fun indexWorkflow() {
+            if (user != null) {
+                val rbacRoles = if (request.rbacRoles == null) user.backendRoles.toSet()
+                else if (!isAdmin(user)) request.rbacRoles?.intersect(user.backendRoles)?.toSet()
+                else request.rbacRoles
+
+                request.workflow = request.workflow.copy(
+                    user = User(user.name, rbacRoles.orEmpty().toList(), user.roles, user.customAttNames)
+                )
+                log.debug("Created workflow's backend roles: $rbacRoles")
+            }
+
+            val indexRequest = IndexRequest(SCHEDULED_JOBS_INDEX)
+                .setRefreshPolicy(request.refreshPolicy)
+                .source(request.workflow.toXContentWithUser(jsonBuilder(), ToXContent.MapParams(mapOf("with_type" to "true"))))
+                .setIfSeqNo(request.seqNo)
+                .setIfPrimaryTerm(request.primaryTerm)
+                .timeout(indexTimeout)
+
+            try {
+                val indexResponse: IndexResponse = client.suspendUntil { client.index(indexRequest, it) }
+                val failureReasons = checkShardsFailure(indexResponse)
+                if (failureReasons != null) {
+                    log.error("Failed to create workflow: $failureReasons")
+                    actionListener.onFailure(
+                        AlertingException.wrap(OpenSearchStatusException(failureReasons.toString(), indexResponse.status()))
+                    )
+                    return
+                }
+                actionListener.onResponse(
+                    IndexWorkflowResponse(
+                        indexResponse.id, indexResponse.version, indexResponse.seqNo,
+                        indexResponse.primaryTerm, request.workflow.copy(id = indexResponse.id)
+                    )
+                )
+            } catch (t: Exception) {
+                log.error("Failed to index workflow", t)
+                actionListener.onFailure(AlertingException.wrap(t))
+            }
+        }
+
+        private suspend fun updateWorkflow() {
+            val getRequest = GetRequest(SCHEDULED_JOBS_INDEX, request.workflowId)
+            try {
+                val getResponse: GetResponse = client.suspendUntil { client.get(getRequest, it) }
+                if (!getResponse.isExists) {
+                    actionListener.onFailure(
+                        AlertingException.wrap(
+                            OpenSearchStatusException("Workflow with ${request.workflowId} is not found", RestStatus.NOT_FOUND)
+                        )
+                    )
+                    return
+                }
+                val xcp = XContentHelper.createParser(
+                    xContentRegistry, LoggingDeprecationHandler.INSTANCE,
+                    getResponse.sourceAsBytesRef, XContentType.JSON
+                )
+                val workflow = ScheduledJob.parse(xcp, getResponse.id, getResponse.version) as Workflow
+                onGetResponse(workflow)
+            } catch (t: Exception) {
+                actionListener.onFailure(AlertingException.wrap(t))
+            }
+        }
+
+        private suspend fun onGetResponse(currentWorkflow: Workflow) {
+            if (!checkUserPermissionsWithResource(user, currentWorkflow.user, actionListener, "workfklow", request.workflowId)) {
+                return
+            }
+
+            // If both are enabled, use the current existing monitor enabled time, otherwise the next execution will be
+            // incorrect.
+            if (request.workflow.enabled && currentWorkflow.enabled)
+                request.workflow = request.workflow.copy(enabledTime = currentWorkflow.enabledTime)
+
+            /**
+             * On update workflow check which backend roles to associate to the workflow.
+             * Below are 2 examples of how the logic works
+             *
+             * Example 1, say we have a Workflow with backend roles [a, b, c, d] associated with it.
+             * If I'm User A (non-admin user) and I have backend roles [a, b, c] associated with me and I make a request to update
+             * the Workflow's backend roles to [a, b]. This would mean that the roles to remove are [c] and the roles to add are [a, b].
+             * The Workflow's backend roles would then be [a, b, d].
+             *
+             * Example 2, say we have a Workflow with backend roles [a, b, c, d] associated with it.
+             * If I'm User A (admin user) and I have backend roles [a, b, c] associated with me and I make a request to update
+             * the Workflow's backend roles to [a, b]. This would mean that the roles to remove are [c, d] and the roles to add are [a, b].
+             * The Workflow's backend roles would then be [a, b].
+             */
+            if (user != null) {
+                if (request.rbacRoles != null) {
+                    if (isAdmin(user)) {
+                        request.workflow = request.workflow.copy(
+                            user = User(user.name, request.rbacRoles, user.roles, user.customAttNames)
+                        )
+                    } else {
+                        // rolesToRemove: these are the backend roles to remove from the monitor
+                        val rolesToRemove = user.backendRoles - request.rbacRoles.orEmpty()
+                        // remove the monitor's roles with rolesToRemove and add any roles passed into the request.rbacRoles
+                        val updatedRbac = currentWorkflow.user?.backendRoles.orEmpty() - rolesToRemove + request.rbacRoles.orEmpty()
+                        request.workflow = request.workflow.copy(
+                            user = User(user.name, updatedRbac, user.roles, user.customAttNames)
+                        )
+                    }
+                } else {
+                    request.workflow = request.workflow
+                        .copy(user = User(user.name, currentWorkflow.user!!.backendRoles, user.roles, user.customAttNames))
+                }
+                log.debug("Update workflow backend roles to: ${request.workflow.user?.backendRoles}")
+            }
+
+            request.workflow = request.workflow.copy(schemaVersion = IndexUtils.scheduledJobIndexSchemaVersion)
+            val indexRequest = IndexRequest(SCHEDULED_JOBS_INDEX)
+                .setRefreshPolicy(request.refreshPolicy)
+                .source(request.workflow.toXContentWithUser(jsonBuilder(), ToXContent.MapParams(mapOf("with_type" to "true"))))
+                .id(request.workflowId)
+                .setIfSeqNo(request.seqNo)
+                .setIfPrimaryTerm(request.primaryTerm)
+                .timeout(indexTimeout)
+
+            try {
+                val indexResponse: IndexResponse = client.suspendUntil { client.index(indexRequest, it) }
+                val failureReasons = checkShardsFailure(indexResponse)
+                if (failureReasons != null) {
+                    actionListener.onFailure(
+                        AlertingException.wrap(OpenSearchStatusException(failureReasons.toString(), indexResponse.status()))
+                    )
+                    return
+                }
+                actionListener.onResponse(
+                    IndexWorkflowResponse(
+                        indexResponse.id, indexResponse.version, indexResponse.seqNo,
+                        indexResponse.primaryTerm, request.workflow.copy(id = currentWorkflow.id)
+                    )
+                )
+            } catch (t: Exception) {
+                actionListener.onFailure(AlertingException.wrap(t))
+            }
+        }
+
+        private fun checkShardsFailure(response: IndexResponse): String? {
+            val failureReasons = StringBuilder()
+            if (response.shardInfo.failed > 0) {
+                response.shardInfo.failures.forEach { entry ->
+                    failureReasons.append(entry.reason())
+                }
+                return failureReasons.toString()
+            }
+            return null
+        }
+    }
+
+    private fun validateChainedMonitorFindings(delegates: List<Delegate>) {
+        val monitorIdOrderMap: Map<String, Int> = delegates.associate { it.monitorId to it.order }
+        delegates.forEach {
+            if (it.chainedMonitorFindings != null) {
+                if (monitorIdOrderMap.containsKey(it.chainedMonitorFindings!!.monitorId) == false) {
+                    throw AlertingException.wrap(
+                        IllegalArgumentException(
+                            "Chained Findings Monitor ${it.chainedMonitorFindings!!.monitorId} doesn't exist in sequence"
+                        )
+                    )
+                }
+                if (it.order <= monitorIdOrderMap[it.chainedMonitorFindings!!.monitorId]!!) {
+                    throw AlertingException.wrap(
+                        IllegalArgumentException(
+                            "Chained Findings Monitor ${it.chainedMonitorFindings!!.monitorId} should be executed before monitor ${it.monitorId}"
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    private fun validateChainedMonitorFindingsMonitors(delegates: List<Delegate>, monitorDelegates: List<Monitor>) {
+        val monitorsById = monitorDelegates.associateBy { it.id }
+        delegates.forEach {
+            if (it.chainedMonitorFindings != null) {
+                val chainedFindingMonitor = monitorsById[it.chainedMonitorFindings!!.monitorId] ?: throw AlertingException.wrap(
+                    IllegalArgumentException("Chained finding monitor doesn't exist")
+                )
+
+                if (chainedFindingMonitor.isQueryLevelMonitor()) {
+                    throw AlertingException.wrap(IllegalArgumentException("Query level monitor can't be part of chained findings"))
+                }
+            }
+        }
+    }
+
+    private fun validateSequenceOrdering(delegates: List<Delegate>) {
+        val orderSet = delegates.stream().filter { it.order > 0 }.map { it.order }.collect(Collectors.toSet())
+        if (orderSet.size != delegates.size) {
+            throw AlertingException.wrap(IllegalArgumentException("Sequence ordering of delegate monitor shouldn't contain duplicate order values"))
+        }
+    }
+
+    private fun validateDuplicateDelegateMonitorReferenceExists(
+        monitorIds: MutableList<String>
+    ) {
+        if (monitorIds.toSet().size != monitorIds.size) {
+            throw AlertingException.wrap(IllegalArgumentException("Duplicate delegates not allowed"))
+        }
+    }
+
+    private fun validateDelegateMonitorsExist(
+        monitorIds: List<String>,
+        delegateMonitors: List<Monitor>
+    ) {
+        val reqMonitorIds: MutableList<String> = monitorIds as MutableList<String>
+        delegateMonitors.forEach {
+            reqMonitorIds.remove(it.id)
+        }
+        if (reqMonitorIds.isNotEmpty()) {
+            throw AlertingException.wrap(IllegalArgumentException(("${reqMonitorIds.joinToString()} are not valid monitor ids")))
+        }
+    }
+
+    /**
+     * Returns monitors for the given ids if user has an access
+     */
+    private suspend fun getDelegateMonitors(
+        user: User?,
+        monitorIds: MutableList<String>
+    ): List<Monitor> {
+        val query = QueryBuilders.boolQuery().filter(QueryBuilders.termsQuery("_id", monitorIds))
+        val searchSource = SearchSourceBuilder().query(query)
+        val monitorSearchRequest = SearchRequest(SCHEDULED_JOBS_INDEX).source(searchSource)
+        // TODO - Add secure tests once the Rest Action is created
+        if (user != null && filterByEnabled) {
+            addFilter(user, monitorSearchRequest.source(), "monitor.user.backend_roles.keyword")
+        }
+
+        val searchMonitorResponse: SearchResponse = client.suspendUntil { client.search(monitorSearchRequest, it) }
+
+        if (searchMonitorResponse.status() != RestStatus.OK) {
+            throw AlertingException.wrap(
+                OpenSearchStatusException(
+                    "User doesn't have read permissions for one or more configured monitors ${monitorIds.joinToString()}",
+                    RestStatus.FORBIDDEN
+                )
+            )
+        }
+        if (searchMonitorResponse.isTimedOut) {
+            throw OpenSearchException("Cannot determine that the $SCHEDULED_JOBS_INDEX index is healthy")
+        }
+        val monitors = mutableListOf<Monitor>()
+        for (hit in searchMonitorResponse.hits) {
+            XContentType.JSON.xContent().createParser(
+                xContentRegistry,
+                LoggingDeprecationHandler.INSTANCE, hit.sourceAsString
+            ).use { hitsParser ->
+                val monitor = ScheduledJob.parse(hitsParser, hit.id, hit.version) as Monitor
+                monitors.add(monitor)
+            }
+        }
+        return monitors
+    }
+
+    /**
+     * Extract indices from monitors
+     */
+    private fun getMonitorIndices(monitors: List<Monitor>): MutableList<String> {
+        val indices = mutableListOf<String>()
+
+        val searchInputs =
+            monitors.flatMap { monitor -> monitor.inputs.filter { it.name() == SearchInput.SEARCH_FIELD || it.name() == DocLevelMonitorInput.DOC_LEVEL_INPUT_FIELD } }
+        searchInputs.forEach {
+            val inputIndices = if (it.name() == SearchInput.SEARCH_FIELD) (it as SearchInput).indices
+            else (it as DocLevelMonitorInput).indices
+            indices.addAll(inputIndices)
+        }
+        return indices
+    }
+
+    /**
+     * Checks if the user can access the monitor indices
+     */
+    private suspend fun validateIndicesAccess(
+        indices: MutableList<String>,
+        client: Client,
+    ) {
+        val indicesSearchRequest = SearchRequest().indices(*indices.toTypedArray())
+            .source(SearchSourceBuilder.searchSource().size(1).query(QueryBuilders.matchAllQuery()))
+
+        val indicesSearchResponse: SearchResponse = client.suspendUntil { client.search(indicesSearchRequest, it) }
+        if (indicesSearchResponse.status() != RestStatus.OK) {
+            throw AlertingException.wrap(
+                OpenSearchStatusException(
+                    "User doesn't have read permissions for one or more configured index ${indices.joinToString()}",
+                    RestStatus.FORBIDDEN
+                )
+            )
+        }
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
@@ -41,8 +41,6 @@ import org.opensearch.common.inject.Inject
 import org.opensearch.common.io.stream.NamedWriteableRegistry
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
-import org.opensearch.common.xcontent.NamedXContentRegistry
-import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentFactory.jsonBuilder
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
@@ -59,6 +57,8 @@ import org.opensearch.commons.alerting.model.SearchInput
 import org.opensearch.commons.alerting.model.Workflow
 import org.opensearch.commons.authuser.User
 import org.opensearch.commons.utils.recreateObject
+import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.core.xcontent.ToXContent
 import org.opensearch.index.IndexNotFoundException
 import org.opensearch.index.query.QueryBuilders
 import org.opensearch.rest.RestRequest

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
@@ -45,6 +45,8 @@ fun Destination.isTestAction(): Boolean = this.type == DestinationType.TEST_ACTI
 
 fun Monitor.isDocLevelMonitor(): Boolean = this.monitorType == Monitor.MonitorType.DOC_LEVEL_MONITOR
 
+fun Monitor.isQueryLevelMonitor(): Boolean = this.monitorType == Monitor.MonitorType.QUERY_LEVEL_MONITOR
+
 /**
  * Since buckets can have multi-value keys, this converts the bucket key values to a string that can be used
  * as the key for a HashMap to easily retrieve [AggregationResultBucket] based on the bucket key values.

--- a/alerting/src/main/kotlin/org/opensearch/alerting/workflow/CompositeWorkflowRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/workflow/CompositeWorkflowRunner.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.workflow
+
+import org.apache.logging.log4j.LogManager
+import org.opensearch.alerting.BucketLevelMonitorRunner
+import org.opensearch.alerting.DocumentLevelMonitorRunner
+import org.opensearch.alerting.MonitorRunnerExecutionContext
+import org.opensearch.alerting.QueryLevelMonitorRunner
+import org.opensearch.alerting.WorkflowMetadataService
+import org.opensearch.alerting.model.MonitorRunResult
+import org.opensearch.alerting.model.WorkflowRunResult
+import org.opensearch.alerting.util.AlertingException
+import org.opensearch.alerting.util.isDocLevelMonitor
+import org.opensearch.alerting.util.isQueryLevelMonitor
+import org.opensearch.commons.alerting.model.CompositeInput
+import org.opensearch.commons.alerting.model.Delegate
+import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.Workflow
+import org.opensearch.commons.alerting.util.isBucketLevelMonitor
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+object CompositeWorkflowRunner : WorkflowRunner() {
+    private val logger = LogManager.getLogger(javaClass)
+
+    override suspend fun runWorkflow(
+        workflow: Workflow,
+        monitorCtx: MonitorRunnerExecutionContext,
+        periodStart: Instant,
+        periodEnd: Instant,
+        dryRun: Boolean
+    ): WorkflowRunResult {
+        val workflowExecutionStartTime = Instant.now()
+
+        val isTempWorkflow = dryRun || workflow.id == Workflow.NO_ID
+
+        val executionId = generateExecutionId(isTempWorkflow, workflow)
+
+        val (workflowMetadata, _) = WorkflowMetadataService.getOrCreateWorkflowMetadata(
+            workflow = workflow,
+            skipIndex = isTempWorkflow,
+            executionId = executionId
+        )
+
+        var workflowResult = WorkflowRunResult(mutableListOf(), workflowExecutionStartTime, null, executionId)
+
+        logger.debug("Workflow ${workflow.id} in $executionId execution is running")
+        val delegates = (workflow.inputs[0] as CompositeInput).sequence.delegates.sortedBy { it.order }
+        var monitors: List<Monitor>
+
+        try {
+            monitors = monitorCtx.workflowService!!.getMonitorsById(delegates.map { it.monitorId }, delegates.size)
+        } catch (e: Exception) {
+            logger.error("Failed getting workflow delegates. Error: ${e.message}", e)
+            return workflowResult.copy(error = AlertingException.wrap(e))
+        }
+        // Validate the monitors size
+        validateMonitorSize(delegates, monitors, workflow)
+
+        val monitorsById = monitors.associateBy { it.id }
+        val resultList = mutableListOf<MonitorRunResult<*>>()
+        var lastErrorDelegateRun: Exception? = null
+
+        for (delegate in delegates) {
+            var indexToDocIds = mapOf<String, List<String>>()
+            var delegateMonitor: Monitor
+            delegateMonitor = monitorsById[delegate.monitorId]
+                ?: throw AlertingException.wrap(
+                    IllegalStateException("Delegate monitor not found ${delegate.monitorId} for the workflow $workflow.id")
+                )
+            if (delegate.chainedMonitorFindings != null) {
+                val chainedMonitor = monitorsById[delegate.chainedMonitorFindings!!.monitorId]
+                    ?: throw AlertingException.wrap(
+                        IllegalStateException("Chained finding monitor not found ${delegate.monitorId} for the workflow $workflow.id")
+                    )
+
+                try {
+                    indexToDocIds = monitorCtx.workflowService!!.getFindingDocIdsByExecutionId(chainedMonitor, executionId)
+                } catch (e: Exception) {
+                    logger.error("Failed to execute workflow. Error: ${e.message}", e)
+                    return workflowResult.copy(error = AlertingException.wrap(e))
+                }
+            }
+
+            val workflowRunContext = WorkflowRunContext(
+                workflowId = workflowMetadata.workflowId,
+                workflowMetadataId = workflowMetadata.id,
+                chainedMonitorId = delegate.chainedMonitorFindings?.monitorId,
+                executionId = executionId,
+                matchingDocIdsPerIndex = indexToDocIds
+            )
+
+            var delegateRunResult: MonitorRunResult<*>?
+            try {
+                delegateRunResult = if (delegateMonitor.isBucketLevelMonitor()) {
+                    BucketLevelMonitorRunner.runMonitor(
+                        delegateMonitor,
+                        monitorCtx,
+                        periodStart,
+                        periodEnd,
+                        dryRun,
+                        workflowRunContext
+                    )
+                } else if (delegateMonitor.isDocLevelMonitor()) {
+                    DocumentLevelMonitorRunner.runMonitor(
+                        delegateMonitor,
+                        monitorCtx,
+                        periodStart,
+                        periodEnd,
+                        dryRun,
+                        workflowRunContext
+                    )
+                } else if (delegateMonitor.isQueryLevelMonitor()) {
+                    QueryLevelMonitorRunner.runMonitor(
+                        delegateMonitor,
+                        monitorCtx,
+                        periodStart,
+                        periodEnd,
+                        dryRun,
+                        workflowRunContext
+                    )
+                } else {
+                    throw AlertingException.wrap(
+                        IllegalStateException("Unsupported monitor type")
+                    )
+                }
+            } catch (ex: Exception) {
+                logger.error("Error executing workflow delegate. Error: ${ex.message}", ex)
+                lastErrorDelegateRun = AlertingException.wrap(ex)
+                continue
+            }
+            if (delegateRunResult != null) resultList.add(delegateRunResult)
+        }
+        logger.debug("Workflow ${workflow.id} in $executionId finished")
+        // Update metadata only if the workflow is not temp
+        if (!isTempWorkflow) {
+            WorkflowMetadataService.upsertWorkflowMetadata(
+                workflowMetadata.copy(latestRunTime = workflowExecutionStartTime, latestExecutionId = executionId),
+                true
+            )
+        }
+
+        return workflowResult.copy(workflowRunResult = resultList, executionEndTime = Instant.now(), error = lastErrorDelegateRun)
+    }
+
+    private fun generateExecutionId(
+        isTempWorkflow: Boolean,
+        workflow: Workflow,
+    ): String {
+        val randomPart = "${LocalDateTime.now(ZoneOffset.UTC)}${UUID.randomUUID()}"
+        return if (isTempWorkflow) randomPart else workflow.id.plus(randomPart)
+    }
+
+    private fun validateMonitorSize(
+        delegates: List<Delegate>,
+        monitors: List<Monitor>,
+        workflow: Workflow,
+    ) {
+        if (delegates.size != monitors.size) {
+            val diffMonitorIds = delegates.map { it.monitorId }.minus(monitors.map { it.id }.toSet()).joinToString()
+            logger.error("Delegate monitors don't exist $diffMonitorIds for the workflow $workflow.id")
+            throw AlertingException.wrap(
+                IllegalStateException("Delegate monitors don't exist $diffMonitorIds for the workflow $workflow.id")
+            )
+        }
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/workflow/WorkflowRunContext.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/workflow/WorkflowRunContext.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.workflow
+
+data class WorkflowRunContext(
+    // In case of dry run it's random generated id, while in other cases it's workflowId
+    val workflowId: String,
+    val workflowMetadataId: String,
+    val chainedMonitorId: String?,
+    val executionId: String,
+    val matchingDocIdsPerIndex: Map<String, List<String>>
+)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/workflow/WorkflowRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/workflow/WorkflowRunner.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.workflow
+
+import org.opensearch.alerting.MonitorRunnerExecutionContext
+import org.opensearch.alerting.model.WorkflowRunResult
+import org.opensearch.commons.alerting.model.Workflow
+import java.time.Instant
+
+abstract class WorkflowRunner {
+    abstract suspend fun runWorkflow(
+        workflow: Workflow,
+        monitorCtx: MonitorRunnerExecutionContext,
+        periodStart: Instant,
+        periodEnd: Instant,
+        dryRun: Boolean
+    ): WorkflowRunResult
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/workflow/WorkflowRunnerService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/workflow/WorkflowRunnerService.kt
@@ -1,0 +1,252 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.workflow
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import org.apache.logging.log4j.LogManager
+import org.opensearch.action.bulk.BackoffPolicy
+import org.opensearch.alerting.AlertService
+import org.opensearch.alerting.InputService
+import org.opensearch.alerting.MonitorRunnerExecutionContext
+import org.opensearch.alerting.TriggerService
+import org.opensearch.alerting.WorkflowService
+import org.opensearch.alerting.alerts.AlertIndices
+import org.opensearch.alerting.core.JobRunner
+import org.opensearch.alerting.model.WorkflowRunResult
+import org.opensearch.alerting.model.destination.DestinationContextFactory
+import org.opensearch.alerting.script.TriggerExecutionContext
+import org.opensearch.alerting.settings.AlertingSettings.Companion.ALERT_BACKOFF_COUNT
+import org.opensearch.alerting.settings.AlertingSettings.Companion.ALERT_BACKOFF_MILLIS
+import org.opensearch.alerting.settings.AlertingSettings.Companion.INDEX_TIMEOUT
+import org.opensearch.alerting.settings.AlertingSettings.Companion.MAX_ACTIONABLE_ALERT_COUNT
+import org.opensearch.alerting.settings.AlertingSettings.Companion.MOVE_ALERTS_BACKOFF_COUNT
+import org.opensearch.alerting.settings.AlertingSettings.Companion.MOVE_ALERTS_BACKOFF_MILLIS
+import org.opensearch.alerting.settings.DestinationSettings.Companion.ALLOW_LIST
+import org.opensearch.alerting.settings.DestinationSettings.Companion.HOST_DENY_LIST
+import org.opensearch.alerting.settings.DestinationSettings.Companion.loadDestinationSettings
+import org.opensearch.alerting.util.DocLevelMonitorQueries
+import org.opensearch.client.Client
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.component.AbstractLifecycleComponent
+import org.opensearch.common.settings.Settings
+import org.opensearch.commons.alerting.model.Alert
+import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.ScheduledJob
+import org.opensearch.commons.alerting.model.Workflow
+import org.opensearch.commons.alerting.model.action.Action
+import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.script.Script
+import org.opensearch.script.ScriptService
+import org.opensearch.script.TemplateScript
+import org.opensearch.threadpool.ThreadPool
+import java.time.Instant
+import kotlin.coroutines.CoroutineContext
+
+object WorkflowRunnerService : JobRunner, CoroutineScope, AbstractLifecycleComponent() {
+
+    private val logger = LogManager.getLogger(javaClass)
+
+    var monitorCtx: MonitorRunnerExecutionContext = MonitorRunnerExecutionContext()
+    private lateinit var runnerSupervisor: Job
+    override val coroutineContext: CoroutineContext
+        get() = Dispatchers.Default + runnerSupervisor
+
+    fun registerClusterService(clusterService: ClusterService): WorkflowRunnerService {
+        monitorCtx.clusterService = clusterService
+        return this
+    }
+
+    fun registerClient(client: Client): WorkflowRunnerService {
+        monitorCtx.client = client
+        return this
+    }
+
+    fun registerNamedXContentRegistry(xContentRegistry: NamedXContentRegistry): WorkflowRunnerService {
+        monitorCtx.xContentRegistry = xContentRegistry
+        return this
+    }
+
+    fun registerScriptService(scriptService: ScriptService): WorkflowRunnerService {
+        monitorCtx.scriptService = scriptService
+        return this
+    }
+
+    fun registerIndexNameExpressionResolver(indexNameExpressionResolver: IndexNameExpressionResolver): WorkflowRunnerService {
+        monitorCtx.indexNameExpressionResolver = indexNameExpressionResolver
+        return this
+    }
+
+    fun registerSettings(settings: Settings): WorkflowRunnerService {
+        monitorCtx.settings = settings
+        return this
+    }
+
+    fun registerThreadPool(threadPool: ThreadPool): WorkflowRunnerService {
+        monitorCtx.threadPool = threadPool
+        return this
+    }
+
+    fun registerAlertIndices(alertIndices: AlertIndices): WorkflowRunnerService {
+        monitorCtx.alertIndices = alertIndices
+        return this
+    }
+
+    fun registerInputService(inputService: InputService): WorkflowRunnerService {
+        monitorCtx.inputService = inputService
+        return this
+    }
+
+    fun registerWorkflowService(workflowService: WorkflowService): WorkflowRunnerService {
+        monitorCtx.workflowService = workflowService
+        return this
+    }
+
+    fun registerTriggerService(triggerService: TriggerService): WorkflowRunnerService {
+        monitorCtx.triggerService = triggerService
+        return this
+    }
+
+    fun registerAlertService(alertService: AlertService): WorkflowRunnerService {
+        monitorCtx.alertService = alertService
+        return this
+    }
+
+    fun registerDocLevelMonitorQueries(docLevelMonitorQueries: DocLevelMonitorQueries): WorkflowRunnerService {
+        monitorCtx.docLevelMonitorQueries = docLevelMonitorQueries
+        return this
+    }
+
+    // Must be called after registerClusterService and registerSettings in AlertingPlugin
+    fun registerConsumers(): WorkflowRunnerService {
+        monitorCtx.retryPolicy = BackoffPolicy.constantBackoff(
+            ALERT_BACKOFF_MILLIS.get(monitorCtx.settings),
+            ALERT_BACKOFF_COUNT.get(monitorCtx.settings)
+        )
+        monitorCtx.clusterService!!.clusterSettings.addSettingsUpdateConsumer(ALERT_BACKOFF_MILLIS, ALERT_BACKOFF_COUNT) { millis, count ->
+            monitorCtx.retryPolicy = BackoffPolicy.constantBackoff(millis, count)
+        }
+
+        monitorCtx.moveAlertsRetryPolicy =
+            BackoffPolicy.exponentialBackoff(
+                MOVE_ALERTS_BACKOFF_MILLIS.get(monitorCtx.settings),
+                MOVE_ALERTS_BACKOFF_COUNT.get(monitorCtx.settings)
+            )
+        monitorCtx.clusterService!!.clusterSettings.addSettingsUpdateConsumer(MOVE_ALERTS_BACKOFF_MILLIS, MOVE_ALERTS_BACKOFF_COUNT) {
+                millis, count ->
+            monitorCtx.moveAlertsRetryPolicy = BackoffPolicy.exponentialBackoff(millis, count)
+        }
+
+        monitorCtx.allowList = ALLOW_LIST.get(monitorCtx.settings)
+        monitorCtx.clusterService!!.clusterSettings.addSettingsUpdateConsumer(ALLOW_LIST) {
+            monitorCtx.allowList = it
+        }
+
+        // Host deny list is not a dynamic setting so no consumer is registered but the variable is set here
+        monitorCtx.hostDenyList = HOST_DENY_LIST.get(monitorCtx.settings)
+
+        monitorCtx.maxActionableAlertCount = MAX_ACTIONABLE_ALERT_COUNT.get(monitorCtx.settings)
+        monitorCtx.clusterService!!.clusterSettings.addSettingsUpdateConsumer(MAX_ACTIONABLE_ALERT_COUNT) {
+            monitorCtx.maxActionableAlertCount = it
+        }
+
+        monitorCtx.indexTimeout = INDEX_TIMEOUT.get(monitorCtx.settings)
+
+        return this
+    }
+
+    // To be safe, call this last as it depends on a number of other components being registered beforehand (client, settings, etc.)
+    fun registerDestinationSettings(): WorkflowRunnerService {
+        monitorCtx.destinationSettings = loadDestinationSettings(monitorCtx.settings!!)
+        monitorCtx.destinationContextFactory =
+            DestinationContextFactory(monitorCtx.client!!, monitorCtx.xContentRegistry!!, monitorCtx.destinationSettings!!)
+        return this
+    }
+
+    // Updates destination settings when the reload API is called so that new keystore values are visible
+    fun reloadDestinationSettings(settings: Settings) {
+        monitorCtx.destinationSettings = loadDestinationSettings(settings)
+
+        // Update destinationContextFactory as well since destinationSettings has been updated
+        monitorCtx.destinationContextFactory!!.updateDestinationSettings(monitorCtx.destinationSettings!!)
+    }
+
+    override fun doStart() {
+        runnerSupervisor = SupervisorJob()
+    }
+
+    override fun doStop() {
+        runnerSupervisor.cancel()
+    }
+
+    override fun doClose() { }
+
+    override fun postIndex(job: ScheduledJob) {
+    }
+
+    override fun postDelete(jobId: String) {
+    }
+
+    override fun runJob(job: ScheduledJob, periodStart: Instant, periodEnd: Instant) {
+        if (job !is Workflow) {
+            throw IllegalArgumentException("Invalid job type")
+        }
+        launch {
+            runJob(job, periodStart, periodEnd, false)
+        }
+    }
+
+    suspend fun runJob(job: ScheduledJob, periodStart: Instant, periodEnd: Instant, dryrun: Boolean): WorkflowRunResult {
+        val workflow = job as Workflow
+        return CompositeWorkflowRunner.runWorkflow(workflow, monitorCtx, periodStart, periodEnd, dryrun)
+    }
+
+    // TODO: See if we can move below methods (or few of these) to a common utils
+    internal fun getRolesForMonitor(monitor: Monitor): List<String> {
+        /*
+         * We need to handle 3 cases:
+         * 1. Monitors created by older versions and never updated. These monitors wont have User details in the
+         * monitor object. `monitor.user` will be null. Insert `all_access, AmazonES_all_access` role.
+         * 2. Monitors are created when security plugin is disabled, these will have empty User object.
+         * (`monitor.user.name`, `monitor.user.roles` are empty )
+         * 3. Monitors are created when security plugin is enabled, these will have an User object.
+         */
+        return if (monitor.user == null) {
+            // fixme: discuss and remove hardcoded to settings?
+            // TODO: Remove "AmazonES_all_access" role?
+            monitorCtx.settings!!.getAsList("", listOf("all_access", "AmazonES_all_access"))
+        } else {
+            monitor.user!!.roles
+        }
+    }
+
+    // TODO: Can this be updated to just use 'Instant.now()'?
+    //  'threadPool.absoluteTimeInMillis()' is referring to a cached value of System.currentTimeMillis() that by default updates every 200ms
+    internal fun currentTime() = Instant.ofEpochMilli(monitorCtx.threadPool!!.absoluteTimeInMillis())
+
+    internal fun isActionActionable(action: Action, alert: Alert?): Boolean {
+        if (alert == null || action.throttle == null) {
+            return true
+        }
+        if (action.throttleEnabled) {
+            val result = alert.actionExecutionResults.firstOrNull { r -> r.actionId == action.id }
+            val lastExecutionTime: Instant? = result?.lastExecutionTime
+            val throttledTimeBound = currentTime().minus(action.throttle!!.value.toLong(), action.throttle!!.unit)
+            return (lastExecutionTime == null || lastExecutionTime.isBefore(throttledTimeBound))
+        }
+        return true
+    }
+
+    internal fun compileTemplate(template: Script, ctx: TriggerExecutionContext): String {
+        return monitorCtx.scriptService!!.compile(template, TemplateScript.CONTEXT)
+            .newInstance(template.params + mapOf("ctx" to ctx.asTemplateArg()))
+            .execute()
+    }
+}

--- a/alerting/src/main/resources/org/opensearch/alerting/alerts/finding_mapping.json
+++ b/alerting/src/main/resources/org/opensearch/alerting/alerts/finding_mapping.json
@@ -60,6 +60,9 @@
           "type" : "keyword"
         }
       }
+    },
+    "execution_id": {
+      "type": "keyword"
     }
   }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
@@ -252,7 +252,10 @@ fun randomWorkflow(
         enabledTime = enabledTime,
         workflowType = WorkflowType.COMPOSITE,
         user = user,
-        inputs = listOf(CompositeInput(Sequence(delegates)))
+        inputs = listOf(CompositeInput(Sequence(delegates))),
+        version = -1L,
+        schemaVersion = 0,
+        triggers = emptyList(),
     )
 }
 
@@ -275,7 +278,10 @@ fun randomWorkflowWithDelegates(
         enabledTime = enabledTime,
         workflowType = WorkflowType.COMPOSITE,
         user = user,
-        inputs = listOf(CompositeInput(Sequence(delegates)))
+        inputs = listOf(CompositeInput(Sequence(delegates))),
+        version = -1L,
+        schemaVersion = 0,
+        triggers = emptyList()
     )
 }
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
@@ -35,8 +35,11 @@ import org.opensearch.commons.alerting.model.ActionExecutionResult
 import org.opensearch.commons.alerting.model.AggregationResultBucket
 import org.opensearch.commons.alerting.model.Alert
 import org.opensearch.commons.alerting.model.BucketLevelTrigger
+import org.opensearch.commons.alerting.model.ChainedMonitorFindings
 import org.opensearch.commons.alerting.model.ClusterMetricsInput
+import org.opensearch.commons.alerting.model.CompositeInput
 import org.opensearch.commons.alerting.model.DataSources
+import org.opensearch.commons.alerting.model.Delegate
 import org.opensearch.commons.alerting.model.DocLevelMonitorInput
 import org.opensearch.commons.alerting.model.DocLevelQuery
 import org.opensearch.commons.alerting.model.DocumentLevelTrigger
@@ -47,7 +50,10 @@ import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.QueryLevelTrigger
 import org.opensearch.commons.alerting.model.Schedule
 import org.opensearch.commons.alerting.model.SearchInput
+import org.opensearch.commons.alerting.model.Sequence
 import org.opensearch.commons.alerting.model.Trigger
+import org.opensearch.commons.alerting.model.Workflow
+import org.opensearch.commons.alerting.model.Workflow.WorkflowType
 import org.opensearch.commons.alerting.model.action.Action
 import org.opensearch.commons.alerting.model.action.ActionExecutionPolicy
 import org.opensearch.commons.alerting.model.action.ActionExecutionScope
@@ -215,6 +221,61 @@ fun randomDocumentLevelMonitor(
         name = name, monitorType = Monitor.MonitorType.DOC_LEVEL_MONITOR, enabled = enabled, inputs = inputs,
         schedule = schedule, triggers = triggers, enabledTime = enabledTime, lastUpdateTime = lastUpdateTime, user = user,
         uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf(), dataSources = dataSources, owner = owner
+    )
+}
+
+fun randomWorkflow(
+    id: String = Workflow.NO_ID,
+    monitorIds: List<String>,
+    name: String = OpenSearchRestTestCase.randomAlphaOfLength(10),
+    user: User? = randomUser(),
+    schedule: Schedule = IntervalSchedule(interval = 5, unit = ChronoUnit.MINUTES),
+    enabled: Boolean = randomBoolean(),
+    enabledTime: Instant? = if (enabled) Instant.now().truncatedTo(ChronoUnit.MILLIS) else null,
+    lastUpdateTime: Instant = Instant.now().truncatedTo(ChronoUnit.MILLIS)
+): Workflow {
+    val delegates = mutableListOf<Delegate>()
+    if (!monitorIds.isNullOrEmpty()) {
+        delegates.add(Delegate(1, monitorIds[0]))
+        for (i in 1 until monitorIds.size) {
+            // Order of monitors in workflow will be the same like forwarded meaning that the first monitorId will be used as second monitor chained finding
+            delegates.add(Delegate(i + 1, monitorIds [i], ChainedMonitorFindings(monitorIds[i - 1])))
+        }
+    }
+
+    return Workflow(
+        id = id,
+        name = name,
+        enabled = enabled,
+        schedule = schedule,
+        lastUpdateTime = lastUpdateTime,
+        enabledTime = enabledTime,
+        workflowType = WorkflowType.COMPOSITE,
+        user = user,
+        inputs = listOf(CompositeInput(Sequence(delegates)))
+    )
+}
+
+fun randomWorkflowWithDelegates(
+    id: String = Workflow.NO_ID,
+    delegates: List<Delegate>,
+    name: String = OpenSearchRestTestCase.randomAlphaOfLength(10),
+    user: User? = randomUser(),
+    schedule: Schedule = IntervalSchedule(interval = 5, unit = ChronoUnit.MINUTES),
+    enabled: Boolean = randomBoolean(),
+    enabledTime: Instant? = if (enabled) Instant.now().truncatedTo(ChronoUnit.MILLIS) else null,
+    lastUpdateTime: Instant = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+): Workflow {
+    return Workflow(
+        id = id,
+        name = name,
+        enabled = enabled,
+        schedule = schedule,
+        lastUpdateTime = lastUpdateTime,
+        enabledTime = enabledTime,
+        workflowType = WorkflowType.COMPOSITE,
+        user = user,
+        inputs = listOf(CompositeInput(Sequence(delegates)))
     )
 }
 
@@ -698,4 +759,8 @@ fun assertUserNull(map: Map<String, Any?>) {
 
 fun assertUserNull(monitor: Monitor) {
     assertNull("User is not null", monitor.user)
+}
+
+fun assertUserNull(workflow: Workflow) {
+    assertNull("User is not null", workflow.user)
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/WorkflowMonitorIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/WorkflowMonitorIT.kt
@@ -397,6 +397,257 @@ class WorkflowMonitorIT : WorkflowSingleNodeTestCase() {
         }
     }
 
+    fun `test get workflow`() {
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(DocLevelQuery(query = "source.ip.v6.v1:12345", name = "3"))
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val monitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger),
+        )
+
+        val monitorResponse = createMonitor(monitor)!!
+
+        val workflowRequest = randomWorkflow(
+            monitorIds = listOf(monitorResponse.id)
+        )
+
+        val workflowResponse = upsertWorkflow(workflowRequest)!!
+        assertNotNull("Workflow creation failed", workflowResponse)
+        assertNotNull(workflowResponse.workflow)
+        assertNotEquals("response is missing Id", Monitor.NO_ID, workflowResponse.id)
+        assertTrue("incorrect version", workflowResponse.version > 0)
+
+        val getWorkflowResponse = getWorkflowById(id = workflowResponse.id)
+        assertNotNull(getWorkflowResponse)
+
+        val workflowById = getWorkflowResponse.workflow!!
+        // Verify workflow
+        assertNotEquals("response is missing Id", Monitor.NO_ID, getWorkflowResponse.id)
+        assertTrue("incorrect version", getWorkflowResponse.version > 0)
+        assertEquals("Workflow name not correct", workflowRequest.name, workflowById.name)
+        assertEquals("Workflow owner not correct", workflowRequest.owner, workflowById.owner)
+        assertEquals("Workflow input not correct", workflowRequest.inputs, workflowById.inputs)
+
+        // Delegate verification
+        @Suppress("UNCHECKED_CAST")
+        val delegates = (workflowById.inputs as List<CompositeInput>)[0].sequence.delegates.sortedBy { it.order }
+        assertEquals("Delegates size not correct", 1, delegates.size)
+
+        val delegate = delegates[0]
+        assertNotNull(delegate)
+        assertEquals("Delegate order not correct", 1, delegate.order)
+        assertEquals("Delegate id not correct", monitorResponse.id, delegate.monitorId)
+    }
+
+    fun `test get workflow for invalid id monitor index doesn't exist`() {
+        // Get workflow for non existing workflow id
+        try {
+            getWorkflowById(id = "-1")
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning GetWorkflow Action error ",
+                    it.contains("Workflow not found")
+                )
+            }
+        }
+    }
+
+    fun `test get workflow for invalid id monitor index exists`() {
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(DocLevelQuery(query = "source.ip.v6.v1:12345", name = "3"))
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val monitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger),
+        )
+        createMonitor(monitor)
+        // Get workflow for non existing workflow id
+        try {
+            getWorkflowById(id = "-1")
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning GetWorkflow Action error ",
+                    it.contains("Workflow not found")
+                )
+            }
+        }
+    }
+
+    fun `test delete workflow delegate monitor deleted`() {
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(DocLevelQuery(query = "source.ip.v6.v1:12345", name = "3"))
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+
+        val monitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger)
+        )
+
+        val monitorResponse = createMonitor(monitor)!!
+
+        val workflowRequest = randomWorkflow(
+            monitorIds = listOf(monitorResponse.id)
+        )
+        val workflowResponse = upsertWorkflow(workflowRequest)!!
+        val workflowId = workflowResponse.id
+        val getWorkflowResponse = getWorkflowById(id = workflowResponse.id)
+
+        assertNotNull(getWorkflowResponse)
+        assertEquals(workflowId, getWorkflowResponse.id)
+
+        deleteWorkflow(workflowId, true)
+        // Verify that the workflow is deleted
+        try {
+            getWorkflowById(workflowId)
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning GetWorkflow Action error ",
+                    it.contains("Workflow not found.")
+                )
+            }
+        }
+        // Verify that the monitor is deleted
+        try {
+            getMonitorResponse(monitorResponse.id)
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning GetMonitor Action error ",
+                    it.contains("Monitor not found")
+                )
+            }
+        }
+    }
+
+    fun `test delete workflow delegate monitor not deleted`() {
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(DocLevelQuery(query = "source.ip.v6.v1:12345", name = "3"))
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+
+        val monitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger)
+        )
+
+        val monitorResponse = createMonitor(monitor)!!
+
+        val workflowRequest = randomWorkflow(
+            monitorIds = listOf(monitorResponse.id)
+        )
+        val workflowResponse = upsertWorkflow(workflowRequest)!!
+        val workflowId = workflowResponse.id
+        val getWorkflowResponse = getWorkflowById(id = workflowResponse.id)
+
+        assertNotNull(getWorkflowResponse)
+        assertEquals(workflowId, getWorkflowResponse.id)
+
+        val workflowRequest2 = randomWorkflow(
+            monitorIds = listOf(monitorResponse.id)
+        )
+        val workflowResponse2 = upsertWorkflow(workflowRequest2)!!
+        val workflowId2 = workflowResponse2.id
+        val getWorkflowResponse2 = getWorkflowById(id = workflowResponse2.id)
+
+        assertNotNull(getWorkflowResponse2)
+        assertEquals(workflowId2, getWorkflowResponse2.id)
+
+        try {
+            deleteWorkflow(workflowId, true)
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning GetWorkflow Action error ",
+                    it.contains("[Not allowed to delete ${monitorResponse.id} monitors")
+                )
+            }
+        }
+        val existingMonitor = getMonitorResponse(monitorResponse.id)
+        assertNotNull(existingMonitor)
+    }
+
+    fun `test trying to delete monitor that is part of workflow sequence`() {
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(DocLevelQuery(query = "source.ip.v6.v1:12345", name = "3"))
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+
+        val monitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger)
+        )
+
+        val monitorResponse = createMonitor(monitor)!!
+
+        val workflowRequest = randomWorkflow(
+            monitorIds = listOf(monitorResponse.id)
+        )
+
+        val workflowResponse = upsertWorkflow(workflowRequest)!!
+        val workflowId = workflowResponse.id
+        val getWorkflowResponse = getWorkflowById(id = workflowResponse.id)
+
+        assertNotNull(getWorkflowResponse)
+        assertEquals(workflowId, getWorkflowResponse.id)
+
+        // Verify that the monitor can't be deleted because it's included in the workflow
+        try {
+            deleteMonitor(monitorResponse.id)
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning DeleteMonitor Action error ",
+                    it.contains("Monitor can't be deleted because it is a part of workflow(s)")
+                )
+            }
+        }
+    }
+
+    fun `test delete workflow for invalid id monitor index doesn't exists`() {
+        // Try deleting non-existing workflow
+        try {
+            deleteWorkflow("-1")
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning DeleteWorkflow Action error ",
+                    it.contains("Workflow not found.")
+                )
+            }
+        }
+    }
+
+    fun `test delete workflow for invalid id monitor index exists`() {
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(DocLevelQuery(query = "source.ip.v6.v1:12345", name = "3"))
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+
+        val monitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger),
+        )
+        createMonitor(monitor)
+        // Try deleting non-existing workflow
+        try {
+            deleteWorkflow("-1")
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning DeleteWorkflow Action error ",
+                    it.contains("Workflow not found.")
+                )
+            }
+        }
+    }
+
     fun `test create workflow without delegate failure`() {
         val workflow = randomWorkflow(
             monitorIds = Collections.emptyList()
@@ -664,7 +915,7 @@ class WorkflowMonitorIT : WorkflowSingleNodeTestCase() {
         val queryMonitor = randomQueryLevelMonitor()
         val queryMonitorResponse = createMonitor(queryMonitor)!!
 
-        var workflow = randomWorkflow(
+        val workflow = randomWorkflow(
             monitorIds = listOf(queryMonitorResponse.id, docMonitorResponse.id)
         )
         try {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/WorkflowMonitorIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/WorkflowMonitorIT.kt
@@ -1,0 +1,802 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting
+
+import org.opensearch.alerting.transport.WorkflowSingleNodeTestCase
+import org.opensearch.commons.alerting.model.ChainedMonitorFindings
+import org.opensearch.commons.alerting.model.CompositeInput
+import org.opensearch.commons.alerting.model.DataSources
+import org.opensearch.commons.alerting.model.Delegate
+import org.opensearch.commons.alerting.model.DocLevelMonitorInput
+import org.opensearch.commons.alerting.model.DocLevelQuery
+import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.rest.RestRequest
+import java.util.Collections
+
+class WorkflowMonitorIT : WorkflowSingleNodeTestCase() {
+
+    fun `test create workflow success`() {
+        val docQuery1 = DocLevelQuery(query = "source.ip.v6.v1:12345", name = "3")
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(docQuery1)
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val customFindingsIndex = "custom_findings_index"
+        val customFindingsIndexPattern = "custom_findings_index-1"
+        val customQueryIndex = "custom_alerts_index"
+        val monitor1 = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger),
+            dataSources = DataSources(
+                queryIndex = customQueryIndex,
+                findingsIndex = customFindingsIndex,
+                findingsIndexPattern = customFindingsIndexPattern
+            )
+        )
+
+        val monitor2 = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger),
+            dataSources = DataSources(
+                queryIndex = customQueryIndex,
+                findingsIndex = customFindingsIndex,
+                findingsIndexPattern = customFindingsIndexPattern
+            )
+        )
+
+        val monitorResponse1 = createMonitor(monitor1)!!
+        val monitorResponse2 = createMonitor(monitor2)!!
+
+        val workflow = randomWorkflow(
+            monitorIds = listOf(monitorResponse1.id, monitorResponse2.id)
+        )
+
+        val workflowResponse = upsertWorkflow(workflow)!!
+        assertNotNull("Workflow creation failed", workflowResponse)
+        assertNotNull(workflowResponse.workflow)
+        assertNotEquals("response is missing Id", Monitor.NO_ID, workflowResponse.id)
+        assertTrue("incorrect version", workflowResponse.version > 0)
+
+        val workflowById = searchWorkflow(workflowResponse.id)!!
+        assertNotNull(workflowById)
+
+        // Verify workflow
+        assertNotEquals("response is missing Id", Monitor.NO_ID, workflowById.id)
+        assertTrue("incorrect version", workflowById.version > 0)
+        assertEquals("Workflow name not correct", workflow.name, workflowById.name)
+        assertEquals("Workflow owner not correct", workflow.owner, workflowById.owner)
+        assertEquals("Workflow input not correct", workflow.inputs, workflowById.inputs)
+
+        // Delegate verification
+        @Suppress("UNCHECKED_CAST")
+        val delegates = (workflowById.inputs as List<CompositeInput>)[0].sequence.delegates.sortedBy { it.order }
+        assertEquals("Delegates size not correct", 2, delegates.size)
+
+        val delegate1 = delegates[0]
+        assertNotNull(delegate1)
+        assertEquals("Delegate1 order not correct", 1, delegate1.order)
+        assertEquals("Delegate1 id not correct", monitorResponse1.id, delegate1.monitorId)
+
+        val delegate2 = delegates[1]
+        assertNotNull(delegate2)
+        assertEquals("Delegate2 order not correct", 2, delegate2.order)
+        assertEquals("Delegate2 id not correct", monitorResponse2.id, delegate2.monitorId)
+        assertEquals(
+            "Delegate2 Chained finding not correct", monitorResponse1.id, delegate2.chainedMonitorFindings!!.monitorId
+        )
+    }
+
+    fun `test update workflow add monitor success`() {
+        val docQuery1 = DocLevelQuery(query = "source.ip.v6.v1:12345", name = "3")
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(docQuery1)
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val customFindingsIndex = "custom_findings_index"
+        val customFindingsIndexPattern = "custom_findings_index-1"
+        val customQueryIndex = "custom_alerts_index"
+        val monitor1 = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger),
+            dataSources = DataSources(
+                queryIndex = customQueryIndex,
+                findingsIndex = customFindingsIndex,
+                findingsIndexPattern = customFindingsIndexPattern
+            )
+        )
+
+        val monitor2 = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger),
+            dataSources = DataSources(
+                queryIndex = customQueryIndex,
+                findingsIndex = customFindingsIndex,
+                findingsIndexPattern = customFindingsIndexPattern
+            )
+        )
+
+        val monitorResponse1 = createMonitor(monitor1)!!
+        val monitorResponse2 = createMonitor(monitor2)!!
+
+        val workflow = randomWorkflow(
+            monitorIds = listOf(monitorResponse1.id, monitorResponse2.id)
+        )
+
+        val workflowResponse = upsertWorkflow(workflow)!!
+        assertNotNull("Workflow creation failed", workflowResponse)
+        assertNotNull(workflowResponse.workflow)
+        assertNotEquals("response is missing Id", Monitor.NO_ID, workflowResponse.id)
+        assertTrue("incorrect version", workflowResponse.version > 0)
+
+        var workflowById = searchWorkflow(workflowResponse.id)!!
+        assertNotNull(workflowById)
+
+        val monitor3 = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger),
+            dataSources = DataSources(
+                queryIndex = customQueryIndex,
+                findingsIndex = customFindingsIndex,
+                findingsIndexPattern = customFindingsIndexPattern
+            )
+        )
+        val monitorResponse3 = createMonitor(monitor3)!!
+
+        val updatedWorkflowResponse = upsertWorkflow(
+            randomWorkflow(
+                monitorIds = listOf(monitorResponse1.id, monitorResponse2.id, monitorResponse3.id)
+            ),
+            workflowResponse.id,
+            RestRequest.Method.PUT
+        )!!
+
+        assertNotNull("Workflow creation failed", updatedWorkflowResponse)
+        assertNotNull(updatedWorkflowResponse.workflow)
+        assertEquals("Workflow id changed", workflowResponse.id, updatedWorkflowResponse.id)
+        assertTrue("incorrect version", updatedWorkflowResponse.version > 0)
+
+        workflowById = searchWorkflow(updatedWorkflowResponse.id)!!
+
+        // Verify workflow
+        assertNotEquals("response is missing Id", Monitor.NO_ID, workflowById.id)
+        assertTrue("incorrect version", workflowById.version > 0)
+        assertEquals("Workflow name not correct", updatedWorkflowResponse.workflow.name, workflowById.name)
+        assertEquals("Workflow owner not correct", updatedWorkflowResponse.workflow.owner, workflowById.owner)
+        assertEquals("Workflow input not correct", updatedWorkflowResponse.workflow.inputs, workflowById.inputs)
+
+        // Delegate verification
+        @Suppress("UNCHECKED_CAST")
+        val delegates = (workflowById.inputs as List<CompositeInput>)[0].sequence.delegates.sortedBy { it.order }
+        assertEquals("Delegates size not correct", 3, delegates.size)
+
+        val delegate1 = delegates[0]
+        assertNotNull(delegate1)
+        assertEquals("Delegate1 order not correct", 1, delegate1.order)
+        assertEquals("Delegate1 id not correct", monitorResponse1.id, delegate1.monitorId)
+
+        val delegate2 = delegates[1]
+        assertNotNull(delegate2)
+        assertEquals("Delegate2 order not correct", 2, delegate2.order)
+        assertEquals("Delegate2 id not correct", monitorResponse2.id, delegate2.monitorId)
+        assertEquals(
+            "Delegate2 Chained finding not correct", monitorResponse1.id, delegate2.chainedMonitorFindings!!.monitorId
+        )
+
+        val delegate3 = delegates[2]
+        assertNotNull(delegate3)
+        assertEquals("Delegate3 order not correct", 3, delegate3.order)
+        assertEquals("Delegate3 id not correct", monitorResponse3.id, delegate3.monitorId)
+        assertEquals(
+            "Delegate3 Chained finding not correct", monitorResponse2.id, delegate3.chainedMonitorFindings!!.monitorId
+        )
+    }
+
+    fun `test update workflow change order of delegate monitors`() {
+        val docQuery1 = DocLevelQuery(query = "source.ip.v6.v1:12345", name = "3")
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(docQuery1)
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val customFindingsIndex = "custom_findings_index"
+        val customFindingsIndexPattern = "custom_findings_index-1"
+        val customQueryIndex = "custom_alerts_index"
+        val monitor1 = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger),
+            dataSources = DataSources(
+                queryIndex = customQueryIndex,
+                findingsIndex = customFindingsIndex,
+                findingsIndexPattern = customFindingsIndexPattern
+            )
+        )
+
+        val monitor2 = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger),
+            dataSources = DataSources(
+                queryIndex = customQueryIndex,
+                findingsIndex = customFindingsIndex,
+                findingsIndexPattern = customFindingsIndexPattern
+            )
+        )
+
+        val monitorResponse1 = createMonitor(monitor1)!!
+        val monitorResponse2 = createMonitor(monitor2)!!
+
+        val workflow = randomWorkflow(
+            monitorIds = listOf(monitorResponse1.id, monitorResponse2.id)
+        )
+
+        val workflowResponse = upsertWorkflow(workflow)!!
+        assertNotNull("Workflow creation failed", workflowResponse)
+        assertNotNull(workflowResponse.workflow)
+        assertNotEquals("response is missing Id", Monitor.NO_ID, workflowResponse.id)
+        assertTrue("incorrect version", workflowResponse.version > 0)
+
+        var workflowById = searchWorkflow(workflowResponse.id)!!
+        assertNotNull(workflowById)
+
+        val updatedWorkflowResponse = upsertWorkflow(
+            randomWorkflow(
+                monitorIds = listOf(monitorResponse2.id, monitorResponse1.id)
+            ),
+            workflowResponse.id,
+            RestRequest.Method.PUT
+        )!!
+
+        assertNotNull("Workflow creation failed", updatedWorkflowResponse)
+        assertNotNull(updatedWorkflowResponse.workflow)
+        assertEquals("Workflow id changed", workflowResponse.id, updatedWorkflowResponse.id)
+        assertTrue("incorrect version", updatedWorkflowResponse.version > 0)
+
+        workflowById = searchWorkflow(updatedWorkflowResponse.id)!!
+
+        // Verify workflow
+        assertNotEquals("response is missing Id", Monitor.NO_ID, workflowById.id)
+        assertTrue("incorrect version", workflowById.version > 0)
+        assertEquals("Workflow name not correct", updatedWorkflowResponse.workflow.name, workflowById.name)
+        assertEquals("Workflow owner not correct", updatedWorkflowResponse.workflow.owner, workflowById.owner)
+        assertEquals("Workflow input not correct", updatedWorkflowResponse.workflow.inputs, workflowById.inputs)
+
+        // Delegate verification
+        @Suppress("UNCHECKED_CAST")
+        val delegates = (workflowById.inputs as List<CompositeInput>)[0].sequence.delegates.sortedBy { it.order }
+        assertEquals("Delegates size not correct", 2, delegates.size)
+
+        val delegate1 = delegates[0]
+        assertNotNull(delegate1)
+        assertEquals("Delegate1 order not correct", 1, delegate1.order)
+        assertEquals("Delegate1 id not correct", monitorResponse2.id, delegate1.monitorId)
+
+        val delegate2 = delegates[1]
+        assertNotNull(delegate2)
+        assertEquals("Delegate2 order not correct", 2, delegate2.order)
+        assertEquals("Delegate2 id not correct", monitorResponse1.id, delegate2.monitorId)
+        assertEquals(
+            "Delegate2 Chained finding not correct", monitorResponse2.id, delegate2.chainedMonitorFindings!!.monitorId
+        )
+    }
+
+    fun `test update workflow remove monitor success`() {
+        val docQuery1 = DocLevelQuery(query = "source.ip.v6.v1:12345", name = "3")
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(docQuery1)
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val customFindingsIndex = "custom_findings_index"
+        val customFindingsIndexPattern = "custom_findings_index-1"
+        val customQueryIndex = "custom_alerts_index"
+        val monitor1 = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger),
+            dataSources = DataSources(
+                queryIndex = customQueryIndex,
+                findingsIndex = customFindingsIndex,
+                findingsIndexPattern = customFindingsIndexPattern
+            )
+        )
+
+        val monitor2 = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger),
+            dataSources = DataSources(
+                queryIndex = customQueryIndex,
+                findingsIndex = customFindingsIndex,
+                findingsIndexPattern = customFindingsIndexPattern
+            )
+        )
+
+        val monitorResponse1 = createMonitor(monitor1)!!
+        val monitorResponse2 = createMonitor(monitor2)!!
+
+        val workflow = randomWorkflow(
+            monitorIds = listOf(monitorResponse1.id, monitorResponse2.id)
+        )
+
+        val workflowResponse = upsertWorkflow(workflow)!!
+        assertNotNull("Workflow creation failed", workflowResponse)
+        assertNotNull(workflowResponse.workflow)
+        assertNotEquals("response is missing Id", Monitor.NO_ID, workflowResponse.id)
+        assertTrue("incorrect version", workflowResponse.version > 0)
+
+        var workflowById = searchWorkflow(workflowResponse.id)!!
+        assertNotNull(workflowById)
+
+        val updatedWorkflowResponse = upsertWorkflow(
+            randomWorkflow(
+                monitorIds = listOf(monitorResponse1.id)
+            ),
+            workflowResponse.id,
+            RestRequest.Method.PUT
+        )!!
+
+        assertNotNull("Workflow creation failed", updatedWorkflowResponse)
+        assertNotNull(updatedWorkflowResponse.workflow)
+        assertEquals("Workflow id changed", workflowResponse.id, updatedWorkflowResponse.id)
+        assertTrue("incorrect version", updatedWorkflowResponse.version > 0)
+
+        workflowById = searchWorkflow(updatedWorkflowResponse.id)!!
+
+        // Verify workflow
+        assertNotEquals("response is missing Id", Monitor.NO_ID, workflowById.id)
+        assertTrue("incorrect version", workflowById.version > 0)
+        assertEquals("Workflow name not correct", updatedWorkflowResponse.workflow.name, workflowById.name)
+        assertEquals("Workflow owner not correct", updatedWorkflowResponse.workflow.owner, workflowById.owner)
+        assertEquals("Workflow input not correct", updatedWorkflowResponse.workflow.inputs, workflowById.inputs)
+
+        // Delegate verification
+        @Suppress("UNCHECKED_CAST")
+        val delegates = (workflowById.inputs as List<CompositeInput>)[0].sequence.delegates.sortedBy { it.order }
+        assertEquals("Delegates size not correct", 1, delegates.size)
+
+        val delegate1 = delegates[0]
+        assertNotNull(delegate1)
+        assertEquals("Delegate1 order not correct", 1, delegate1.order)
+        assertEquals("Delegate1 id not correct", monitorResponse1.id, delegate1.monitorId)
+    }
+
+    fun `test update workflow doesn't exist failure`() {
+        val docQuery1 = DocLevelQuery(query = "source.ip.v6.v1:12345", name = "3")
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(docQuery1)
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val customFindingsIndex = "custom_findings_index"
+        val customFindingsIndexPattern = "custom_findings_index-1"
+        val customQueryIndex = "custom_alerts_index"
+        val monitor1 = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger),
+            dataSources = DataSources(
+                queryIndex = customQueryIndex,
+                findingsIndex = customFindingsIndex,
+                findingsIndexPattern = customFindingsIndexPattern
+            )
+        )
+
+        val monitorResponse1 = createMonitor(monitor1)!!
+
+        val workflow = randomWorkflow(
+            monitorIds = listOf(monitorResponse1.id)
+        )
+        val workflowResponse = upsertWorkflow(workflow)!!
+        assertNotNull("Workflow creation failed", workflowResponse)
+
+        try {
+            upsertWorkflow(workflow, "testId", RestRequest.Method.PUT)
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning GetWorkflow Action error ",
+                    it.contains("Workflow with testId is not found")
+                )
+            }
+        }
+    }
+
+    fun `test create workflow without delegate failure`() {
+        val workflow = randomWorkflow(
+            monitorIds = Collections.emptyList()
+        )
+        try {
+            upsertWorkflow(workflow)
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning IndexWorkflow Action error ",
+                    it.contains("Delegates list can not be empty.")
+                )
+            }
+        }
+    }
+
+    fun `test update workflow without delegate failure`() {
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(DocLevelQuery(query = "source.ip.v6.v1:12345", name = "3"))
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val monitor1 = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger)
+        )
+
+        val monitor2 = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger),
+        )
+
+        val monitorResponse1 = createMonitor(monitor1)!!
+        val monitorResponse2 = createMonitor(monitor2)!!
+
+        var workflow = randomWorkflow(
+            monitorIds = listOf(monitorResponse1.id, monitorResponse2.id)
+        )
+
+        val workflowResponse = upsertWorkflow(workflow)!!
+        assertNotNull("Workflow creation failed", workflowResponse)
+
+        workflow = randomWorkflow(
+            id = workflowResponse.id,
+            monitorIds = Collections.emptyList()
+        )
+        try {
+            upsertWorkflow(workflow)
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning IndexWorkflow Action error ",
+                    it.contains("Delegates list can not be empty.")
+                )
+            }
+        }
+    }
+
+    fun `test create workflow duplicate delegate failure`() {
+        val workflow = randomWorkflow(
+            monitorIds = listOf("1", "1", "2")
+        )
+        try {
+            upsertWorkflow(workflow)
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning IndexWorkflow Action error ",
+                    it.contains("Duplicate delegates not allowed")
+                )
+            }
+        }
+    }
+
+    fun `test update workflow duplicate delegate failure`() {
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(DocLevelQuery(query = "source.ip.v6.v1:12345", name = "3"))
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val monitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger)
+        )
+
+        val monitorResponse = createMonitor(monitor)!!
+
+        var workflow = randomWorkflow(
+            monitorIds = listOf(monitorResponse.id)
+        )
+
+        val workflowResponse = upsertWorkflow(workflow)!!
+        assertNotNull("Workflow creation failed", workflowResponse)
+
+        workflow = randomWorkflow(
+            id = workflowResponse.id,
+            monitorIds = listOf("1", "1", "2")
+        )
+        try {
+            upsertWorkflow(workflow)
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning IndexWorkflow Action error ",
+                    it.contains("Duplicate delegates not allowed")
+                )
+            }
+        }
+    }
+
+    fun `test create workflow delegate monitor doesn't exist failure`() {
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(DocLevelQuery(query = "source.ip.v6.v1:12345", name = "3"))
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+
+        val monitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger)
+        )
+        val monitorResponse = createMonitor(monitor)!!
+
+        val workflow = randomWorkflow(
+            monitorIds = listOf("-1", monitorResponse.id)
+        )
+        try {
+            upsertWorkflow(workflow)
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning IndexWorkflow Action error ",
+                    it.contains("are not valid monitor ids")
+                )
+            }
+        }
+    }
+
+    fun `test update workflow delegate monitor doesn't exist failure`() {
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(DocLevelQuery(query = "source.ip.v6.v1:12345", name = "3"))
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+
+        val monitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger)
+        )
+        val monitorResponse = createMonitor(monitor)!!
+
+        var workflow = randomWorkflow(
+            monitorIds = listOf(monitorResponse.id)
+        )
+        val workflowResponse = upsertWorkflow(workflow)!!
+        assertNotNull("Workflow creation failed", workflowResponse)
+
+        workflow = randomWorkflow(
+            id = workflowResponse.id,
+            monitorIds = listOf("-1", monitorResponse.id)
+        )
+
+        try {
+            upsertWorkflow(workflow)
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning IndexWorkflow Action error ",
+                    it.contains("are not valid monitor ids")
+                )
+            }
+        }
+    }
+
+    fun `test create workflow sequence order not correct failure`() {
+        val delegates = listOf(
+            Delegate(1, "monitor-1"),
+            Delegate(1, "monitor-2"),
+            Delegate(2, "monitor-3")
+        )
+        val workflow = randomWorkflowWithDelegates(
+            delegates = delegates
+        )
+        try {
+            upsertWorkflow(workflow)
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning IndexWorkflow Action error ",
+                    it.contains("Sequence ordering of delegate monitor shouldn't contain duplicate order values")
+                )
+            }
+        }
+    }
+
+    fun `test update workflow sequence order not correct failure`() {
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(DocLevelQuery(query = "source.ip.v6.v1:12345", name = "3"))
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+
+        val monitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger)
+        )
+        val monitorResponse = createMonitor(monitor)!!
+
+        var workflow = randomWorkflow(
+            monitorIds = listOf(monitorResponse.id)
+        )
+        val workflowResponse = upsertWorkflow(workflow)!!
+        assertNotNull("Workflow creation failed", workflowResponse)
+
+        val delegates = listOf(
+            Delegate(1, "monitor-1"),
+            Delegate(1, "monitor-2"),
+            Delegate(2, "monitor-3")
+        )
+        workflow = randomWorkflowWithDelegates(
+            id = workflowResponse.id,
+            delegates = delegates
+        )
+        try {
+            upsertWorkflow(workflow)
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning IndexWorkflow Action error ",
+                    it.contains("Sequence ordering of delegate monitor shouldn't contain duplicate order values")
+                )
+            }
+        }
+    }
+
+    fun `test create workflow chained findings monitor not in sequence failure`() {
+        val delegates = listOf(
+            Delegate(1, "monitor-1"),
+            Delegate(2, "monitor-2", ChainedMonitorFindings("monitor-1")),
+            Delegate(3, "monitor-3", ChainedMonitorFindings("monitor-x"))
+        )
+        val workflow = randomWorkflowWithDelegates(
+            delegates = delegates
+        )
+
+        try {
+            upsertWorkflow(workflow)
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning IndexWorkflow Action error ",
+                    it.contains("Chained Findings Monitor monitor-x doesn't exist in sequence")
+                )
+            }
+        }
+    }
+
+    fun `test create workflow query monitor chained findings monitor failure`() {
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(DocLevelQuery(query = "source.ip.v6.v1:12345", name = "3"))
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+
+        val docMonitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger)
+        )
+        val docMonitorResponse = createMonitor(docMonitor)!!
+
+        val queryMonitor = randomQueryLevelMonitor()
+        val queryMonitorResponse = createMonitor(queryMonitor)!!
+
+        var workflow = randomWorkflow(
+            monitorIds = listOf(queryMonitorResponse.id, docMonitorResponse.id)
+        )
+        try {
+            upsertWorkflow(workflow)
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning IndexWorkflow Action error ",
+                    it.contains("Query level monitor can't be part of chained findings")
+                )
+            }
+        }
+    }
+
+    fun `test create workflow when monitor index not initialized failure`() {
+        val delegates = listOf(
+            Delegate(1, "monitor-1")
+        )
+        val workflow = randomWorkflowWithDelegates(
+            delegates = delegates
+        )
+
+        try {
+            upsertWorkflow(workflow)
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning IndexWorkflow Action error ",
+                    it.contains("Monitors not found")
+                )
+            }
+        }
+    }
+
+    fun `test update workflow chained findings monitor not in sequence failure`() {
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(DocLevelQuery(query = "source.ip.v6.v1:12345", name = "3"))
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+
+        val monitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger)
+        )
+        val monitorResponse = createMonitor(monitor)!!
+
+        var workflow = randomWorkflow(
+            monitorIds = listOf(monitorResponse.id)
+        )
+        val workflowResponse = upsertWorkflow(workflow)!!
+        assertNotNull("Workflow creation failed", workflowResponse)
+
+        val delegates = listOf(
+            Delegate(1, "monitor-1"),
+            Delegate(2, "monitor-2", ChainedMonitorFindings("monitor-1")),
+            Delegate(3, "monitor-3", ChainedMonitorFindings("monitor-x"))
+        )
+        workflow = randomWorkflowWithDelegates(
+            id = workflowResponse.id,
+            delegates = delegates
+        )
+
+        try {
+            upsertWorkflow(workflow)
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning IndexWorkflow Action error ",
+                    it.contains("Chained Findings Monitor monitor-x doesn't exist in sequence")
+                )
+            }
+        }
+    }
+
+    fun `test create workflow chained findings order not correct failure`() {
+        val delegates = listOf(
+            Delegate(1, "monitor-1"),
+            Delegate(3, "monitor-2", ChainedMonitorFindings("monitor-1")),
+            Delegate(2, "monitor-3", ChainedMonitorFindings("monitor-2"))
+        )
+        val workflow = randomWorkflowWithDelegates(
+            delegates = delegates
+        )
+
+        try {
+            upsertWorkflow(workflow)
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning IndexWorkflow Action error ",
+                    it.contains("Chained Findings Monitor monitor-2 should be executed before monitor monitor-3")
+                )
+            }
+        }
+    }
+
+    fun `test update workflow chained findings order not correct failure`() {
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(DocLevelQuery(query = "source.ip.v6.v1:12345", name = "3"))
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+
+        val monitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger)
+        )
+        val monitorResponse = createMonitor(monitor)!!
+
+        var workflow = randomWorkflow(
+            monitorIds = listOf(monitorResponse.id)
+        )
+        val workflowResponse = upsertWorkflow(workflow)!!
+        assertNotNull("Workflow creation failed", workflowResponse)
+
+        val delegates = listOf(
+            Delegate(1, "monitor-1"),
+            Delegate(3, "monitor-2", ChainedMonitorFindings("monitor-1")),
+            Delegate(2, "monitor-3", ChainedMonitorFindings("monitor-2"))
+        )
+        workflow = randomWorkflowWithDelegates(
+            delegates = delegates
+        )
+
+        try {
+            upsertWorkflow(workflow)
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning IndexWorkflow Action error ",
+                    it.contains("Chained Findings Monitor monitor-2 should be executed before monitor monitor-3")
+                )
+            }
+        }
+    }
+}

--- a/alerting/src/test/kotlin/org/opensearch/alerting/WorkflowRunnerIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/WorkflowRunnerIT.kt
@@ -7,13 +7,16 @@ package org.opensearch.alerting
 
 import org.junit.Assert
 import org.opensearch.action.support.WriteRequest
+import org.opensearch.alerting.alerts.AlertIndices
 import org.opensearch.alerting.model.DocumentLevelTriggerRunResult
 import org.opensearch.alerting.transport.WorkflowSingleNodeTestCase
 import org.opensearch.alerting.util.AlertingException
 import org.opensearch.commons.alerting.action.AcknowledgeAlertRequest
 import org.opensearch.commons.alerting.action.AlertingActions
 import org.opensearch.commons.alerting.action.GetAlertsRequest
+import org.opensearch.commons.alerting.action.GetAlertsResponse
 import org.opensearch.commons.alerting.aggregation.bucketselectorext.BucketSelectorExtAggregationBuilder
+import org.opensearch.commons.alerting.model.Alert
 import org.opensearch.commons.alerting.model.DataSources
 import org.opensearch.commons.alerting.model.DocLevelMonitorInput
 import org.opensearch.commons.alerting.model.DocLevelQuery
@@ -118,14 +121,16 @@ class WorkflowRunnerIT : WorkflowSingleNodeTestCase() {
         Assert.assertEquals(monitor2.name, monitorsRunResults[1].monitorName)
         Assert.assertEquals(1, monitorsRunResults[1].triggerResults.size)
 
-        assertAlerts(monitorResponse.id, customAlertsIndex1, 2)
+        val getAlertsResponse = assertAlerts(monitorResponse.id, customAlertsIndex1, 2)
+        assertAcknowledges(getAlertsResponse.alerts, monitorResponse.id, 2)
         assertFindings(monitorResponse.id, customFindingsIndex1, 2, 2, listOf("1", "2"))
 
-        assertAlerts(monitorResponse2.id, customAlertsIndex2, 1)
+        val getAlertsResponse2 = assertAlerts(monitorResponse2.id, customAlertsIndex2, 1)
+        assertAcknowledges(getAlertsResponse2.alerts, monitorResponse2.id, 1)
         assertFindings(monitorResponse2.id, customFindingsIndex2, 1, 1, listOf("2"))
     }
 
-    fun `test execute workflows with shared monitor delegates`() {
+    fun `test execute workflows with shared doc level monitor delegate`() {
         val docQuery = DocLevelQuery(query = "test_field_1:\"us-west-2\"", name = "3")
         val docLevelInput = DocLevelMonitorInput("description", listOf(index), listOf(docQuery))
         val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
@@ -184,9 +189,22 @@ class WorkflowRunnerIT : WorkflowSingleNodeTestCase() {
         assertEquals(monitor.name, monitorsRunResults[0].monitorName)
         assertEquals(1, monitorsRunResults[0].triggerResults.size)
 
+        // Assert and not ack the alerts (in order to verify later on that all the alerts are generated)
         assertAlerts(monitorResponse.id, customAlertsIndex, 2)
         assertFindings(monitorResponse.id, customFindingsIndex, 2, 2, listOf("1", "2"))
+        // Verify workflow and monitor delegate metadata
+        val workflowMetadata = searchWorkflowMetadata(id = workflowId)
+        assertNotNull("Workflow metadata not initialized", workflowMetadata)
+        assertEquals(
+            "Workflow metadata execution id not correct",
+            executeWorkflowResponse.workflowRunResult.executionId,
+            workflowMetadata!!.latestExecutionId
+        )
+        val monitorMetadataId = "${monitorResponse.id}-${workflowMetadata.id}"
+        val monitorMetadata = searchMonitorMetadata(monitorMetadataId)
+        assertNotNull(monitorMetadata)
 
+        // Execute second workflow
         val workflowId1 = workflowResponse1.id
         val executeWorkflowResponse1 = executeWorkflow(workflowById1, workflowId1, false)!!
         val monitorsRunResults1 = executeWorkflowResponse1.workflowRunResult.workflowRunResult
@@ -195,8 +213,134 @@ class WorkflowRunnerIT : WorkflowSingleNodeTestCase() {
         assertEquals(monitor.name, monitorsRunResults1[0].monitorName)
         assertEquals(1, monitorsRunResults1[0].triggerResults.size)
 
-        assertAlerts(monitorResponse.id, customAlertsIndex, 2)
+        val getAlertsResponse = assertAlerts(monitorResponse.id, customAlertsIndex, 4)
+        assertAcknowledges(getAlertsResponse.alerts, monitorResponse.id, 4)
         assertFindings(monitorResponse.id, customFindingsIndex, 4, 4, listOf("1", "2", "1", "2"))
+        // Verify workflow and monitor delegate metadata
+        val workflowMetadata1 = searchWorkflowMetadata(id = workflowId1)
+        assertNotNull("Workflow metadata not initialized", workflowMetadata1)
+        assertEquals(
+            "Workflow metadata execution id not correct",
+            executeWorkflowResponse1.workflowRunResult.executionId,
+            workflowMetadata1!!.latestExecutionId
+        )
+        val monitorMetadataId1 = "${monitorResponse.id}-${workflowMetadata1.id}"
+        val monitorMetadata1 = searchMonitorMetadata(monitorMetadataId1)
+        assertNotNull(monitorMetadata1)
+        // Verify that for two workflows two different doc level monitor metadata has been created
+        assertTrue("Different monitor is used in workflows", monitorMetadata!!.monitorId == monitorMetadata1!!.monitorId)
+        assertTrue(monitorMetadata.id != monitorMetadata1.id)
+    }
+
+    fun `test execute workflows with shared doc level monitor delegate updating delegate datasource`() {
+        val docQuery = DocLevelQuery(query = "test_field_1:\"us-west-2\"", name = "3")
+        val docLevelInput = DocLevelMonitorInput("description", listOf(index), listOf(docQuery))
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+
+        var monitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger)
+        )
+        val monitorResponse = createMonitor(monitor)!!
+
+        val workflow = randomWorkflow(
+            monitorIds = listOf(monitorResponse.id)
+        )
+        val workflowResponse = upsertWorkflow(workflow)!!
+        val workflowById = searchWorkflow(workflowResponse.id)
+        assertNotNull(workflowById)
+
+        val workflow1 = randomWorkflow(
+            monitorIds = listOf(monitorResponse.id)
+        )
+        val workflowResponse1 = upsertWorkflow(workflow1)!!
+        val workflowById1 = searchWorkflow(workflowResponse1.id)
+        assertNotNull(workflowById1)
+
+        var testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS))
+        // Matches monitor1
+        val testDoc1 = """{
+            "message" : "This is an error from IAD region",
+            "source.ip.v6.v2" : 16644, 
+            "test_strict_date_time" : "$testTime",
+            "test_field_1" : "us-west-2"
+        }"""
+        indexDoc(index, "1", testDoc1)
+
+        testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS))
+        val testDoc2 = """{
+            "message" : "This is an error from IAD region",
+            "source.ip.v6.v2" : 16645, 
+            "test_strict_date_time" : "$testTime",
+            "test_field_1" : "us-west-2"
+        }"""
+        indexDoc(index, "2", testDoc2)
+
+        val workflowId = workflowResponse.id
+        val executeWorkflowResponse = executeWorkflow(workflowById, workflowId, false)!!
+        val monitorsRunResults = executeWorkflowResponse.workflowRunResult.workflowRunResult
+        assertEquals(1, monitorsRunResults.size)
+
+        assertEquals(monitor.name, monitorsRunResults[0].monitorName)
+        assertEquals(1, monitorsRunResults[0].triggerResults.size)
+
+        assertAlerts(monitorResponse.id, AlertIndices.ALERT_INDEX, 2)
+        assertFindings(monitorResponse.id, AlertIndices.FINDING_HISTORY_WRITE_INDEX, 2, 2, listOf("1", "2"))
+        // Verify workflow and monitor delegate metadata
+        val workflowMetadata = searchWorkflowMetadata(id = workflowId)
+        assertNotNull("Workflow metadata not initialized", workflowMetadata)
+        assertEquals(
+            "Workflow metadata execution id not correct",
+            executeWorkflowResponse.workflowRunResult.executionId,
+            workflowMetadata!!.latestExecutionId
+        )
+        val monitorMetadataId = "${monitorResponse.id}-${workflowMetadata.id}"
+        val monitorMetadata = searchMonitorMetadata(monitorMetadataId)
+        assertNotNull(monitorMetadata)
+
+        val customAlertsIndex = "custom_alerts_index"
+        val customFindingsIndex = "custom_findings_index"
+        val customFindingsIndexPattern = "custom_findings_index-1"
+        val monitorId = monitorResponse.id
+        updateMonitor(
+            monitor = monitor.copy(
+                dataSources = DataSources(
+                    alertsIndex = customAlertsIndex,
+                    findingsIndex = customFindingsIndex,
+                    findingsIndexPattern = customFindingsIndexPattern
+                )
+            ),
+            monitorId
+        )
+
+        // Execute second workflow
+        val workflowId1 = workflowResponse1.id
+        val executeWorkflowResponse1 = executeWorkflow(workflowById1, workflowId1, false)!!
+        val monitorsRunResults1 = executeWorkflowResponse1.workflowRunResult.workflowRunResult
+        assertEquals(1, monitorsRunResults1.size)
+
+        assertEquals(monitor.name, monitorsRunResults1[0].monitorName)
+        assertEquals(1, monitorsRunResults1[0].triggerResults.size)
+
+        // Verify alerts for the custom index
+        val getAlertsResponse = assertAlerts(monitorResponse.id, customAlertsIndex, 2)
+        assertAcknowledges(getAlertsResponse.alerts, monitorResponse.id, 2)
+        assertFindings(monitorResponse.id, customFindingsIndex, 2, 2, listOf("1", "2"))
+
+        // Verify workflow and monitor delegate metadata
+        val workflowMetadata1 = searchWorkflowMetadata(id = workflowId1)
+        assertNotNull("Workflow metadata not initialized", workflowMetadata1)
+        assertEquals(
+            "Workflow metadata execution id not correct",
+            executeWorkflowResponse1.workflowRunResult.executionId,
+            workflowMetadata1!!.latestExecutionId
+        )
+        val monitorMetadataId1 = "${monitorResponse.id}-${workflowMetadata1.id}"
+        val monitorMetadata1 = searchMonitorMetadata(monitorMetadataId1)
+        assertNotNull(monitorMetadata1)
+        // Verify that for two workflows two different doc level monitor metadata has been created
+        assertTrue("Different monitor is used in workflows", monitorMetadata!!.monitorId == monitorMetadata1!!.monitorId)
+        assertTrue(monitorMetadata.id != monitorMetadata1.id)
     }
 
     fun `test execute workflow verify workflow metadata`() {
@@ -248,6 +392,10 @@ class WorkflowRunnerIT : WorkflowSingleNodeTestCase() {
             executeWorkflowResponse.workflowRunResult.executionId,
             workflowMetadata!!.latestExecutionId
         )
+        val monitorMetadataId = "${monitorResponse.id}-${workflowMetadata.id}"
+        val monitorMetadata = searchMonitorMetadata(monitorMetadataId)
+        assertNotNull(monitorMetadata)
+
         // Second execution
         val executeWorkflowResponse1 = executeWorkflow(workflowById, workflowId, false)!!
         val monitorsRunResults1 = executeWorkflowResponse1.workflowRunResult.workflowRunResult
@@ -260,6 +408,10 @@ class WorkflowRunnerIT : WorkflowSingleNodeTestCase() {
             executeWorkflowResponse1.workflowRunResult.executionId,
             workflowMetadata1!!.latestExecutionId
         )
+        val monitorMetadataId1 = "${monitorResponse.id}-${workflowMetadata1.id}"
+        assertTrue(monitorMetadataId == monitorMetadataId1)
+        val monitorMetadata1 = searchMonitorMetadata(monitorMetadataId1)
+        assertNotNull(monitorMetadata1)
     }
 
     fun `test execute workflow dryrun verify workflow metadata not created`() {
@@ -315,7 +467,7 @@ class WorkflowRunnerIT : WorkflowSingleNodeTestCase() {
         assertTrue(exception is NoSuchElementException)
     }
 
-    fun `test execute workflow with custom alerts and finding index with bucket level doc level delegates when bucket level delegate is used in chained finding`() {
+    fun `test execute workflow with custom alerts and finding index when bucket monitor is used in chained finding of doc monitor`() {
         val query = QueryBuilders.rangeQuery("test_strict_date_time")
             .gt("{{period_end}}||-10d")
             .lte("{{period_end}}")
@@ -325,7 +477,8 @@ class WorkflowRunnerIT : WorkflowSingleNodeTestCase() {
         )
         val compositeAgg = CompositeAggregationBuilder("composite_agg", compositeSources)
         val input = SearchInput(indices = listOf(index), query = SearchSourceBuilder().size(0).query(query).aggregation(compositeAgg))
-        // Bucket level monitor will reduce the size of matched doc ids on those that belong to a bucket that contains more than 1 document after term grouping
+        // Bucket level monitor will reduce the size of matched doc ids on those that belong
+        // to a bucket that contains more than 1 document after term grouping
         val triggerScript = """
             params.docCount > 1
         """.trimIndent()
@@ -406,11 +559,13 @@ class WorkflowRunnerIT : WorkflowSingleNodeTestCase() {
         for (monitorRunResults in executeWorkflowResponse.workflowRunResult.workflowRunResult) {
             if (bucketLevelMonitorResponse.monitor.name == monitorRunResults.monitorName) {
                 val searchResult = monitorRunResults.inputResults.results.first()
+
                 @Suppress("UNCHECKED_CAST")
                 val buckets = searchResult.stringMap("aggregations")?.stringMap("composite_agg")?.get("buckets") as List<Map<String, Any>>
                 assertEquals("Incorrect search result", 3, buckets.size)
 
-                assertAlerts(bucketLevelMonitorResponse.id, bucketCustomAlertsIndex, 2)
+                val getAlertsResponse = assertAlerts(bucketLevelMonitorResponse.id, bucketCustomAlertsIndex, 2)
+                assertAcknowledges(getAlertsResponse.alerts, bucketLevelMonitorResponse.id, 2)
                 assertFindings(bucketLevelMonitorResponse.id, bucketCustomFindingsIndex, 1, 4, listOf("1", "2", "3", "4"))
             } else {
                 assertEquals(1, monitorRunResults.inputResults.results.size)
@@ -422,13 +577,14 @@ class WorkflowRunnerIT : WorkflowSingleNodeTestCase() {
                 val expectedTriggeredDocIds = listOf("1", "2", "3", "4")
                 assertEquals(expectedTriggeredDocIds, triggeredDocIds.sorted())
 
-                assertAlerts(docLevelMonitorResponse.id, docCustomAlertsIndex, 4)
+                val getAlertsResponse = assertAlerts(docLevelMonitorResponse.id, docCustomAlertsIndex, 4)
+                assertAcknowledges(getAlertsResponse.alerts, docLevelMonitorResponse.id, 4)
                 assertFindings(docLevelMonitorResponse.id, docCustomFindingsIndex, 4, 4, listOf("1", "2", "3", "4"))
             }
         }
     }
 
-    fun `test execute workflow with custom alerts and finding index with bucket level and doc level delegates when doc level delegate is used in chained finding`() {
+    fun `test execute workflow with custom alerts and finding index when doc level delegate is used in chained finding`() {
         val docQuery1 = DocLevelQuery(query = "test_field_1:\"test_value_2\"", name = "1")
         val docQuery2 = DocLevelQuery(query = "test_field_1:\"test_value_3\"", name = "2")
 
@@ -512,11 +668,17 @@ class WorkflowRunnerIT : WorkflowSingleNodeTestCase() {
         """.trimIndent()
 
         val queryLevelTrigger = randomQueryLevelTrigger(condition = Script(queryTriggerScript))
-        val queryMonitorResponse = createMonitor(randomQueryLevelMonitor(inputs = listOf(queryMonitorInput), triggers = listOf(queryLevelTrigger)))!!
+        val queryMonitorResponse =
+            createMonitor(randomQueryLevelMonitor(inputs = listOf(queryMonitorInput), triggers = listOf(queryLevelTrigger)))!!
 
         // 1. docMonitor (chainedFinding = null) 2. bucketMonitor (chainedFinding = docMonitor) 3. docMonitor (chainedFinding = bucketMonitor) 4. queryMonitor (chainedFinding = docMonitor 3)
         var workflow = randomWorkflow(
-            monitorIds = listOf(docLevelMonitorResponse.id, bucketLevelMonitorResponse.id, docLevelMonitorResponse1.id, queryMonitorResponse.id)
+            monitorIds = listOf(
+                docLevelMonitorResponse.id,
+                bucketLevelMonitorResponse.id,
+                docLevelMonitorResponse1.id,
+                queryMonitorResponse.id
+            )
         )
         val workflowResponse = upsertWorkflow(workflow)!!
         val workflowById = searchWorkflow(workflowResponse.id)
@@ -554,18 +716,37 @@ class WorkflowRunnerIT : WorkflowSingleNodeTestCase() {
                     val expectedTriggeredDocIds = listOf("3", "4", "5", "6")
                     assertEquals(expectedTriggeredDocIds, triggeredDocIds.sorted())
 
-                    assertAlerts(docLevelMonitorResponse.id, docLevelMonitorResponse.monitor.dataSources.alertsIndex, 4)
-                    assertFindings(docLevelMonitorResponse.id, docLevelMonitorResponse.monitor.dataSources.findingsIndex, 4, 4, listOf("3", "4", "5", "6"))
+                    val getAlertsResponse =
+                        assertAlerts(docLevelMonitorResponse.id, docLevelMonitorResponse.monitor.dataSources.alertsIndex, 4)
+                    assertAcknowledges(getAlertsResponse.alerts, docLevelMonitorResponse.id, 4)
+                    assertFindings(
+                        docLevelMonitorResponse.id,
+                        docLevelMonitorResponse.monitor.dataSources.findingsIndex,
+                        4,
+                        4,
+                        listOf("3", "4", "5", "6")
+                    )
                 }
                 // Verify second bucket level monitor execution, alerts and findings
                 bucketLevelMonitorResponse.monitor.name -> {
                     val searchResult = monitorRunResults.inputResults.results.first()
+
                     @Suppress("UNCHECKED_CAST")
-                    val buckets = searchResult.stringMap("aggregations")?.stringMap("composite_agg")?.get("buckets") as List<Map<String, Any>>
+                    val buckets =
+                        searchResult
+                            .stringMap("aggregations")?.stringMap("composite_agg")?.get("buckets") as List<Map<String, Any>>
                     assertEquals("Incorrect search result", 2, buckets.size)
 
-                    assertAlerts(bucketLevelMonitorResponse.id, bucketLevelMonitorResponse.monitor.dataSources.alertsIndex, 2)
-                    assertFindings(bucketLevelMonitorResponse.id, bucketLevelMonitorResponse.monitor.dataSources.findingsIndex, 1, 4, listOf("3", "4", "5", "6"))
+                    val getAlertsResponse =
+                        assertAlerts(bucketLevelMonitorResponse.id, bucketLevelMonitorResponse.monitor.dataSources.alertsIndex, 2)
+                    assertAcknowledges(getAlertsResponse.alerts, bucketLevelMonitorResponse.id, 2)
+                    assertFindings(
+                        bucketLevelMonitorResponse.id,
+                        bucketLevelMonitorResponse.monitor.dataSources.findingsIndex,
+                        1,
+                        4,
+                        listOf("3", "4", "5", "6")
+                    )
                 }
                 // Verify third doc level monitor execution, alerts and findings
                 docLevelMonitorResponse1.monitor.name -> {
@@ -578,8 +759,16 @@ class WorkflowRunnerIT : WorkflowSingleNodeTestCase() {
                     val expectedTriggeredDocIds = listOf("5", "6")
                     assertEquals(expectedTriggeredDocIds, triggeredDocIds.sorted())
 
-                    assertAlerts(docLevelMonitorResponse1.id, docLevelMonitorResponse1.monitor.dataSources.alertsIndex, 2)
-                    assertFindings(docLevelMonitorResponse1.id, docLevelMonitorResponse1.monitor.dataSources.findingsIndex, 2, 2, listOf("5", "6"))
+                    val getAlertsResponse =
+                        assertAlerts(docLevelMonitorResponse1.id, docLevelMonitorResponse1.monitor.dataSources.alertsIndex, 2)
+                    assertAcknowledges(getAlertsResponse.alerts, docLevelMonitorResponse1.id, 2)
+                    assertFindings(
+                        docLevelMonitorResponse1.id,
+                        docLevelMonitorResponse1.monitor.dataSources.findingsIndex,
+                        2,
+                        2,
+                        listOf("5", "6")
+                    )
                 }
                 // Verify fourth query level monitor execution
                 queryMonitorResponse.monitor.name -> {
@@ -587,10 +776,14 @@ class WorkflowRunnerIT : WorkflowSingleNodeTestCase() {
                     val values = monitorRunResults.triggerResults.values
                     assertEquals(1, values.size)
                     @Suppress("UNCHECKED_CAST")
-                    val totalHits = ((monitorRunResults.inputResults.results[0]["hits"] as Map<String, Any>)["total"] as Map<String, Any>) ["value"]
+                    val totalHits =
+                        ((monitorRunResults.inputResults.results[0]["hits"] as Map<String, Any>)["total"] as Map<String, Any>)["value"]
                     assertEquals(2, totalHits)
                     @Suppress("UNCHECKED_CAST")
-                    val docIds = ((monitorRunResults.inputResults.results[0]["hits"] as Map<String, Any>)["hits"] as List<Map<String, String>>).map { it["_id"]!! }
+                    val docIds =
+                        (
+                            (monitorRunResults.inputResults.results[0]["hits"] as Map<String, Any>)["hits"] as List<Map<String, String>>
+                            ).map { it["_id"]!! }
                     assertEquals(listOf("5", "6"), docIds.sorted())
                 }
             }
@@ -623,7 +816,7 @@ class WorkflowRunnerIT : WorkflowSingleNodeTestCase() {
         assertNotNull(error)
         assertTrue(error is AlertingException)
         assertEquals(RestStatus.NOT_FOUND, (error as AlertingException).status)
-        assertEquals("Configured indices are not found: [$index]", (error as AlertingException).message)
+        assertEquals("Configured indices are not found: [$index]", error.message)
     }
 
     fun `test execute workflow wrong workflow id`() {
@@ -667,7 +860,7 @@ class WorkflowRunnerIT : WorkflowSingleNodeTestCase() {
         customFindingsIndex: String,
         findingSize: Int,
         matchedQueryNumber: Int,
-        relatedDocIds: List<String>
+        relatedDocIds: List<String>,
     ) {
         val findings = searchFindings(monitorId, customFindingsIndex)
         assertEquals("Findings saved for test monitor", findingSize, findings.size)
@@ -681,8 +874,8 @@ class WorkflowRunnerIT : WorkflowSingleNodeTestCase() {
     private fun assertAlerts(
         monitorId: String,
         customAlertsIndex: String,
-        alertSize: Int
-    ) {
+        alertSize: Int,
+    ): GetAlertsResponse {
         val alerts = searchAlerts(monitorId, customAlertsIndex)
         assertEquals("Alert saved for test monitor", alertSize, alerts.size)
         val table = Table("asc", "id", null, alertSize, 0, "")
@@ -700,7 +893,15 @@ class WorkflowRunnerIT : WorkflowSingleNodeTestCase() {
         assertTrue(getAlertsResponse != null)
         assertTrue(getAlertsResponse.alerts.size == alertSize)
 
-        val alertIds = getAlertsResponse.alerts.map { it.id }
+        return getAlertsResponse
+    }
+
+    private fun assertAcknowledges(
+        alerts: List<Alert>,
+        monitorId: String,
+        alertSize: Int,
+    ) {
+        val alertIds = alerts.map { it.id }
         val acknowledgeAlertResponse = client().execute(
             AlertingActions.ACKNOWLEDGE_ALERTS_ACTION_TYPE,
             AcknowledgeAlertRequest(monitorId, alertIds, WriteRequest.RefreshPolicy.IMMEDIATE)

--- a/alerting/src/test/kotlin/org/opensearch/alerting/WorkflowRunnerIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/WorkflowRunnerIT.kt
@@ -1,0 +1,710 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting
+
+import org.junit.Assert
+import org.opensearch.action.support.WriteRequest
+import org.opensearch.alerting.model.DocumentLevelTriggerRunResult
+import org.opensearch.alerting.transport.WorkflowSingleNodeTestCase
+import org.opensearch.alerting.util.AlertingException
+import org.opensearch.commons.alerting.action.AcknowledgeAlertRequest
+import org.opensearch.commons.alerting.action.AlertingActions
+import org.opensearch.commons.alerting.action.GetAlertsRequest
+import org.opensearch.commons.alerting.aggregation.bucketselectorext.BucketSelectorExtAggregationBuilder
+import org.opensearch.commons.alerting.model.DataSources
+import org.opensearch.commons.alerting.model.DocLevelMonitorInput
+import org.opensearch.commons.alerting.model.DocLevelQuery
+import org.opensearch.commons.alerting.model.SearchInput
+import org.opensearch.commons.alerting.model.Table
+import org.opensearch.index.query.QueryBuilders
+import org.opensearch.rest.RestStatus
+import org.opensearch.script.Script
+import org.opensearch.search.aggregations.bucket.composite.CompositeAggregationBuilder
+import org.opensearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder
+import org.opensearch.search.builder.SearchSourceBuilder
+import java.lang.Exception
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import java.util.NoSuchElementException
+import java.util.concurrent.ExecutionException
+
+class WorkflowRunnerIT : WorkflowSingleNodeTestCase() {
+
+    fun `test execute workflow with custom alerts and finding index with doc level delegates`() {
+        val docQuery1 = DocLevelQuery(query = "test_field_1:\"us-west-2\"", name = "3")
+        val docLevelInput1 = DocLevelMonitorInput("description", listOf(index), listOf(docQuery1))
+        val trigger1 = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val customAlertsIndex1 = "custom_alerts_index"
+        val customFindingsIndex1 = "custom_findings_index"
+        val customFindingsIndexPattern1 = "custom_findings_index-1"
+        var monitor1 = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput1),
+            triggers = listOf(trigger1),
+            dataSources = DataSources(
+                alertsIndex = customAlertsIndex1,
+                findingsIndex = customFindingsIndex1,
+                findingsIndexPattern = customFindingsIndexPattern1
+            )
+        )
+        val monitorResponse = createMonitor(monitor1)!!
+
+        val docQuery2 = DocLevelQuery(query = "source.ip.v6.v2:16645", name = "4")
+        val docLevelInput2 = DocLevelMonitorInput("description", listOf(index), listOf(docQuery2))
+        val trigger2 = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val customAlertsIndex2 = "custom_alerts_index_2"
+        val customFindingsIndex2 = "custom_findings_index_2"
+        val customFindingsIndexPattern2 = "custom_findings_index-2"
+        var monitor2 = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput2),
+            triggers = listOf(trigger2),
+            dataSources = DataSources(
+                alertsIndex = customAlertsIndex2,
+                findingsIndex = customFindingsIndex2,
+                findingsIndexPattern = customFindingsIndexPattern2
+            )
+        )
+
+        val monitorResponse2 = createMonitor(monitor2)!!
+
+        var workflow = randomWorkflow(
+            monitorIds = listOf(monitorResponse.id, monitorResponse2.id)
+        )
+        val workflowResponse = upsertWorkflow(workflow)!!
+        val workflowById = searchWorkflow(workflowResponse.id)
+        assertNotNull(workflowById)
+
+        var testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS))
+        // Matches monitor1
+        val testDoc1 = """{
+            "message" : "This is an error from IAD region",
+            "source.ip.v6.v2" : 16644, 
+            "test_strict_date_time" : "$testTime",
+            "test_field_1" : "us-west-2"
+        }"""
+        indexDoc(index, "1", testDoc1)
+
+        testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS))
+        // Matches monitor1 and monitor2
+        val testDoc2 = """{
+            "message" : "This is an error from IAD region",
+            "source.ip.v6.v2" : 16645, 
+            "test_strict_date_time" : "$testTime",
+            "test_field_1" : "us-west-2"
+        }"""
+        indexDoc(index, "2", testDoc2)
+
+        testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS))
+        // Doesn't match
+        val testDoc3 = """{
+            "message" : "This is an error from IAD region",
+            "source.ip.v6.v2" : 16645, 
+            "test_strict_date_time" : "$testTime",
+            "test_field_1" : "us-east-1"
+        }"""
+        indexDoc(index, "3", testDoc3)
+
+        val workflowId = workflowResponse.id
+        val executeWorkflowResponse = executeWorkflow(workflowById, workflowId, false)!!
+        val monitorsRunResults = executeWorkflowResponse.workflowRunResult.workflowRunResult
+        assertEquals(2, monitorsRunResults.size)
+
+        assertEquals(monitor1.name, monitorsRunResults[0].monitorName)
+        assertEquals(1, monitorsRunResults[0].triggerResults.size)
+
+        Assert.assertEquals(monitor2.name, monitorsRunResults[1].monitorName)
+        Assert.assertEquals(1, monitorsRunResults[1].triggerResults.size)
+
+        assertAlerts(monitorResponse.id, customAlertsIndex1, 2)
+        assertFindings(monitorResponse.id, customFindingsIndex1, 2, 2, listOf("1", "2"))
+
+        assertAlerts(monitorResponse2.id, customAlertsIndex2, 1)
+        assertFindings(monitorResponse2.id, customFindingsIndex2, 1, 1, listOf("2"))
+    }
+
+    fun `test execute workflows with shared monitor delegates`() {
+        val docQuery = DocLevelQuery(query = "test_field_1:\"us-west-2\"", name = "3")
+        val docLevelInput = DocLevelMonitorInput("description", listOf(index), listOf(docQuery))
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val customAlertsIndex = "custom_alerts_index"
+        val customFindingsIndex = "custom_findings_index"
+        val customFindingsIndexPattern = "custom_findings_index-1"
+        var monitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger),
+            dataSources = DataSources(
+                alertsIndex = customAlertsIndex,
+                findingsIndex = customFindingsIndex,
+                findingsIndexPattern = customFindingsIndexPattern
+            )
+        )
+        val monitorResponse = createMonitor(monitor)!!
+
+        var workflow = randomWorkflow(
+            monitorIds = listOf(monitorResponse.id)
+        )
+        val workflowResponse = upsertWorkflow(workflow)!!
+        val workflowById = searchWorkflow(workflowResponse.id)
+        assertNotNull(workflowById)
+
+        var workflow1 = randomWorkflow(
+            monitorIds = listOf(monitorResponse.id)
+        )
+        val workflowResponse1 = upsertWorkflow(workflow1)!!
+        val workflowById1 = searchWorkflow(workflowResponse1.id)
+        assertNotNull(workflowById1)
+
+        var testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS))
+        // Matches monitor1
+        val testDoc1 = """{
+            "message" : "This is an error from IAD region",
+            "source.ip.v6.v2" : 16644, 
+            "test_strict_date_time" : "$testTime",
+            "test_field_1" : "us-west-2"
+        }"""
+        indexDoc(index, "1", testDoc1)
+
+        testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS))
+        val testDoc2 = """{
+            "message" : "This is an error from IAD region",
+            "source.ip.v6.v2" : 16645, 
+            "test_strict_date_time" : "$testTime",
+            "test_field_1" : "us-west-2"
+        }"""
+        indexDoc(index, "2", testDoc2)
+
+        val workflowId = workflowResponse.id
+        val executeWorkflowResponse = executeWorkflow(workflowById, workflowId, false)!!
+        val monitorsRunResults = executeWorkflowResponse.workflowRunResult.workflowRunResult
+        assertEquals(1, monitorsRunResults.size)
+
+        assertEquals(monitor.name, monitorsRunResults[0].monitorName)
+        assertEquals(1, monitorsRunResults[0].triggerResults.size)
+
+        assertAlerts(monitorResponse.id, customAlertsIndex, 2)
+        assertFindings(monitorResponse.id, customFindingsIndex, 2, 2, listOf("1", "2"))
+
+        val workflowId1 = workflowResponse1.id
+        val executeWorkflowResponse1 = executeWorkflow(workflowById1, workflowId1, false)!!
+        val monitorsRunResults1 = executeWorkflowResponse1.workflowRunResult.workflowRunResult
+        assertEquals(1, monitorsRunResults1.size)
+
+        assertEquals(monitor.name, monitorsRunResults1[0].monitorName)
+        assertEquals(1, monitorsRunResults1[0].triggerResults.size)
+
+        assertAlerts(monitorResponse.id, customAlertsIndex, 2)
+        assertFindings(monitorResponse.id, customFindingsIndex, 4, 4, listOf("1", "2", "1", "2"))
+    }
+
+    fun `test execute workflow verify workflow metadata`() {
+        val docQuery1 = DocLevelQuery(query = "test_field_1:\"us-west-2\"", name = "3")
+        val docLevelInput1 = DocLevelMonitorInput("description", listOf(index), listOf(docQuery1))
+        val trigger1 = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        var monitor1 = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput1),
+            triggers = listOf(trigger1)
+        )
+        val monitorResponse = createMonitor(monitor1)!!
+
+        val docQuery2 = DocLevelQuery(query = "source.ip.v6.v2:16645", name = "4")
+        val docLevelInput2 = DocLevelMonitorInput("description", listOf(index), listOf(docQuery2))
+        val trigger2 = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        var monitor2 = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput2),
+            triggers = listOf(trigger2),
+        )
+
+        val monitorResponse2 = createMonitor(monitor2)!!
+
+        var workflow = randomWorkflow(
+            monitorIds = listOf(monitorResponse.id, monitorResponse2.id)
+        )
+        val workflowResponse = upsertWorkflow(workflow)!!
+        val workflowById = searchWorkflow(workflowResponse.id)
+        assertNotNull(workflowById)
+
+        var testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS))
+        // Matches monitor1
+        val testDoc1 = """{
+            "message" : "This is an error from IAD region",
+            "source.ip.v6.v2" : 16644, 
+            "test_strict_date_time" : "$testTime",
+            "test_field_1" : "us-west-2"
+        }"""
+        indexDoc(index, "1", testDoc1)
+        // First execution
+        val workflowId = workflowResponse.id
+        val executeWorkflowResponse = executeWorkflow(workflowById, workflowId, false)!!
+        val monitorsRunResults = executeWorkflowResponse.workflowRunResult.workflowRunResult
+        assertEquals(2, monitorsRunResults.size)
+
+        val workflowMetadata = searchWorkflowMetadata(id = workflowId)
+        assertNotNull("Workflow metadata not initialized", workflowMetadata)
+        assertEquals(
+            "Workflow metadata execution id not correct",
+            executeWorkflowResponse.workflowRunResult.executionId,
+            workflowMetadata!!.latestExecutionId
+        )
+        // Second execution
+        val executeWorkflowResponse1 = executeWorkflow(workflowById, workflowId, false)!!
+        val monitorsRunResults1 = executeWorkflowResponse1.workflowRunResult.workflowRunResult
+        assertEquals(2, monitorsRunResults1.size)
+
+        val workflowMetadata1 = searchWorkflowMetadata(id = workflowId)
+        assertNotNull("Workflow metadata not initialized", workflowMetadata)
+        assertEquals(
+            "Workflow metadata execution id not correct",
+            executeWorkflowResponse1.workflowRunResult.executionId,
+            workflowMetadata1!!.latestExecutionId
+        )
+    }
+
+    fun `test execute workflow dryrun verify workflow metadata not created`() {
+        val docQuery1 = DocLevelQuery(query = "test_field_1:\"us-west-2\"", name = "3")
+        val docLevelInput1 = DocLevelMonitorInput("description", listOf(index), listOf(docQuery1))
+        val trigger1 = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        var monitor1 = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput1),
+            triggers = listOf(trigger1)
+        )
+        val monitorResponse = createMonitor(monitor1)!!
+
+        val docQuery2 = DocLevelQuery(query = "source.ip.v6.v2:16645", name = "4")
+        val docLevelInput2 = DocLevelMonitorInput("description", listOf(index), listOf(docQuery2))
+        val trigger2 = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        var monitor2 = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput2),
+            triggers = listOf(trigger2),
+        )
+
+        val monitorResponse2 = createMonitor(monitor2)!!
+
+        var workflow = randomWorkflow(
+            monitorIds = listOf(monitorResponse.id, monitorResponse2.id)
+        )
+        val workflowResponse = upsertWorkflow(workflow)!!
+        val workflowById = searchWorkflow(workflowResponse.id)
+        assertNotNull(workflowById)
+
+        var testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS))
+        // Matches monitor1
+        val testDoc1 = """{
+            "message" : "This is an error from IAD region",
+            "source.ip.v6.v2" : 16644, 
+            "test_strict_date_time" : "$testTime",
+            "test_field_1" : "us-west-2"
+        }"""
+        indexDoc(index, "1", testDoc1)
+        // First execution
+        val workflowId = workflowResponse.id
+        val executeWorkflowResponse = executeWorkflow(workflowById, workflowId, true)
+        assertNotNull("Workflow run result is null", executeWorkflowResponse)
+        val monitorsRunResults = executeWorkflowResponse!!.workflowRunResult.workflowRunResult
+        assertEquals(2, monitorsRunResults.size)
+
+        var exception: Exception? = null
+        try {
+            searchWorkflowMetadata(id = workflowId)
+        } catch (ex: Exception) {
+            exception = ex
+        }
+        assertTrue(exception is NoSuchElementException)
+    }
+
+    fun `test execute workflow with custom alerts and finding index with bucket level doc level delegates when bucket level delegate is used in chained finding`() {
+        val query = QueryBuilders.rangeQuery("test_strict_date_time")
+            .gt("{{period_end}}||-10d")
+            .lte("{{period_end}}")
+            .format("epoch_millis")
+        val compositeSources = listOf(
+            TermsValuesSourceBuilder("test_field_1").field("test_field_1")
+        )
+        val compositeAgg = CompositeAggregationBuilder("composite_agg", compositeSources)
+        val input = SearchInput(indices = listOf(index), query = SearchSourceBuilder().size(0).query(query).aggregation(compositeAgg))
+        // Bucket level monitor will reduce the size of matched doc ids on those that belong to a bucket that contains more than 1 document after term grouping
+        val triggerScript = """
+            params.docCount > 1
+        """.trimIndent()
+
+        var trigger = randomBucketLevelTrigger()
+        trigger = trigger.copy(
+            bucketSelector = BucketSelectorExtAggregationBuilder(
+                name = trigger.id,
+                bucketsPathsMap = mapOf("docCount" to "_count"),
+                script = Script(triggerScript),
+                parentBucketPath = "composite_agg",
+                filter = null,
+            )
+        )
+        val bucketCustomAlertsIndex = "custom_alerts_index"
+        val bucketCustomFindingsIndex = "custom_findings_index"
+        val bucketCustomFindingsIndexPattern = "custom_findings_index-1"
+
+        val bucketLevelMonitorResponse = createMonitor(
+            randomBucketLevelMonitor(
+                inputs = listOf(input),
+                enabled = false,
+                triggers = listOf(trigger),
+                dataSources = DataSources(
+                    findingsEnabled = true,
+                    alertsIndex = bucketCustomAlertsIndex,
+                    findingsIndex = bucketCustomFindingsIndex,
+                    findingsIndexPattern = bucketCustomFindingsIndexPattern
+                )
+            )
+        )!!
+
+        val docQuery1 = DocLevelQuery(query = "test_field_1:\"test_value_2\"", name = "1")
+        val docQuery2 = DocLevelQuery(query = "test_field_1:\"test_value_1\"", name = "2")
+        val docQuery3 = DocLevelQuery(query = "test_field_1:\"test_value_3\"", name = "3")
+        val docLevelInput = DocLevelMonitorInput("description", listOf(index), listOf(docQuery1, docQuery2, docQuery3))
+        val docTrigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val docCustomAlertsIndex = "custom_alerts_index"
+        val docCustomFindingsIndex = "custom_findings_index"
+        val docCustomFindingsIndexPattern = "custom_findings_index-1"
+        var docLevelMonitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(docTrigger),
+            dataSources = DataSources(
+                alertsIndex = docCustomAlertsIndex,
+                findingsIndex = docCustomFindingsIndex,
+                findingsIndexPattern = docCustomFindingsIndexPattern
+            )
+        )
+
+        val docLevelMonitorResponse = createMonitor(docLevelMonitor)!!
+        // 1. bucketMonitor (chainedFinding = null) 2. docMonitor (chainedFinding = bucketMonitor)
+        var workflow = randomWorkflow(
+            monitorIds = listOf(bucketLevelMonitorResponse.id, docLevelMonitorResponse.id)
+        )
+        val workflowResponse = upsertWorkflow(workflow)!!
+        val workflowById = searchWorkflow(workflowResponse.id)
+        assertNotNull(workflowById)
+
+        // Creates 5 documents
+        insertSampleTimeSerializedData(
+            index,
+            listOf(
+                "test_value_1",
+                "test_value_1", // adding duplicate to verify aggregation
+                "test_value_2",
+                "test_value_2",
+                "test_value_3"
+            )
+        )
+
+        val workflowId = workflowResponse.id
+        // 1. bucket level monitor should reduce the doc findings to 4 (1, 2, 3, 4)
+        // 2. Doc level monitor will match those 4 documents although it contains rules for matching all 5 documents (docQuery3 matches the fifth)
+        val executeWorkflowResponse = executeWorkflow(workflowById, workflowId, false)!!
+        assertNotNull(executeWorkflowResponse)
+
+        for (monitorRunResults in executeWorkflowResponse.workflowRunResult.workflowRunResult) {
+            if (bucketLevelMonitorResponse.monitor.name == monitorRunResults.monitorName) {
+                val searchResult = monitorRunResults.inputResults.results.first()
+                @Suppress("UNCHECKED_CAST")
+                val buckets = searchResult.stringMap("aggregations")?.stringMap("composite_agg")?.get("buckets") as List<Map<String, Any>>
+                assertEquals("Incorrect search result", 3, buckets.size)
+
+                assertAlerts(bucketLevelMonitorResponse.id, bucketCustomAlertsIndex, 2)
+                assertFindings(bucketLevelMonitorResponse.id, bucketCustomFindingsIndex, 1, 4, listOf("1", "2", "3", "4"))
+            } else {
+                assertEquals(1, monitorRunResults.inputResults.results.size)
+                val values = monitorRunResults.triggerResults.values
+                assertEquals(1, values.size)
+                @Suppress("UNCHECKED_CAST")
+                val docLevelTrigger = values.iterator().next() as DocumentLevelTriggerRunResult
+                val triggeredDocIds = docLevelTrigger.triggeredDocs.map { it.split("|")[0] }
+                val expectedTriggeredDocIds = listOf("1", "2", "3", "4")
+                assertEquals(expectedTriggeredDocIds, triggeredDocIds.sorted())
+
+                assertAlerts(docLevelMonitorResponse.id, docCustomAlertsIndex, 4)
+                assertFindings(docLevelMonitorResponse.id, docCustomFindingsIndex, 4, 4, listOf("1", "2", "3", "4"))
+            }
+        }
+    }
+
+    fun `test execute workflow with custom alerts and finding index with bucket level and doc level delegates when doc level delegate is used in chained finding`() {
+        val docQuery1 = DocLevelQuery(query = "test_field_1:\"test_value_2\"", name = "1")
+        val docQuery2 = DocLevelQuery(query = "test_field_1:\"test_value_3\"", name = "2")
+
+        var docLevelMonitor = randomDocumentLevelMonitor(
+            inputs = listOf(DocLevelMonitorInput("description", listOf(index), listOf(docQuery1, docQuery2))),
+            triggers = listOf(randomDocumentLevelTrigger(condition = ALWAYS_RUN)),
+            dataSources = DataSources(
+                alertsIndex = "custom_alerts_index",
+                findingsIndex = "custom_findings_index",
+                findingsIndexPattern = "custom_findings_index-1"
+            )
+        )
+
+        val docLevelMonitorResponse = createMonitor(docLevelMonitor)!!
+
+        val query = QueryBuilders.rangeQuery("test_strict_date_time")
+            .gt("{{period_end}}||-10d")
+            .lte("{{period_end}}")
+            .format("epoch_millis")
+        val compositeSources = listOf(
+            TermsValuesSourceBuilder("test_field_1").field("test_field_1")
+        )
+        val compositeAgg = CompositeAggregationBuilder("composite_agg", compositeSources)
+        val input = SearchInput(indices = listOf(index), query = SearchSourceBuilder().size(0).query(query).aggregation(compositeAgg))
+        // Bucket level monitor will reduce the size of matched doc ids on those that belong to a bucket that contains more than 1 document after term grouping
+        val triggerScript = """
+            params.docCount > 1
+        """.trimIndent()
+
+        var trigger = randomBucketLevelTrigger()
+        trigger = trigger.copy(
+            bucketSelector = BucketSelectorExtAggregationBuilder(
+                name = trigger.id,
+                bucketsPathsMap = mapOf("docCount" to "_count"),
+                script = Script(triggerScript),
+                parentBucketPath = "composite_agg",
+                filter = null,
+            )
+        )
+
+        val bucketLevelMonitorResponse = createMonitor(
+            randomBucketLevelMonitor(
+                inputs = listOf(input),
+                enabled = false,
+                triggers = listOf(trigger),
+                dataSources = DataSources(
+                    findingsEnabled = true,
+                    alertsIndex = "custom_alerts_index",
+                    findingsIndex = "custom_findings_index",
+                    findingsIndexPattern = "custom_findings_index-1"
+                )
+            )
+        )!!
+
+        var docLevelMonitor1 = randomDocumentLevelMonitor(
+            // Match the documents with test_field_1: test_value_3
+            inputs = listOf(DocLevelMonitorInput("description", listOf(index), listOf(docQuery2))),
+            triggers = listOf(randomDocumentLevelTrigger(condition = ALWAYS_RUN)),
+            dataSources = DataSources(
+                findingsEnabled = true,
+                alertsIndex = "custom_alerts_index_1",
+                findingsIndex = "custom_findings_index_1",
+                findingsIndexPattern = "custom_findings_index_1-1"
+            )
+        )
+
+        val docLevelMonitorResponse1 = createMonitor(docLevelMonitor1)!!
+
+        val queryMonitorInput = SearchInput(
+            indices = listOf(index),
+            query = SearchSourceBuilder().query(
+                QueryBuilders
+                    .rangeQuery("test_strict_date_time")
+                    .gt("{{period_end}}||-10d")
+                    .lte("{{period_end}}")
+                    .format("epoch_millis")
+            )
+        )
+        val queryTriggerScript = """
+            return ctx.results[0].hits.hits.size() > 0
+        """.trimIndent()
+
+        val queryLevelTrigger = randomQueryLevelTrigger(condition = Script(queryTriggerScript))
+        val queryMonitorResponse = createMonitor(randomQueryLevelMonitor(inputs = listOf(queryMonitorInput), triggers = listOf(queryLevelTrigger)))!!
+
+        // 1. docMonitor (chainedFinding = null) 2. bucketMonitor (chainedFinding = docMonitor) 3. docMonitor (chainedFinding = bucketMonitor) 4. queryMonitor (chainedFinding = docMonitor 3)
+        var workflow = randomWorkflow(
+            monitorIds = listOf(docLevelMonitorResponse.id, bucketLevelMonitorResponse.id, docLevelMonitorResponse1.id, queryMonitorResponse.id)
+        )
+        val workflowResponse = upsertWorkflow(workflow)!!
+        val workflowById = searchWorkflow(workflowResponse.id)
+        assertNotNull(workflowById)
+
+        // Creates 5 documents
+        insertSampleTimeSerializedData(
+            index,
+            listOf(
+                "test_value_1",
+                "test_value_1", // adding duplicate to verify aggregation
+                "test_value_2",
+                "test_value_2",
+                "test_value_3",
+                "test_value_3"
+            )
+        )
+
+        val workflowId = workflowResponse.id
+        // 1. Doc level monitor should reduce the doc findings to 4 (3 - test_value_2, 4 - test_value_2, 5 - test_value_3, 6 - test_value_3)
+        // 2. Bucket level monitor will match the fetch the docs from current findings execution, although it contains rules for matching documents which has test_value_2 and test value_3
+        val executeWorkflowResponse = executeWorkflow(workflowById, workflowId, false)!!
+        assertNotNull(executeWorkflowResponse)
+
+        for (monitorRunResults in executeWorkflowResponse.workflowRunResult.workflowRunResult) {
+            when (monitorRunResults.monitorName) {
+                // Verify first doc level monitor execution, alerts and findings
+                docLevelMonitorResponse.monitor.name -> {
+                    assertEquals(1, monitorRunResults.inputResults.results.size)
+                    val values = monitorRunResults.triggerResults.values
+                    assertEquals(1, values.size)
+                    @Suppress("UNCHECKED_CAST")
+                    val docLevelTrigger = values.iterator().next() as DocumentLevelTriggerRunResult
+                    val triggeredDocIds = docLevelTrigger.triggeredDocs.map { it.split("|")[0] }
+                    val expectedTriggeredDocIds = listOf("3", "4", "5", "6")
+                    assertEquals(expectedTriggeredDocIds, triggeredDocIds.sorted())
+
+                    assertAlerts(docLevelMonitorResponse.id, docLevelMonitorResponse.monitor.dataSources.alertsIndex, 4)
+                    assertFindings(docLevelMonitorResponse.id, docLevelMonitorResponse.monitor.dataSources.findingsIndex, 4, 4, listOf("3", "4", "5", "6"))
+                }
+                // Verify second bucket level monitor execution, alerts and findings
+                bucketLevelMonitorResponse.monitor.name -> {
+                    val searchResult = monitorRunResults.inputResults.results.first()
+                    @Suppress("UNCHECKED_CAST")
+                    val buckets = searchResult.stringMap("aggregations")?.stringMap("composite_agg")?.get("buckets") as List<Map<String, Any>>
+                    assertEquals("Incorrect search result", 2, buckets.size)
+
+                    assertAlerts(bucketLevelMonitorResponse.id, bucketLevelMonitorResponse.monitor.dataSources.alertsIndex, 2)
+                    assertFindings(bucketLevelMonitorResponse.id, bucketLevelMonitorResponse.monitor.dataSources.findingsIndex, 1, 4, listOf("3", "4", "5", "6"))
+                }
+                // Verify third doc level monitor execution, alerts and findings
+                docLevelMonitorResponse1.monitor.name -> {
+                    assertEquals(1, monitorRunResults.inputResults.results.size)
+                    val values = monitorRunResults.triggerResults.values
+                    assertEquals(1, values.size)
+                    @Suppress("UNCHECKED_CAST")
+                    val docLevelTrigger = values.iterator().next() as DocumentLevelTriggerRunResult
+                    val triggeredDocIds = docLevelTrigger.triggeredDocs.map { it.split("|")[0] }
+                    val expectedTriggeredDocIds = listOf("5", "6")
+                    assertEquals(expectedTriggeredDocIds, triggeredDocIds.sorted())
+
+                    assertAlerts(docLevelMonitorResponse1.id, docLevelMonitorResponse1.monitor.dataSources.alertsIndex, 2)
+                    assertFindings(docLevelMonitorResponse1.id, docLevelMonitorResponse1.monitor.dataSources.findingsIndex, 2, 2, listOf("5", "6"))
+                }
+                // Verify fourth query level monitor execution
+                queryMonitorResponse.monitor.name -> {
+                    assertEquals(1, monitorRunResults.inputResults.results.size)
+                    val values = monitorRunResults.triggerResults.values
+                    assertEquals(1, values.size)
+                    @Suppress("UNCHECKED_CAST")
+                    val totalHits = ((monitorRunResults.inputResults.results[0]["hits"] as Map<String, Any>)["total"] as Map<String, Any>) ["value"]
+                    assertEquals(2, totalHits)
+                    @Suppress("UNCHECKED_CAST")
+                    val docIds = ((monitorRunResults.inputResults.results[0]["hits"] as Map<String, Any>)["hits"] as List<Map<String, String>>).map { it["_id"]!! }
+                    assertEquals(listOf("5", "6"), docIds.sorted())
+                }
+            }
+        }
+    }
+
+    fun `test execute workflow input error`() {
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(DocLevelQuery(query = "source.ip.v6.v1:12345", name = "3"))
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+
+        val monitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger)
+        )
+
+        val monitorResponse = createMonitor(monitor)!!
+        var workflow = randomWorkflow(
+            monitorIds = listOf(monitorResponse.id)
+        )
+        val workflowResponse = upsertWorkflow(workflow)!!
+        val workflowById = searchWorkflow(workflowResponse.id)
+        assertNotNull(workflowById)
+
+        deleteIndex(index)
+
+        val response = executeWorkflow(workflowById, workflowById!!.id, false)!!
+        val error = response.workflowRunResult.workflowRunResult[0].error
+        assertNotNull(error)
+        assertTrue(error is AlertingException)
+        assertEquals(RestStatus.NOT_FOUND, (error as AlertingException).status)
+        assertEquals("Configured indices are not found: [$index]", (error as AlertingException).message)
+    }
+
+    fun `test execute workflow wrong workflow id`() {
+        val docLevelInput = DocLevelMonitorInput(
+            "description", listOf(index), listOf(DocLevelQuery(query = "source.ip.v6.v1:12345", name = "3"))
+        )
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+
+        val monitor = randomDocumentLevelMonitor(
+            inputs = listOf(docLevelInput),
+            triggers = listOf(trigger)
+        )
+
+        val monitorResponse = createMonitor(monitor)!!
+
+        val workflowRequest = randomWorkflow(
+            monitorIds = listOf(monitorResponse.id)
+        )
+        val workflowResponse = upsertWorkflow(workflowRequest)!!
+        val workflowId = workflowResponse.id
+        val getWorkflowResponse = getWorkflowById(id = workflowResponse.id)
+
+        assertNotNull(getWorkflowResponse)
+        assertEquals(workflowId, getWorkflowResponse.id)
+
+        var exception: Exception? = null
+        val badWorkflowId = getWorkflowResponse.id + "bad"
+        try {
+            executeWorkflow(id = badWorkflowId)
+        } catch (ex: Exception) {
+            exception = ex
+        }
+        assertTrue(exception is ExecutionException)
+        assertTrue(exception!!.cause is AlertingException)
+        assertEquals(RestStatus.NOT_FOUND, (exception.cause as AlertingException).status)
+        assertEquals("Can't find workflow with id: $badWorkflowId", exception.cause!!.message)
+    }
+
+    private fun assertFindings(
+        monitorId: String,
+        customFindingsIndex: String,
+        findingSize: Int,
+        matchedQueryNumber: Int,
+        relatedDocIds: List<String>
+    ) {
+        val findings = searchFindings(monitorId, customFindingsIndex)
+        assertEquals("Findings saved for test monitor", findingSize, findings.size)
+
+        val findingDocIds = findings.flatMap { it.relatedDocIds }
+
+        assertEquals("Didn't match $matchedQueryNumber query", matchedQueryNumber, findingDocIds.size)
+        assertTrue("Findings saved for test monitor", relatedDocIds.containsAll(findingDocIds))
+    }
+
+    private fun assertAlerts(
+        monitorId: String,
+        customAlertsIndex: String,
+        alertSize: Int
+    ) {
+        val alerts = searchAlerts(monitorId, customAlertsIndex)
+        assertEquals("Alert saved for test monitor", alertSize, alerts.size)
+        val table = Table("asc", "id", null, alertSize, 0, "")
+        var getAlertsResponse = client()
+            .execute(
+                AlertingActions.GET_ALERTS_ACTION_TYPE,
+                GetAlertsRequest(table, "ALL", "ALL", null, customAlertsIndex)
+            )
+            .get()
+        assertTrue(getAlertsResponse != null)
+        assertTrue(getAlertsResponse.alerts.size == alertSize)
+        getAlertsResponse = client()
+            .execute(AlertingActions.GET_ALERTS_ACTION_TYPE, GetAlertsRequest(table, "ALL", "ALL", monitorId, null))
+            .get()
+        assertTrue(getAlertsResponse != null)
+        assertTrue(getAlertsResponse.alerts.size == alertSize)
+
+        val alertIds = getAlertsResponse.alerts.map { it.id }
+        val acknowledgeAlertResponse = client().execute(
+            AlertingActions.ACKNOWLEDGE_ALERTS_ACTION_TYPE,
+            AcknowledgeAlertRequest(monitorId, alertIds, WriteRequest.RefreshPolicy.IMMEDIATE)
+        ).get()
+
+        assertEquals(alertSize, acknowledgeAlertResponse.acknowledged.size)
+    }
+}

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -841,7 +841,9 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         refreshIndex("*")
         val updatedMonitor = monitor.copy(triggers = emptyList())
         val updateResponse = client().makeRequest(
-            "PUT", "$ALERTING_BASE_URI/${monitor.id}", emptyMap(),
+            "PUT",
+            "$ALERTING_BASE_URI/${monitor.id}",
+            emptyMap(),
             updatedMonitor.toHttpEntity()
         )
         assertEquals("Update request not successful", RestStatus.OK, updateResponse.restStatus())

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/AlertingSingleNodeTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/AlertingSingleNodeTestCase.kt
@@ -24,7 +24,6 @@ import org.opensearch.alerting.action.GetMonitorRequest
 import org.opensearch.alerting.alerts.AlertIndices
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.unit.TimeValue
-import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.common.xcontent.json.JsonXContent
@@ -38,6 +37,7 @@ import org.opensearch.commons.alerting.model.Alert
 import org.opensearch.commons.alerting.model.Finding
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.Table
+import org.opensearch.core.xcontent.XContentBuilder
 import org.opensearch.index.IndexService
 import org.opensearch.index.query.TermQueryBuilder
 import org.opensearch.index.reindex.ReindexPlugin

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/AlertingSingleNodeTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/AlertingSingleNodeTestCase.kt
@@ -7,6 +7,7 @@ package org.opensearch.alerting.transport
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope
 import org.opensearch.action.admin.indices.alias.get.GetAliasesRequest
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest
 import org.opensearch.action.admin.indices.get.GetIndexRequest
 import org.opensearch.action.admin.indices.get.GetIndexRequestBuilder
 import org.opensearch.action.admin.indices.get.GetIndexResponse
@@ -23,6 +24,8 @@ import org.opensearch.alerting.action.GetMonitorRequest
 import org.opensearch.alerting.alerts.AlertIndices
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.unit.TimeValue
+import org.opensearch.common.xcontent.XContentBuilder
+import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.common.xcontent.json.JsonXContent
 import org.opensearch.commons.alerting.action.AlertingActions
@@ -35,16 +38,22 @@ import org.opensearch.commons.alerting.model.Alert
 import org.opensearch.commons.alerting.model.Finding
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.Table
+import org.opensearch.index.IndexService
 import org.opensearch.index.query.TermQueryBuilder
 import org.opensearch.index.reindex.ReindexPlugin
 import org.opensearch.index.seqno.SequenceNumbers
 import org.opensearch.join.ParentJoinPlugin
+import org.opensearch.painless.PainlessPlugin
 import org.opensearch.plugins.Plugin
 import org.opensearch.rest.RestRequest
+import org.opensearch.script.mustache.MustachePlugin
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.search.fetch.subphase.FetchSourceContext
 import org.opensearch.test.OpenSearchSingleNodeTestCase
 import java.time.Instant
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import java.util.Locale
 
 /**
@@ -75,17 +84,58 @@ abstract class AlertingSingleNodeTestCase : OpenSearchSingleNodeTestCase() {
         return client().execute(ExecuteMonitorAction.INSTANCE, request).get()
     }
 
-    /** A test index that can be used across tests. Feel free to add new fields but don't remove any. */
-    protected fun createTestIndex() {
-        createIndex(
-            index, Settings.EMPTY,
-            """
-                "properties" : {
-                  "test_strict_date_time" : { "type" : "date", "format" : "strict_date_time" },
-                  "test_field" : { "type" : "keyword" }
+    protected fun insertSampleTimeSerializedData(index: String, data: List<String>) {
+        data.forEachIndexed { i, value ->
+            val twoMinsAgo = ZonedDateTime.now().minus(2, ChronoUnit.MINUTES).truncatedTo(ChronoUnit.MILLIS)
+            val testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(twoMinsAgo)
+            val testDoc = """
+                {
+                  "test_strict_date_time": "$testTime",
+                  "test_field_1": "$value",
+                  "number": "$i"
                 }
             """.trimIndent()
+            // Indexing documents with deterministic doc id to allow for easy selected deletion during testing
+            indexDoc(index, (i + 1).toString(), testDoc)
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun Map<String, Any>.stringMap(key: String): Map<String, Any>? {
+        val map = this as Map<String, Map<String, Any>>
+        return map[key]
+    }
+
+    /** A test index that can be used across tests. Feel free to add new fields but don't remove any. */
+    protected fun createTestIndex() {
+        val mapping = XContentFactory.jsonBuilder()
+        mapping.startObject()
+            .startObject("properties")
+            .startObject("test_strict_date_time")
+            .field("type", "date")
+            .field("format", "strict_date_time")
+            .endObject()
+            .startObject("test_field_1")
+            .field("type", "keyword")
+            .endObject()
+            .endObject()
+            .endObject()
+
+        createIndex(
+            index, Settings.EMPTY, mapping
         )
+    }
+
+    private fun createIndex(
+        index: String?,
+        settings: Settings?,
+        mappings: XContentBuilder?,
+    ): IndexService? {
+        val createIndexRequestBuilder = client().admin().indices().prepareCreate(index).setSettings(settings)
+        if (mappings != null) {
+            createIndexRequestBuilder.setMapping(mappings)
+        }
+        return this.createIndex(index, createIndexRequestBuilder)
     }
 
     protected fun indexDoc(index: String, id: String, doc: String) {
@@ -230,7 +280,18 @@ abstract class AlertingSingleNodeTestCase : OpenSearchSingleNodeTestCase() {
     ).get()
 
     override fun getPlugins(): List<Class<out Plugin>> {
-        return listOf(AlertingPlugin::class.java, ReindexPlugin::class.java, ParentJoinPlugin::class.java)
+        return listOf(
+            AlertingPlugin::class.java,
+            ReindexPlugin::class.java,
+            MustachePlugin::class.java,
+            PainlessPlugin::class.java,
+            ParentJoinPlugin::class.java
+        )
+    }
+
+    protected fun deleteIndex(index: String) {
+        val response = client().admin().indices().delete(DeleteIndexRequest(index)).get()
+        assertTrue("Unable to delete index", response.isAcknowledged())
     }
 
     override fun resetNodeAfterTest(): Boolean {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/AlertingSingleNodeTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/AlertingSingleNodeTestCase.kt
@@ -126,6 +126,25 @@ abstract class AlertingSingleNodeTestCase : OpenSearchSingleNodeTestCase() {
         )
     }
 
+    protected fun createTestIndex(index: String) {
+        val mapping = XContentFactory.jsonBuilder()
+        mapping.startObject()
+            .startObject("properties")
+            .startObject("test_strict_date_time")
+            .field("type", "date")
+            .field("format", "strict_date_time")
+            .endObject()
+            .startObject("test_field_1")
+            .field("type", "keyword")
+            .endObject()
+            .endObject()
+            .endObject()
+
+        createIndex(
+            index, Settings.EMPTY, mapping
+        )
+    }
+
     private fun createIndex(
         index: String?,
         settings: Settings?,

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/WorkflowSingleNodeTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/WorkflowSingleNodeTestCase.kt
@@ -9,6 +9,9 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope
 import org.opensearch.action.support.WriteRequest
 import org.opensearch.common.xcontent.json.JsonXContent
 import org.opensearch.commons.alerting.action.AlertingActions
+import org.opensearch.commons.alerting.action.DeleteWorkflowRequest
+import org.opensearch.commons.alerting.action.GetWorkflowRequest
+import org.opensearch.commons.alerting.action.GetWorkflowResponse
 import org.opensearch.commons.alerting.action.IndexWorkflowRequest
 import org.opensearch.commons.alerting.action.IndexWorkflowResponse
 import org.opensearch.commons.alerting.model.ScheduledJob
@@ -71,5 +74,18 @@ abstract class WorkflowSingleNodeTestCase : AlertingSingleNodeTestCase() {
         )
 
         return client().execute(AlertingActions.INDEX_WORKFLOW_ACTION_TYPE, request).actionGet()
+    }
+    protected fun getWorkflowById(id: String): GetWorkflowResponse {
+        return client().execute(
+            AlertingActions.GET_WORKFLOW_ACTION_TYPE,
+            GetWorkflowRequest(id, RestRequest.Method.GET)
+        ).get()
+    }
+
+    protected fun deleteWorkflow(workflowId: String, deleteDelegateMonitors: Boolean? = null) {
+        client().execute(
+            AlertingActions.DELETE_WORKFLOW_ACTION_TYPE,
+            DeleteWorkflowRequest(workflowId, deleteDelegateMonitors)
+        ).get()
     }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/WorkflowSingleNodeTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/WorkflowSingleNodeTestCase.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.transport
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope
+import org.opensearch.action.support.WriteRequest
+import org.opensearch.common.xcontent.XContentParser
+import org.opensearch.common.xcontent.json.JsonXContent
+import org.opensearch.commons.alerting.action.AlertingActions
+import org.opensearch.commons.alerting.action.IndexWorkflowRequest
+import org.opensearch.commons.alerting.action.IndexWorkflowResponse
+import org.opensearch.commons.alerting.model.ScheduledJob
+import org.opensearch.commons.alerting.model.Workflow
+import org.opensearch.index.query.TermQueryBuilder
+import org.opensearch.index.seqno.SequenceNumbers
+import org.opensearch.rest.RestRequest
+import org.opensearch.search.builder.SearchSourceBuilder
+
+/**
+ * A test that keep a singleton node started for all tests that can be used to get
+ * references to Guice injectors in unit tests.
+ */
+
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+abstract class WorkflowSingleNodeTestCase : AlertingSingleNodeTestCase() {
+
+    protected fun searchWorkflow(
+        id: String,
+        indices: String = ScheduledJob.SCHEDULED_JOBS_INDEX,
+        refresh: Boolean = true,
+    ): Workflow? {
+        try {
+            if (refresh) refreshIndex(indices)
+        } catch (e: Exception) {
+            logger.warn("Could not refresh index $indices because: ${e.message}")
+            return null
+        }
+        val ssb = SearchSourceBuilder()
+        ssb.version(true)
+        ssb.query(TermQueryBuilder("_id", id))
+        val searchResponse = client().prepareSearch(indices).setRouting(id).setSource(ssb).get()
+
+        return searchResponse.hits.hits.map { it ->
+            val xcp = createParser(JsonXContent.jsonXContent, it.sourceRef).also { it.nextToken() }
+            lateinit var workflow: Workflow
+            while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
+                xcp.nextToken()
+                when (xcp.currentName()) {
+                    "workflow" -> workflow = Workflow.parse(xcp)
+                }
+            }
+            workflow.copy(id = it.id, version = it.version)
+        }.first()
+    }
+
+    protected fun upsertWorkflow(
+        workflow: Workflow,
+        id: String = Workflow.NO_ID,
+        method: RestRequest.Method = RestRequest.Method.POST,
+    ): IndexWorkflowResponse? {
+        val request = IndexWorkflowRequest(
+            workflowId = id,
+            seqNo = SequenceNumbers.UNASSIGNED_SEQ_NO,
+            primaryTerm = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
+            refreshPolicy = WriteRequest.RefreshPolicy.parse("true"),
+            method = method,
+            workflow = workflow
+        )
+
+        return client().execute(AlertingActions.INDEX_WORKFLOW_ACTION_TYPE, request).actionGet()
+    }
+}

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/WorkflowSingleNodeTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/WorkflowSingleNodeTestCase.kt
@@ -7,13 +7,13 @@ package org.opensearch.alerting.transport
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope
 import org.opensearch.action.support.WriteRequest
-import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.json.JsonXContent
 import org.opensearch.commons.alerting.action.AlertingActions
 import org.opensearch.commons.alerting.action.IndexWorkflowRequest
 import org.opensearch.commons.alerting.action.IndexWorkflowResponse
 import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.model.Workflow
+import org.opensearch.core.xcontent.XContentParser
 import org.opensearch.index.query.TermQueryBuilder
 import org.opensearch.index.seqno.SequenceNumbers
 import org.opensearch.rest.RestRequest

--- a/core/src/main/resources/mappings/scheduled-jobs.json
+++ b/core/src/main/resources/mappings/scheduled-jobs.json
@@ -663,6 +663,29 @@
           "enabled": false
         }
       }
+    },
+    "workflow_metadata" : {
+      "properties": {
+        "workflow_id": {
+          "type": "keyword"
+        },
+        "monitor_ids": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 1000
+            }
+          }
+        },
+        "latest_run_time": {
+          "type": "date",
+          "format": "strict_date_time||epoch_millis"
+        },
+        "latest_execution_id": {
+          "type": "keyword"
+        }
+      }
     }
   }
 }

--- a/core/src/main/resources/mappings/scheduled-jobs.json
+++ b/core/src/main/resources/mappings/scheduled-jobs.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 6
+    "schema_version": 7
   },
   "properties": {
     "monitor": {
@@ -296,6 +296,151 @@
         "ui_metadata": {
           "type": "object",
           "enabled": false
+        }
+      }
+    },
+    "workflow": {
+      "dynamic": "false",
+      "properties": {
+        "schema_version": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "owner": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "workflow_type": {
+          "type": "keyword"
+        },
+        "user": {
+          "properties": {
+            "name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "backend_roles": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            },
+            "roles": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            },
+            "custom_attribute_names": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            }
+          }
+        },
+        "type": {
+          "type": "keyword"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "enabled_time": {
+          "type": "date",
+          "format": "strict_date_time||epoch_millis"
+        },
+        "last_update_time": {
+          "type": "date",
+          "format": "strict_date_time||epoch_millis"
+        },
+        "schedule": {
+          "properties": {
+            "period": {
+              "properties": {
+                "interval": {
+                  "type": "integer"
+                },
+                "unit": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "cron": {
+              "properties": {
+                "expression": {
+                  "type": "text"
+                },
+                "timezone": {
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "inputs": {
+          "type": "nested",
+          "properties": {
+            "composite_input": {
+              "type": "nested",
+              "properties": {
+                "sequence": {
+                  "properties": {
+                    "delegates": {
+                      "type": "nested",
+                      "properties": {
+                        "order": {
+                          "type": "integer"
+                        },
+                        "monitor_id": {
+                          "type": "keyword"
+                        },
+                        "chained_monitor_findings": {
+                          "properties": {
+                            "monitor_id": {
+                              "type": "keyword"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "group_by_fields": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
PRs reviewed in feature branch:
Added layer for creating and updating the workflow (#831)
Fixed xContent dependencies due to OSCore changes (#839)
Dependency fix (#846)
Added transport layer classes for getting and deleting the workflow (#835)
Refactored workflowIndexing validation - removed coroutine and context ( #857)
Added workflow execution logic (#850)
Added fix when executing the workflow and when chained findings index is not initialized( #890)
Fixed deleting monitor workflow metadata (#882)