### PR TITLE
Fixed search monitor API to return alert counts.

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchMonitorAction.kt
@@ -21,11 +21,9 @@ import org.opensearch.common.settings.Settings
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
 import org.opensearch.common.xcontent.XContentFactory.jsonBuilder
 import org.opensearch.common.xcontent.XContentType
-import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.model.ScheduledJob.Companion.SCHEDULED_JOBS_INDEX
 import org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS
-import org.opensearch.index.query.QueryBuilders
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
 import org.opensearch.rest.BytesRestResponse

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestSearchMonitorAction.kt
@@ -97,14 +97,6 @@ class RestSearchMonitorAction(
         searchSourceBuilder.parseXContent(request.contentOrSourceParamParser())
         searchSourceBuilder.fetchSource(context(request))
 
-        val queryBuilder = QueryBuilders.boolQuery().must(searchSourceBuilder.query())
-        if (index == SCHEDULED_JOBS_INDEX) {
-            queryBuilder.filter(QueryBuilders.existsQuery(Monitor.MONITOR_TYPE))
-        }
-
-        searchSourceBuilder.query(queryBuilder)
-            .seqNoAndPrimaryTerm(true)
-            .version(true)
         val searchRequest = SearchRequest()
             .source(searchSourceBuilder)
             .indices(index)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
@@ -13,7 +13,6 @@ import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.alerting.action.SearchMonitorAction
 import org.opensearch.alerting.action.SearchMonitorRequest
-import org.opensearch.alerting.alerts.AlertIndices.Companion.ALL_ALERT_INDEX_PATTERN
 import org.opensearch.alerting.opensearchapi.addFilter
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.util.AlertingException

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
@@ -53,7 +53,8 @@ class TransportSearchMonitorAction @Inject constructor(
         val searchSourceBuilder = searchMonitorRequest.searchRequest.source()
             .seqNoAndPrimaryTerm(true)
             .version(true)
-        val queryBuilder = QueryBuilders.boolQuery().must(searchSourceBuilder.query())
+        val queryBuilder = if (searchSourceBuilder.query() == null) BoolQueryBuilder()
+        else QueryBuilders.boolQuery().must(searchSourceBuilder.query())
 
         // The SearchMonitor API supports one 'index' parameter of either the SCHEDULED_JOBS_INDEX or ALL_ALERT_INDEX_PATTERN.
         // When querying the ALL_ALERT_INDEX_PATTERN, we don't want to check whether the MONITOR_TYPE field exists

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
@@ -23,6 +23,7 @@ import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
 import org.opensearch.common.settings.Settings
 import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.authuser.User
 import org.opensearch.index.query.BoolQueryBuilder
 import org.opensearch.index.query.ExistsQueryBuilder
@@ -51,12 +52,14 @@ class TransportSearchMonitorAction @Inject constructor(
 
     override fun doExecute(task: Task, searchMonitorRequest: SearchMonitorRequest, actionListener: ActionListener<SearchResponse>) {
         val searchSourceBuilder = searchMonitorRequest.searchRequest.source()
-        val queryBuilder = if (searchSourceBuilder.query() == null) BoolQueryBuilder()
-        else QueryBuilders.boolQuery().must(searchSourceBuilder.query())
+            .seqNoAndPrimaryTerm(true)
+            .version(true)
+        val queryBuilder = QueryBuilders.boolQuery().must(searchSourceBuilder.query())
 
-        if (searchMonitorRequest.searchRequest.indices().size == 1 &&
-            !searchMonitorRequest.searchRequest.indices().contains(ALL_ALERT_INDEX_PATTERN)
-        ) {
+        // The SearchMonitor API supports one 'index' parameter of either the SCHEDULED_JOBS_INDEX or ALL_ALERT_INDEX_PATTERN.
+        // When querying the ALL_ALERT_INDEX_PATTERN, we don't want to check whether the MONITOR_TYPE field exists
+        // because we're querying alert indexes.
+        if (searchMonitorRequest.searchRequest.indices().contains(ScheduledJob.SCHEDULED_JOBS_INDEX)) {
             queryBuilder.filter(QueryBuilders.existsQuery(Monitor.MONITOR_TYPE))
         }
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -1293,7 +1293,7 @@ class MonitorRestApiIT : AlertingRestTestCase() {
             monitorAlertCounts[monitor.id] = alertCounts
 
             repeat(numAcknowledgedAlerts) {
-                createAlert(randomAlert(monitor).copy(acknowledgedTime = Instant.now(),state = Alert.State.ACKNOWLEDGED))
+                createAlert(randomAlert(monitor).copy(acknowledgedTime = Instant.now(), state = Alert.State.ACKNOWLEDGED))
             }
             repeat(numActiveAlerts) {
                 createAlert(randomAlert(monitor).copy(state = Alert.State.ACTIVE))
@@ -1352,20 +1352,28 @@ class MonitorRestApiIT : AlertingRestTestCase() {
             val monitorCounts = monitorAlertCounts[id]!!
 
             val acknowledged = (bucket["acknowledged"]!! as Map<String, Int>)["doc_count"]!!
-            assertEquals("Incorrect ${Alert.State.ACKNOWLEDGED} count returned for monitor $id",
-                monitorCounts[Alert.State.ACKNOWLEDGED.name], acknowledged)
+            assertEquals(
+                "Incorrect ${Alert.State.ACKNOWLEDGED} count returned for monitor $id",
+                monitorCounts[Alert.State.ACKNOWLEDGED.name], acknowledged
+            )
 
             val active = (bucket["active"]!! as Map<String, Int>)["doc_count"]!!
-            assertEquals("Incorrect ${Alert.State.ACTIVE} count returned for monitor $id",
-                monitorCounts[Alert.State.ACTIVE.name], active)
+            assertEquals(
+                "Incorrect ${Alert.State.ACTIVE} count returned for monitor $id",
+                monitorCounts[Alert.State.ACTIVE.name], active
+            )
 
             val errors = (bucket["errors"]!! as Map<String, Int>)["doc_count"]!!
-            assertEquals("Incorrect ${Alert.State.ERROR} count returned for monitor $id",
-                monitorCounts[Alert.State.ERROR.name], errors)
+            assertEquals(
+                "Incorrect ${Alert.State.ERROR} count returned for monitor $id",
+                monitorCounts[Alert.State.ERROR.name], errors
+            )
 
             val ignored = (bucket["ignored"]!! as Map<String, Int>)["doc_count"]!!
-            assertEquals("Incorrect IGNORED count returned for monitor $id",
-                monitorCounts["IGNORED"], ignored)
+            assertEquals(
+                "Incorrect IGNORED count returned for monitor $id",
+                monitorCounts["IGNORED"], ignored
+            )
         }
     }
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -1339,7 +1339,7 @@ class MonitorRestApiIT : AlertingRestTestCase() {
             "GET",
             "$ALERTING_BASE_URI/_search",
             hashMapOf("index" to AlertIndices.ALL_ALERT_INDEX_PATTERN),
-            NStringEntity(sourceBuilder.toString(), ContentType.APPLICATION_JSON)
+            StringEntity(sourceBuilder.toString(), ContentType.APPLICATION_JSON)
         )
         val xcp = createParser(XContentType.JSON.xContent(), searchResponse.entity.content).map()
         val aggregations = (xcp["aggregations"]!! as Map<String, Map<String, Any>>)

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -54,7 +54,9 @@ import org.opensearch.core.xcontent.XContentBuilder
 import org.opensearch.index.query.QueryBuilders
 import org.opensearch.rest.RestStatus
 import org.opensearch.script.Script
+import org.opensearch.search.aggregations.AggregationBuilders
 import org.opensearch.search.builder.SearchSourceBuilder
+import org.opensearch.search.sort.SortOrder
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.test.junit.annotations.TestLogging
 import org.opensearch.test.rest.OpenSearchRestTestCase
@@ -1260,6 +1262,110 @@ class MonitorRestApiIT : AlertingRestTestCase() {
                 "Incompatible trigger [${trigger.id}] for monitor type [${Monitor.MonitorType.QUERY_LEVEL_MONITOR}]",
                 e.message
             )
+        }
+    }
+
+    /**
+     * This use case is needed by the frontend plugin for displaying alert counts on the Monitors list page.
+     * https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/server/services/MonitorService.js#L235
+     */
+    fun `test get acknowledged, active, error, and ignored alerts counts`() {
+        putAlertMappings()
+        val monitorAlertCounts = hashMapOf<String, HashMap<String, Int>>()
+        val numMonitors = randomIntBetween(1, 10)
+        repeat(numMonitors) {
+            val monitor = createRandomMonitor(refresh = true)
+
+            val numAcknowledgedAlerts = randomIntBetween(1, 10)
+            val numActiveAlerts = randomIntBetween(1, 10)
+            var numCompletedAlerts = randomIntBetween(1, 10)
+            val numErrorAlerts = randomIntBetween(1, 10)
+            val numIgnoredAlerts = randomIntBetween(1, numCompletedAlerts)
+            numCompletedAlerts -= numIgnoredAlerts
+
+            val alertCounts = hashMapOf(
+                Alert.State.ACKNOWLEDGED.name to numAcknowledgedAlerts,
+                Alert.State.ACTIVE.name to numActiveAlerts,
+                Alert.State.COMPLETED.name to numCompletedAlerts,
+                Alert.State.ERROR.name to numErrorAlerts,
+                "IGNORED" to numIgnoredAlerts
+            )
+            monitorAlertCounts[monitor.id] = alertCounts
+
+            repeat(numAcknowledgedAlerts) {
+                createAlert(randomAlert(monitor).copy(acknowledgedTime = Instant.now(),state = Alert.State.ACKNOWLEDGED))
+            }
+            repeat(numActiveAlerts) {
+                createAlert(randomAlert(monitor).copy(state = Alert.State.ACTIVE))
+            }
+            repeat(numCompletedAlerts) {
+                createAlert(randomAlert(monitor).copy(acknowledgedTime = Instant.now(), state = Alert.State.COMPLETED))
+            }
+            repeat(numErrorAlerts) {
+                createAlert(randomAlert(monitor).copy(state = Alert.State.ERROR))
+            }
+            repeat(numIgnoredAlerts) {
+                createAlert(randomAlert(monitor).copy(acknowledgedTime = null, state = Alert.State.COMPLETED))
+            }
+        }
+
+        val sourceBuilder = SearchSourceBuilder()
+            .size(0)
+            .query(QueryBuilders.termsQuery("monitor_id", monitorAlertCounts.keys))
+            .aggregation(
+                AggregationBuilders
+                    .terms("uniq_monitor_ids").field("monitor_id")
+                    .subAggregation(AggregationBuilders.filter("active", QueryBuilders.termQuery("state", "ACTIVE")))
+                    .subAggregation(AggregationBuilders.filter("acknowledged", QueryBuilders.termQuery("state", "ACKNOWLEDGED")))
+                    .subAggregation(AggregationBuilders.filter("errors", QueryBuilders.termQuery("state", "ERROR")))
+                    .subAggregation(
+                        AggregationBuilders.filter(
+                            "ignored",
+                            QueryBuilders.boolQuery()
+                                .filter(QueryBuilders.termQuery("state", "COMPLETED"))
+                                .mustNot(QueryBuilders.existsQuery("acknowledged_time"))
+                        )
+                    )
+                    .subAggregation(AggregationBuilders.max("last_notification_time").field("last_notification_time"))
+                    .subAggregation(
+                        AggregationBuilders.topHits("latest_alert")
+                            .size(1)
+                            .sort("start_time", SortOrder.DESC)
+                            .fetchSource(arrayOf("last_notification_time", "trigger_name"), null)
+                    )
+            )
+
+        val searchResponse = client().makeRequest(
+            "GET",
+            "$ALERTING_BASE_URI/_search",
+            hashMapOf("index" to AlertIndices.ALL_ALERT_INDEX_PATTERN),
+            NStringEntity(sourceBuilder.toString(), ContentType.APPLICATION_JSON)
+        )
+        val xcp = createParser(XContentType.JSON.xContent(), searchResponse.entity.content).map()
+        val aggregations = (xcp["aggregations"]!! as Map<String, Map<String, Any>>)
+        val uniqMonitorIds = aggregations["uniq_monitor_ids"]!!
+        val buckets = uniqMonitorIds["buckets"]!! as ArrayList<Map<String, Any>>
+
+        assertEquals("Incorrect number of monitors returned", monitorAlertCounts.keys.size, buckets.size)
+        buckets.forEach { bucket ->
+            val id = bucket["key"]!!
+            val monitorCounts = monitorAlertCounts[id]!!
+
+            val acknowledged = (bucket["acknowledged"]!! as Map<String, Int>)["doc_count"]!!
+            assertEquals("Incorrect ${Alert.State.ACKNOWLEDGED} count returned for monitor $id",
+                monitorCounts[Alert.State.ACKNOWLEDGED.name], acknowledged)
+
+            val active = (bucket["active"]!! as Map<String, Int>)["doc_count"]!!
+            assertEquals("Incorrect ${Alert.State.ACTIVE} count returned for monitor $id",
+                monitorCounts[Alert.State.ACTIVE.name], active)
+
+            val errors = (bucket["errors"]!! as Map<String, Int>)["doc_count"]!!
+            assertEquals("Incorrect ${Alert.State.ERROR} count returned for monitor $id",
+                monitorCounts[Alert.State.ERROR.name], errors)
+
+            val ignored = (bucket["ignored"]!! as Map<String, Int>)["doc_count"]!!
+            assertEquals("Incorrect IGNORED count returned for monitor $id",
+                monitorCounts["IGNORED"], ignored)
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Fixed a bug in the search monitor API when which prevent alert counts from being returned.
2. Implemented integ test for frontend use case.

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).