### PR TITLE
add alertId parameter in get chained alert API and paginate associated alerts if alertId param is mentioned

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetWorkflowAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetWorkflowAlertsAction.kt
@@ -55,10 +55,15 @@ class RestGetWorkflowAlertsAction : BaseRestHandler() {
         val severityLevel = request.param("severityLevel", "ALL")
         val alertState = request.param("alertState", "ALL")
         val workflowId: String? = request.param("workflowIds")
+        val alertId: String? = request.param("alertIds")
         val getAssociatedAlerts: Boolean = request.param("getAssociatedAlerts", "false").toBoolean()
         val workflowIds = mutableListOf<String>()
         if (workflowId.isNullOrEmpty() == false) {
             workflowIds.add(workflowId)
+        }
+        val alertIds = mutableListOf<String>()
+        if (alertId.isNullOrEmpty() == false) {
+            alertIds.add(alertId)
         }
         val table = Table(
             sortOrder,
@@ -77,7 +82,8 @@ class RestGetWorkflowAlertsAction : BaseRestHandler() {
             associatedAlertsIndex = null,
             workflowIds = workflowIds,
             monitorIds = emptyList(),
-            getAssociatedAlerts = getAssociatedAlerts
+            getAssociatedAlerts = getAssociatedAlerts,
+            alertIds = alertIds
         )
         return RestChannelConsumer { channel ->
             client.execute(AlertingActions.GET_WORKFLOW_ALERTS_ACTION_TYPE, getWorkflowAlertsRequest, RestToXContentListener(channel))

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAlertsAction.kt
@@ -243,7 +243,7 @@ class TransportGetWorkflowAlertsAction @Inject constructor(
                 if (!tableProp.missing.isNullOrBlank()) {
                     sortBuilder.missing(tableProp.missing)
                 }
-                searchRequest.source().sort(sortBuilder).size(tableProp.size)
+                searchRequest.source().sort(sortBuilder).size(tableProp.size).from(tableProp.startIndex)
             }
             queryBuilder.must(QueryBuilders.termsQuery("_id", associatedAlertIds))
             queryBuilder.must(QueryBuilders.termQuery(Alert.STATE_FIELD, Alert.State.AUDIT))

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAlertsAction.kt
@@ -126,13 +126,18 @@ class TransportGetWorkflowAlertsAction @Inject constructor(
                         .field("trigger_name")
                 )
         }
+        // if alert id is mentioned we cannot set "from" field as it may not return id. we would be using it to paginate associated alerts
+        val from = if (getWorkflowAlertsRequest.alertIds.isNullOrEmpty())
+            tableProp.startIndex
+        else 0
+
         val searchSourceBuilder = SearchSourceBuilder()
             .version(true)
             .seqNoAndPrimaryTerm(true)
             .query(queryBuilder)
             .sort(sortBuilder)
             .size(tableProp.size)
-            .from(tableProp.startIndex)
+            .from(from)
 
         client.threadPool().threadContext.stashContext().use {
             scope.launch {
@@ -206,22 +211,42 @@ class TransportGetWorkflowAlertsAction @Inject constructor(
                 parseAlertsFromSearchResponse(response)
             )
             if (alerts.isNotEmpty() && getWorkflowAlertsRequest.getAssociatedAlerts == true)
-                getAssociatedAlerts(associatedAlerts, alerts, resolveAssociatedAlertsIndexName(getWorkflowAlertsRequest))
+                getAssociatedAlerts(
+                    associatedAlerts,
+                    alerts,
+                    resolveAssociatedAlertsIndexName(getWorkflowAlertsRequest),
+                    getWorkflowAlertsRequest
+                )
             actionListener.onResponse(GetWorkflowAlertsResponse(alerts, associatedAlerts, totalAlertCount))
         } catch (e: Exception) {
             actionListener.onFailure(AlertingException("Failed to get alerts", RestStatus.INTERNAL_SERVER_ERROR, e))
         }
     }
 
-    private suspend fun getAssociatedAlerts(associatedAlerts: MutableList<Alert>, alerts: MutableList<Alert>, alertIndex: String) {
+    private suspend fun getAssociatedAlerts(
+        associatedAlerts: MutableList<Alert>,
+        alerts: MutableList<Alert>,
+        alertIndex: String,
+        getWorkflowAlertsRequest: GetWorkflowAlertsRequest,
+    ) {
         try {
             val associatedAlertIds = mutableSetOf<String>()
             alerts.forEach { associatedAlertIds.addAll(it.associatedAlertIds) }
             if (associatedAlertIds.isEmpty()) return
             val queryBuilder = QueryBuilders.boolQuery()
+            val searchRequest = SearchRequest(alertIndex)
+            // if chained alert id param is non-null, paginate the associated alerts.
+            if (getWorkflowAlertsRequest.alertIds.isNullOrEmpty() == false) {
+                val tableProp = getWorkflowAlertsRequest.table
+                val sortBuilder = SortBuilders.fieldSort(tableProp.sortString)
+                    .order(SortOrder.fromString(tableProp.sortOrder))
+                if (!tableProp.missing.isNullOrBlank()) {
+                    sortBuilder.missing(tableProp.missing)
+                }
+                searchRequest.source().sort(sortBuilder).size(tableProp.size)
+            }
             queryBuilder.must(QueryBuilders.termsQuery("_id", associatedAlertIds))
             queryBuilder.must(QueryBuilders.termQuery(Alert.STATE_FIELD, Alert.State.AUDIT))
-            val searchRequest = SearchRequest(alertIndex)
             searchRequest.source().query(queryBuilder)
             val response: SearchResponse = client.suspendUntil { search(searchRequest, it) }
             associatedAlerts.addAll(parseAlertsFromSearchResponse(response))

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
@@ -795,9 +795,13 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
 
     protected fun getWorkflowAlerts(
         workflowId: String,
+        alertId: String? = "",
         getAssociatedAlerts: Boolean = true,
     ): Response {
-        return getWorkflowAlerts(client(), mutableMapOf(Pair("workflowIds", workflowId), Pair("getAssociatedAlerts", getAssociatedAlerts)))
+        return getWorkflowAlerts(
+            client(),
+            mutableMapOf(Pair("workflowIds", workflowId), Pair("getAssociatedAlerts", getAssociatedAlerts), Pair("alertIds", alertId!!))
+        )
     }
 
     protected fun getWorkflowAlerts(

--- a/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
@@ -5696,22 +5696,27 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
             workflowId = workflowId,
             alertIds = listOf(res.alerts[0].id),
             table = Table("asc", "monitor_id", null, 100, 100, null)
-
         )
         Assert.assertEquals(res100to200.associatedAlerts.size, 100)
         var res200to300 = getWorkflowAlerts(
             workflowId = workflowId,
             alertIds = listOf(res.alerts[0].id),
-            table = Table("asc", "monitor_id", null, 200, 100, null)
-
+            table = Table("asc", "monitor_id", null, 100, 201, null)
         )
-        Assert.assertEquals(res100to200.associatedAlerts.size, 100)
+        Assert.assertEquals(res200to300.associatedAlerts.size, 100)
         var res0to99 = getWorkflowAlerts(
             workflowId = workflowId,
             alertIds = listOf(res.alerts[0].id),
             table = Table("asc", "monitor_id", null, 100, 0, null)
-
         )
         Assert.assertEquals(res0to99.associatedAlerts.size, 100)
+
+        val ids100to200 = res100to200.associatedAlerts.stream().map { it.id }.collect(Collectors.toSet())
+        val idsSet0to99 = res0to99.associatedAlerts.stream().map { it.id }.collect(Collectors.toSet())
+        val idsSet200to300 = res200to300.associatedAlerts.stream().map { it.id }.collect(Collectors.toSet())
+
+        Assert.assertTrue(idsSet0to99.all { it !in ids100to200 })
+        Assert.assertTrue(idsSet0to99.all { it !in idsSet200to300 })
+        Assert.assertTrue(ids100to200.all { it !in idsSet200to300 })
     }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/WorkflowRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/WorkflowRestApiIT.kt
@@ -1101,7 +1101,7 @@ class WorkflowRestApiIT : AlertingRestTestCase() {
         assertTrue(
             (workflowTriggerResults[andTrigger.id] as Map<String, Any>)["triggered"] as Boolean
         )
-        val res = getWorkflowAlerts(workflowId, true)
+        val res = getWorkflowAlerts(workflowId = workflowId, getAssociatedAlerts = true)
         val getWorkflowAlerts = entityAsMap(res)
         Assert.assertTrue(getWorkflowAlerts.containsKey("alerts"))
         Assert.assertTrue(getWorkflowAlerts.containsKey("associatedAlerts"))
@@ -1113,6 +1113,18 @@ class WorkflowRestApiIT : AlertingRestTestCase() {
         val associatedAlerts = getWorkflowAlerts["associatedAlerts"] as List<HashMap<String, Any>>
         assertEquals(associatedAlerts.size, 2)
 
+        val res1 = getWorkflowAlerts(workflowId = workflowId, alertId = alerts[0]["id"].toString(), getAssociatedAlerts = true)
+        val getWorkflowAlerts1 = entityAsMap(res1)
+        Assert.assertTrue(getWorkflowAlerts1.containsKey("alerts"))
+        Assert.assertTrue(getWorkflowAlerts1.containsKey("associatedAlerts"))
+        val alerts1 = getWorkflowAlerts1["alerts"] as List<HashMap<String, Any>>
+        assertEquals(alerts1.size, 1)
+        Assert.assertEquals(alerts1[0]["execution_id"], executionId)
+        Assert.assertEquals(alerts1[0]["workflow_id"], workflowId)
+        Assert.assertEquals(alerts1[0]["monitor_id"], "")
+        val associatedAlerts1 = getWorkflowAlerts1["associatedAlerts"] as List<HashMap<String, Any>>
+        assertEquals(associatedAlerts1.size, 2)
+
         val getAlertsRes = getAlerts()
         val getAlertsMap = getAlertsRes.asMap()
         Assert.assertTrue(getAlertsMap.containsKey("alerts"))
@@ -1121,11 +1133,11 @@ class WorkflowRestApiIT : AlertingRestTestCase() {
         Assert.assertEquals(getAlertsAlerts[0]["execution_id"], executionId)
         Assert.assertEquals(getAlertsAlerts[0]["workflow_id"], workflowId)
         Assert.assertEquals(getAlertsAlerts[0]["monitor_id"], "")
-        Assert.assertEquals(getAlertsAlerts[0]["id"], alerts[0]["id"])
+        Assert.assertEquals(getAlertsAlerts[0]["id"], alerts1[0]["id"])
 
-        val ackRes = acknowledgeChainedAlerts(workflowId, alerts[0]["id"].toString())
+        val ackRes = acknowledgeChainedAlerts(workflowId, alerts1[0]["id"].toString())
         val acknowledgeChainedAlertsResponse = entityAsMap(ackRes)
         val acknowledged = acknowledgeChainedAlertsResponse["success"] as List<String>
-        Assert.assertEquals(acknowledged[0], alerts[0]["id"])
+        Assert.assertEquals(acknowledged[0], alerts1[0]["id"])
     }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/AlertingSingleNodeTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/AlertingSingleNodeTestCase.kt
@@ -283,19 +283,20 @@ abstract class AlertingSingleNodeTestCase : OpenSearchSingleNodeTestCase() {
         alertState: Alert.State? = Alert.State.ACTIVE,
         alertIndex: String? = "",
         associatedAlertsIndex: String? = "",
+        alertIds: List<String>? = emptyList(),
+        table: Table? = Table("asc", "monitor_id", null, 100, 0, null),
     ): GetWorkflowAlertsResponse {
-        val table = Table("asc", "monitor_id", null, 100, 0, null)
         return client().execute(
             AlertingActions.GET_WORKFLOW_ALERTS_ACTION_TYPE,
             GetWorkflowAlertsRequest(
-                table = table,
+                table = table!!,
                 severityLevel = "ALL",
                 alertState = alertState!!.name,
                 alertIndex = alertIndex,
                 associatedAlertsIndex = associatedAlertsIndex,
                 monitorIds = emptyList(),
                 workflowIds = listOf(workflowId),
-                alertIds = emptyList(),
+                alertIds = alertIds,
                 getAssociatedAlerts = getAssociatedAlerts!!
             )
         ).get()


### PR DESCRIPTION

Get chained alert API will support filtering based on an alertId. The motivation is to fetch associated alerts with support for pagination. The size and sort params would apply to fetch associated alerts in this api when alert id is mentioned


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).