### PR TITLE
Update BWC version to fix BWC tests

### DIFF
--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v2
       - name: Run integration tests with multi node config
-        run: ./gradlew integTest -PnumNodes=3 -x alertingBwcCluster#fullRestartClusterTask -x alertingBwcCluster#mixedClusterTask -x alertingBwcCluster#oldVersionClusterTask0 -x alertingBwcCluster#oldVersionClusterTask1 -x alertingBwcCluster#rollingUpgradeClusterTask -x alertingBwcCluster#twoThirdsUpgradedClusterTask
+        run: ./gradlew integTest -PnumNodes=3

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -42,7 +42,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build and run with Gradle
         working-directory: ${{ env.WORKING_DIR }}
-        run: ./gradlew gradlew assemble integTest ${{ env.BUILD_ARGS }}
+        run: ./gradlew assemble integTest ${{ env.BUILD_ARGS }}
         env:
           _JAVA_OPTIONS: ${{ matrix.os_java_options }}
       - name: Create Artifact Path

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -42,7 +42,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build and run with Gradle
         working-directory: ${{ env.WORKING_DIR }}
-        run: ./gradlew build ${{ env.BUILD_ARGS }} -x alertingBwcCluster#fullRestartClusterTask -x alertingBwcCluster#mixedClusterTask -x alertingBwcCluster#oldVersionClusterTask0 -x alertingBwcCluster#oldVersionClusterTask1 -x alertingBwcCluster#rollingUpgradeClusterTask -x alertingBwcCluster#twoThirdsUpgradedClusterTask
+        run: ./gradlew gradlew assemble integTest ${{ env.BUILD_ARGS }}
         env:
           _JAVA_OPTIONS: ${{ matrix.os_java_options }}
       - name: Create Artifact Path

--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'jacoco'
 
 def usingRemoteCluster = System.properties.containsKey('tests.rest.cluster') || System.properties.containsKey('tests.cluster')
 def usingMultiNode = project.properties.containsKey('numNodes')
-String bwcVersion = "2.6.0.0"
+String bwcVersion = "2.10.0.0"
 
 ext {
     projectSubstitutions = [:]
@@ -102,7 +102,7 @@ dependencies {
     zipArchive group: 'org.opensearch.plugin', name:'notifications', version: "${opensearch_build}"
 
     // Needed for BWC tests
-    zipArchive group: 'org.opensearch.plugin', name:'alerting', version: "${bwcVersion}"
+    zipArchive group: 'org.opensearch.plugin', name:'alerting', version: "${bwcVersion}-SNAPSHOT"
 
     compileOnly "org.opensearch.plugin:opensearch-scripting-painless-spi:${versions.opensearch}"
     api "org.opensearch.plugin:percolator-client:${opensearch_version}"
@@ -260,7 +260,7 @@ String baseName = "alertingBwcCluster"
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-            versions = ["2.6.0-SNAPSHOT", "3.0.0-SNAPSHOT"]
+            versions = ["2.10.0-SNAPSHOT", "3.0.0-SNAPSHOT"]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>(){
                 @Override


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Update the BWC version to fix the BWC tests as `mixedClusterTask` and `rollingUpgradeClusterTask` needs the previous major version to be the latest (eg. Needs to be 2.10 vs 2.6)

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).