### PR TITLE
upgrade google guava 32.0.1 to resolve CVE CVE-2023-2976

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -15,7 +15,10 @@ dependencies {
     api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlin_version}"
     implementation "com.cronutils:cron-utils:9.1.6"
     api "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
-    implementation 'com.google.googlejavaformat:google-java-format:1.10.0'
+    implementation('com.google.googlejavaformat:google-java-format:1.10.0')  {
+        exclude group: 'com.google.guava'
+    }
+    implementation 'com.google.guava:guava:32.0.1-jre'
     api "org.opensearch:common-utils:${common_utils_version}@jar"
     implementation 'commons-validator:commons-validator:1.7'
 


### PR DESCRIPTION
Exclude <v32 version of google guava in google java format and add google guava 32.0.1 to resolve CVE CVE-2023-2976

