### PR TITLE
Chained Alert Behaviour Changes

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt
@@ -349,7 +349,7 @@ class AlertService(
                 startTime = Instant.now(),
                 lastNotificationTime = currentTime,
                 state = Alert.State.ACTIVE,
-                errorMessage = null, schemaVersion = -1,
+                errorMessage = null, schemaVersion = IndexUtils.alertIndexSchemaVersion,
                 chainedAlertTrigger = ctx.trigger,
                 executionId = executionId,
                 workflow = workflow,
@@ -846,7 +846,7 @@ class AlertService(
     }
 
     /**
-     * Searches for Alerts in the monitor's alertIndex.
+     * Searches for ACTIVE/ACKNOWLEDGED chained alerts in the workflow's alertIndex.
      *
      * @param monitorId The Monitor to get Alerts for
      * @param size The number of search hits (Alerts) to return

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt
@@ -19,6 +19,7 @@ import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.WriteRequest
 import org.opensearch.alerting.alerts.AlertIndices
 import org.opensearch.alerting.model.ActionRunResult
+import org.opensearch.alerting.model.ChainedAlertTriggerRunResult
 import org.opensearch.alerting.model.QueryLevelTriggerRunResult
 import org.opensearch.alerting.opensearchapi.firstFailureOrNull
 import org.opensearch.alerting.opensearchapi.retry
@@ -82,6 +83,26 @@ class AlertService(
     }
 
     private val logger = LogManager.getLogger(AlertService::class.java)
+
+    suspend fun loadCurrentAlertsForWorkflow(workflow: Workflow, dataSources: DataSources): Map<Trigger, Alert?> {
+        val searchAlertsResponse: SearchResponse = searchAlerts(
+            workflow = workflow,
+            size = workflow.triggers.size * 2, // We expect there to be only a single in-progress alert so fetch 2 to check
+            dataSources = dataSources
+        )
+
+        val foundAlerts = searchAlertsResponse.hits.map { Alert.parse(contentParser(it.sourceRef), it.id, it.version) }
+            .groupBy { it.triggerId }
+        foundAlerts.values.forEach { alerts ->
+            if (alerts.size > 1) {
+                logger.warn("Found multiple alerts for same trigger: $alerts")
+            }
+        }
+
+        return workflow.triggers.associateWith { trigger ->
+            foundAlerts[trigger.id]?.firstOrNull()
+        }
+    }
 
     suspend fun loadCurrentAlertsForQueryLevelMonitor(monitor: Monitor, workflowRunContext: WorkflowRunContext?): Map<Trigger, Alert?> {
         val searchAlertsResponse: SearchResponse = searchAlerts(
@@ -257,18 +278,84 @@ class AlertService(
         ctx: ChainedAlertTriggerExecutionContext,
         executionId: String,
         workflow: Workflow,
-        associatedAlertIds: List<String>
-    ): Alert {
-        return Alert(
-            startTime = Instant.now(),
-            lastNotificationTime = Instant.now(),
-            state = Alert.State.ACTIVE,
-            errorMessage = null, schemaVersion = -1,
-            chainedAlertTrigger = ctx.trigger,
-            executionId = executionId,
-            workflow = workflow,
-            associatedAlertIds = associatedAlertIds
-        )
+        associatedAlertIds: List<String>,
+        result: ChainedAlertTriggerRunResult,
+        alertError: AlertError? = null,
+    ): Alert? {
+
+        val currentTime = Instant.now()
+        val currentAlert = ctx.alert
+
+        val updatedActionExecutionResults = mutableListOf<ActionExecutionResult>()
+        val currentActionIds = mutableSetOf<String>()
+        if (currentAlert != null) {
+            // update current alert's action execution results
+            for (actionExecutionResult in currentAlert.actionExecutionResults) {
+                val actionId = actionExecutionResult.actionId
+                currentActionIds.add(actionId)
+                val actionRunResult = result.actionResults[actionId]
+                when {
+                    actionRunResult == null -> updatedActionExecutionResults.add(actionExecutionResult)
+                    actionRunResult.throttled ->
+                        updatedActionExecutionResults.add(
+                            actionExecutionResult.copy(
+                                throttledCount = actionExecutionResult.throttledCount + 1
+                            )
+                        )
+
+                    else -> updatedActionExecutionResults.add(actionExecutionResult.copy(lastExecutionTime = actionRunResult.executionTime))
+                }
+            }
+            // add action execution results which not exist in current alert
+            updatedActionExecutionResults.addAll(
+                result.actionResults.filter { !currentActionIds.contains(it.key) }
+                    .map { ActionExecutionResult(it.key, it.value.executionTime, if (it.value.throttled) 1 else 0) }
+            )
+        } else {
+            updatedActionExecutionResults.addAll(
+                result.actionResults.map {
+                    ActionExecutionResult(it.key, it.value.executionTime, if (it.value.throttled) 1 else 0)
+                }
+            )
+        }
+
+        // Merge the alert's error message to the current alert's history
+        val updatedHistory = currentAlert?.errorHistory.update(alertError)
+        return if (alertError == null && !result.triggered) {
+            currentAlert?.copy(
+                state = Alert.State.COMPLETED,
+                endTime = currentTime,
+                errorMessage = null,
+                errorHistory = updatedHistory,
+                actionExecutionResults = updatedActionExecutionResults,
+                schemaVersion = IndexUtils.alertIndexSchemaVersion
+            )
+        } else if (alertError == null && currentAlert?.isAcknowledged() == true) {
+            null
+        } else if (currentAlert != null) {
+            val alertState = Alert.State.ACTIVE
+            currentAlert.copy(
+                state = alertState,
+                lastNotificationTime = currentTime,
+                errorMessage = alertError?.message,
+                errorHistory = updatedHistory,
+                actionExecutionResults = updatedActionExecutionResults,
+                schemaVersion = IndexUtils.alertIndexSchemaVersion,
+            )
+        } else {
+            if (alertError == null) Alert.State.ACTIVE
+            else Alert.State.ERROR
+            Alert(
+                startTime = Instant.now(),
+                lastNotificationTime = Instant.now(),
+                state = Alert.State.ACTIVE,
+                errorMessage = null, schemaVersion = -1,
+                chainedAlertTrigger = ctx.trigger,
+                executionId = executionId,
+                workflow = workflow,
+                associatedAlertIds = associatedAlertIds
+            )
+        }
     }
 
     fun updateActionResultsForBucketLevelAlert(
@@ -755,6 +842,37 @@ class AlertService(
             throw (searchResponse.firstFailureOrNull()?.cause ?: RuntimeException("Unknown error loading alerts"))
         }
 
+        return searchResponse
+    }
+
+    /**
+     * Searches for Alerts in the monitor's alertIndex.
+     *
+     * @param monitorId The Monitor to get Alerts for
+     * @param size The number of search hits (Alerts) to return
+     */
+    private suspend fun searchAlerts(
+        workflow: Workflow,
+        size: Int,
+        dataSources: DataSources,
+    ): SearchResponse {
+        val workflowId = workflow.id
+        val alertIndex = dataSources.alertsIndex
+
+        val queryBuilder = QueryBuilders.boolQuery()
+            .must(QueryBuilders.termQuery(Alert.WORKFLOW_ID_FIELD, workflowId))
+            .must(QueryBuilders.termQuery(Alert.MONITOR_ID_FIELD, ""))
+        val searchSourceBuilder = SearchSourceBuilder()
+            .size(size)
+            .query(queryBuilder)
+
+        val searchRequest = SearchRequest(alertIndex)
+            .routing(workflowId)
+            .source(searchSourceBuilder)
+        val searchResponse: SearchResponse = client.suspendUntil { client.search(searchRequest, it) }
+        if (searchResponse.status() != RestStatus.OK) {
+            throw (searchResponse.firstFailureOrNull()?.cause ?: RuntimeException("Unknown error loading alerts"))
+        }
         return searchResponse
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt
@@ -347,7 +347,7 @@ class AlertService(
             else Alert.State.ERROR
             Alert(
                 startTime = Instant.now(),
-                lastNotificationTime = Instant.now(),
+                lastNotificationTime = currentTime,
                 state = Alert.State.ACTIVE,
                 errorMessage = null, schemaVersion = -1,
                 chainedAlertTrigger = ctx.trigger,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/TriggerService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/TriggerService.kt
@@ -12,6 +12,7 @@ import org.opensearch.alerting.model.ChainedAlertTriggerRunResult
 import org.opensearch.alerting.model.DocumentLevelTriggerRunResult
 import org.opensearch.alerting.model.QueryLevelTriggerRunResult
 import org.opensearch.alerting.script.BucketLevelTriggerExecutionContext
+import org.opensearch.alerting.script.ChainedAlertTriggerExecutionContext
 import org.opensearch.alerting.script.QueryLevelTriggerExecutionContext
 import org.opensearch.alerting.script.TriggerScript
 import org.opensearch.alerting.triggercondition.parsers.TriggerExpressionParser
@@ -47,6 +48,15 @@ class TriggerService(val scriptService: ScriptService) {
         workflowRunContext: WorkflowRunContext?,
     ): Boolean {
         if (workflowRunContext?.auditDelegateMonitorAlerts == true) return false
+        // Suppress actions if the current alert is acknowledged and there are no errors.
+        val suppress = ctx.alert?.state == Alert.State.ACKNOWLEDGED && result.error == null && ctx.error == null
+        return result.triggered && !suppress
+    }
+
+    fun isChainedAlertTriggerActionable(
+        ctx: ChainedAlertTriggerExecutionContext,
+        result: ChainedAlertTriggerRunResult,
+    ): Boolean {
         // Suppress actions if the current alert is acknowledged and there are no errors.
         val suppress = ctx.alert?.state == Alert.State.ACKNOWLEDGED && result.error == null && ctx.error == null
         return result.triggered && !suppress

--- a/alerting/src/main/kotlin/org/opensearch/alerting/script/ChainedAlertTriggerExecutionContext.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/script/ChainedAlertTriggerExecutionContext.kt
@@ -23,26 +23,6 @@ data class ChainedAlertTriggerExecutionContext(
     val alert: Alert? = null
 ) {
 
-    constructor(
-        workflow: Workflow,
-        workflowRunResult: WorkflowRunResult,
-        trigger: ChainedAlertTrigger,
-        alertGeneratingMonitors: Set<String>,
-        monitorIdToAlertIdsMap: Map<String, Set<String>>,
-        alert: Alert? = null
-    ) :
-        this(
-            workflow,
-            workflowRunResult,
-            workflowRunResult.executionStartTime,
-            workflowRunResult.executionEndTime,
-            workflowRunResult.error,
-            trigger,
-            alertGeneratingMonitors,
-            monitorIdToAlertIdsMap,
-            alert
-        )
-
     /**
      * Mustache templates need special permissions to reflectively introspect field names. To avoid doing this we
      * translate the context to a Map of Strings to primitive types, which can be accessed without reflection.

--- a/alerting/src/main/kotlin/org/opensearch/alerting/script/ChainedAlertTriggerExecutionContext.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/script/ChainedAlertTriggerExecutionContext.kt
@@ -6,6 +6,7 @@
 package org.opensearch.alerting.script
 
 import org.opensearch.alerting.model.WorkflowRunResult
+import org.opensearch.commons.alerting.model.Alert
 import org.opensearch.commons.alerting.model.ChainedAlertTrigger
 import org.opensearch.commons.alerting.model.Workflow
 import java.time.Instant
@@ -18,7 +19,8 @@ data class ChainedAlertTriggerExecutionContext(
     val error: Exception? = null,
     val trigger: ChainedAlertTrigger,
     val alertGeneratingMonitors: Set<String>,
-    val monitorIdToAlertIdsMap: Map<String, Set<String>>
+    val monitorIdToAlertIdsMap: Map<String, Set<String>>,
+    val alert: Alert? = null
 ) {
 
     constructor(
@@ -26,7 +28,8 @@ data class ChainedAlertTriggerExecutionContext(
         workflowRunResult: WorkflowRunResult,
         trigger: ChainedAlertTrigger,
         alertGeneratingMonitors: Set<String>,
-        monitorIdToAlertIdsMap: Map<String, Set<String>>
+        monitorIdToAlertIdsMap: Map<String, Set<String>>,
+        alert: Alert? = null
     ) :
         this(
             workflow,
@@ -36,7 +39,8 @@ data class ChainedAlertTriggerExecutionContext(
             workflowRunResult.error,
             trigger,
             alertGeneratingMonitors,
-            monitorIdToAlertIdsMap
+            monitorIdToAlertIdsMap,
+            alert
         )
 
     /**

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAlertsAction.kt
@@ -157,8 +157,14 @@ class TransportGetWorkflowAlertsAction @Inject constructor(
     }
 
     fun resolveAlertsIndexName(getAlertsRequest: GetWorkflowAlertsRequest): String {
-        return if (getAlertsRequest.alertIndex.isNullOrEmpty()) AlertIndices.ALERT_INDEX
-        else getAlertsRequest.alertIndex!!
+        var alertIndex = AlertIndices.ALL_ALERT_INDEX_PATTERN
+        if (getAlertsRequest.alertIndex.isNullOrEmpty() == false) {
+            alertIndex = getAlertsRequest.alertIndex!!
+        }
+        return if (alertIndex == AlertIndices.ALERT_INDEX)
+            AlertIndices.ALL_ALERT_INDEX_PATTERN
+        else
+            alertIndex
     }
 
     fun resolveAssociatedAlertsIndexName(getAlertsRequest: GetWorkflowAlertsRequest): String {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/workflow/CompositeWorkflowRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/workflow/CompositeWorkflowRunner.kt
@@ -171,6 +171,8 @@ object CompositeWorkflowRunner : WorkflowRunner() {
                 val triggerCtx = ChainedAlertTriggerExecutionContext(
                     workflow = workflow,
                     workflowRunResult = workflowRunResult,
+                    periodStart = workflowRunResult.executionStartTime,
+                    periodEnd = workflowRunResult.executionEndTime,
                     trigger = caTrigger,
                     alertGeneratingMonitors = monitorIdToAlertIdsMap.keys,
                     monitorIdToAlertIdsMap = monitorIdToAlertIdsMap,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/workflow/WorkflowRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/workflow/WorkflowRunner.kt
@@ -31,6 +31,7 @@ import org.opensearch.commons.alerting.model.Table
 import org.opensearch.commons.alerting.model.Workflow
 import org.opensearch.commons.alerting.model.action.Action
 import org.opensearch.commons.notifications.model.NotificationConfigInfo
+import org.opensearch.core.common.Strings
 import org.opensearch.script.Script
 import org.opensearch.script.TemplateScript
 import java.time.Instant
@@ -52,12 +53,15 @@ abstract class WorkflowRunner {
         dryrun: Boolean
     ): ActionRunResult {
         return try {
+            if (!MonitorRunnerService.isActionActionable(action, ctx.alert)) {
+                return ActionRunResult(action.id, action.name, mapOf(), true, null, null)
+            }
             val actionOutput = mutableMapOf<String, String>()
             actionOutput[Action.SUBJECT] = if (action.subjectTemplate != null) {
                 compileTemplate(action.subjectTemplate!!, ctx)
             } else ""
             actionOutput[Action.MESSAGE] = compileTemplate(action.messageTemplate, ctx)
-            if (actionOutput[Action.MESSAGE].isNullOrEmpty()) {
+            if (Strings.isNullOrEmpty(actionOutput[Action.MESSAGE])) {
                 throw IllegalStateException("Message content missing in the Destination with id: ${action.destinationId}")
             }
             if (!dryrun) {


### PR DESCRIPTION
Context:
---
Workflow/Composite monitor supports triggers whose conditions are configured as Boolean conditions with AND, OR, NOT
Operators and monitors as variables. For ex. Trigger condition M1 && M2 means trigger condition is matched if both monitors M1 and M2 create alerts (in AUDIT state) in the current execution. If workflow trigger condition is matched we create Chained Alert.
 
Current behavior
---
Alerts are created in ACTIVE state. 
When alert are acknowledged they move to ACKNOWLEDGED state.

New behavior introduced with this PR
===
**- If no ACTIVE/ACKNOWLEDGEDstate alert already exists for composite monitor trigger, we create a new ACTIVE state alert.**
**- If ACTIVE/ACKNOWLEDGED state alert already exists, we update that alert’s lastNotificationTime itself. But we do NOT create a new Alert. The pre-existing ACTIVE state alert will remain in ACTIVE state.**
**- When composite monitor trigger condition is NOT matched: 
If ACTIVE/ACKNOWLEDGED  state alert already exists, we would mark it as COMPLETED.**