### PR TITLE
[Backport 2.x] fix alert constructor with noop trigger to use executi…

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
@@ -248,7 +248,12 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
                 // If any error happened during trigger execution, upsert monitor error alert
                 val errorMessage = constructErrorMessageFromTriggerResults(triggerResults = triggerResults)
                 if (errorMessage.isNotEmpty()) {
-                    monitorCtx.alertService!!.upsertMonitorErrorAlert(monitor = monitor, errorMessage = errorMessage)
+                    monitorCtx.alertService!!.upsertMonitorErrorAlert(
+                        monitor = monitor,
+                        errorMessage = errorMessage,
+                        executionId = workflowRunContext?.executionId,
+                        workflowRunContext
+                    )
                 } else {
                     onSuccessfulMonitorRun(monitorCtx, monitor)
                 }
@@ -263,7 +268,7 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
             return monitorResult.copy(triggerResults = triggerResults)
         } catch (e: Exception) {
             val errorMessage = ExceptionsHelper.detailedMessage(e)
-            monitorCtx.alertService!!.upsertMonitorErrorAlert(monitor, errorMessage)
+            monitorCtx.alertService!!.upsertMonitorErrorAlert(monitor, errorMessage, workflowRunContext?.executionId, workflowRunContext)
             logger.error("Failed running Document-level-monitor ${monitor.name}", e)
             val alertingException = AlertingException(
                 errorMessage,

--- a/alerting/src/main/resources/org/opensearch/alerting/alerts/alert_mapping.json
+++ b/alerting/src/main/resources/org/opensearch/alerting/alerts/alert_mapping.json
@@ -13,9 +13,6 @@
     "monitor_id": {
       "type": "keyword"
     },
-    "workflow_id": {
-      "type": "keyword"
-    },
     "monitor_version": {
       "type": "long"
     },
@@ -26,9 +23,6 @@
       "type": "long"
     },
     "severity": {
-      "type": "keyword"
-    },
-    "execution_id": {
       "type": "keyword"
     },
     "monitor_name": {
@@ -77,6 +71,15 @@
         }
       }
     },
+    "execution_id": {
+      "type": "keyword"
+    },
+    "workflow_id": {
+      "type": "keyword"
+    },
+    "workflow_name": {
+      "type": "keyword"
+    },
     "trigger_id": {
       "type": "keyword"
     },
@@ -90,6 +93,14 @@
       }
     },
     "finding_ids": {
+      "type" : "text",
+      "fields" : {
+        "keyword" : {
+          "type" : "keyword"
+        }
+      }
+    },
+    "associated_alert_ids": {
       "type" : "text",
       "fields" : {
         "keyword" : {


### PR DESCRIPTION
…on id and workflow id


*Issue #, if available:*

*Description of changes:*
backport of pr #981 

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).