### PR TITLE
fix password argument in SecureRestClientBuilder constructor for SecureWorkflowRestApiIT

### DIFF
--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureWorkflowRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureWorkflowRestApiIT.kt
@@ -1407,10 +1407,10 @@ class SecureWorkflowRestApiIT : AlertingRestTestCase() {
         try {
             executeWorkflow(workflowId = workflowResponse.id)
             val bucketAlerts = searchAlerts(bucketMonitor)
-            assertEquals("Incorrect number of alerts", 2, bucketAlerts.size)
+            assertEquals("Incorrect number of alerts", 0, bucketAlerts.size)
 
             val docAlerts = searchAlerts(docMonitor)
-            assertEquals("Incorrect number of alerts", 1, docAlerts.size)
+            assertEquals("Incorrect number of alerts", 0, docAlerts.size)
         } finally {
             deleteRoleAndRoleMapping(TEST_HR_ROLE)
         }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureWorkflowRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureWorkflowRestApiIT.kt
@@ -82,7 +82,7 @@ class SecureWorkflowRestApiIT : AlertingRestTestCase() {
     fun create() {
         if (userClient == null) {
             createUser(user, arrayOf())
-            userClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), user, user).setSocketTimeout(60000).build()
+            userClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), user, password).setSocketTimeout(60000).build()
         }
     }
 
@@ -369,7 +369,7 @@ class SecureWorkflowRestApiIT : AlertingRestTestCase() {
             listOf("role2"),
             getClusterPermissionsFromCustomRole(ALERTING_GET_WORKFLOW_ACCESS)
         )
-        val getUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), getUser, getUser)
+        val getUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), getUser, password)
             .setSocketTimeout(60000).build()
 
         val getWorkflowResponse = getUserClient?.makeRequest(
@@ -430,7 +430,7 @@ class SecureWorkflowRestApiIT : AlertingRestTestCase() {
         )
 
         val userWithDifferentRoleClient = SecureRestClientBuilder(
-            clusterHosts.toTypedArray(), isHttps(), userWithDifferentRole, userWithDifferentRole
+            clusterHosts.toTypedArray(), isHttps(), userWithDifferentRole, password
         )
             .setSocketTimeout(60000).build()
 
@@ -625,7 +625,7 @@ class SecureWorkflowRestApiIT : AlertingRestTestCase() {
             listOf("role2"),
             getClusterPermissionsFromCustomRole(ALERTING_GET_WORKFLOW_ACCESS)
         )
-        val getUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), getUser, getUser)
+        val getUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), getUser, password)
             .setSocketTimeout(60000).build()
 
         val getWorkflowResponse = getUserClient?.makeRequest(
@@ -786,7 +786,7 @@ class SecureWorkflowRestApiIT : AlertingRestTestCase() {
             listOf("role2"),
             getClusterPermissionsFromCustomRole(ALERTING_GET_WORKFLOW_ACCESS)
         )
-        val getUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), getUser, getUser)
+        val getUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), getUser, password)
             .setSocketTimeout(60000).build()
 
         val getWorkflowResponse = getUserClient?.makeRequest(
@@ -846,7 +846,7 @@ class SecureWorkflowRestApiIT : AlertingRestTestCase() {
             false
         )
 
-        val updateUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), updateUser, updateUser)
+        val updateUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), updateUser, password)
             .setSocketTimeout(60000).build()
         val updatedWorkflow = updateWorkflowWithClient(updateUserClient, createdWorkflow, listOf("role5"))
 
@@ -904,7 +904,7 @@ class SecureWorkflowRestApiIT : AlertingRestTestCase() {
             listOf("role1", "role2"),
             getClusterPermissionsFromCustomRole(ALERTING_GET_WORKFLOW_ACCESS)
         )
-        val getUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), getUser, getUser)
+        val getUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), getUser, password)
             .setSocketTimeout(60000).build()
 
         val getWorkflowResponse = getUserClient?.makeRequest(
@@ -1074,7 +1074,7 @@ class SecureWorkflowRestApiIT : AlertingRestTestCase() {
                 getClusterPermissionsFromCustomRole(ALERTING_GET_WORKFLOW_ACCESS)
             )
         )
-        val deleteUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), deleteUser, deleteUser)
+        val deleteUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), deleteUser, password)
             .setSocketTimeout(60000).build()
 
         try {


### PR DESCRIPTION
fix password argument in SecureRestClientBuilder constructor for SecureWorkflowRestApiIT

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).