### PR TITLE
upgrade transitive dependency com.google.guava:guava:32.1.2-jre for CVE-2023-2976

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -15,7 +15,10 @@ dependencies {
     api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlin_version}"
     implementation "com.cronutils:cron-utils:9.1.6"
     api "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
-    implementation 'com.google.googlejavaformat:google-java-format:1.10.0'
+    implementation('com.google.googlejavaformat:google-java-format:1.10.0')  {
+        exclude group: 'com.google.guava'
+    }
+    implementation 'com.google.guava:guava:32.0.1-jre'
     api "org.opensearch:common-utils:${common_utils_version}@jar"
     implementation 'commons-validator:commons-validator:1.7'
 


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2023-2976 recommends using google.guava v32+

we have a transitive dependency from com.google.googlejavaformat:google-java-format:1.10.0. upgrading it won't help as all versions of googlejavaformat are currently using guava versions mentioned in CVE.