### PR TITLE
add workflow null or empty check only when empty workflow id passed.

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetAlertsAction.kt
@@ -61,6 +61,8 @@ class RestGetAlertsAction : BaseRestHandler() {
         val workflowIds = mutableListOf<String>()
         if (workflowId.isNullOrEmpty() == false) {
             workflowIds.add(workflowId)
+        } else {
+            workflowIds.add("")
         }
         val table = Table(
             sortOrder,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
@@ -115,7 +115,9 @@ class TransportGetAlertsAction @Inject constructor(
 
         if (getAlertsRequest.monitorId != null) {
             queryBuilder.filter(QueryBuilders.termQuery("monitor_id", getAlertsRequest.monitorId))
-            if (getAlertsRequest.workflowIds.isNullOrEmpty()) {
+            if (
+                getAlertsRequest.workflowIds != null && getAlertsRequest.workflowIds!!.size == 1 && getAlertsRequest.workflowIds!![0] == ""
+            ) {
                 val noWorkflowIdQuery = QueryBuilders.boolQuery()
                     .should(QueryBuilders.boolQuery().mustNot(QueryBuilders.existsQuery(Alert.WORKFLOW_ID_FIELD)))
                     .should(QueryBuilders.termsQuery(Alert.WORKFLOW_ID_FIELD, ""))
@@ -123,14 +125,19 @@ class TransportGetAlertsAction @Inject constructor(
             }
         } else if (getAlertsRequest.monitorIds.isNullOrEmpty() == false) {
             queryBuilder.filter(QueryBuilders.termsQuery("monitor_id", getAlertsRequest.monitorIds))
-            if (getAlertsRequest.workflowIds.isNullOrEmpty()) {
+            if (
+                getAlertsRequest.workflowIds != null && getAlertsRequest.workflowIds!!.size == 1 && getAlertsRequest.workflowIds!![0] == ""
+            ) {
                 val noWorkflowIdQuery = QueryBuilders.boolQuery()
                     .should(QueryBuilders.boolQuery().mustNot(QueryBuilders.existsQuery(Alert.WORKFLOW_ID_FIELD)))
                     .should(QueryBuilders.termsQuery(Alert.WORKFLOW_ID_FIELD, ""))
                 queryBuilder.must(noWorkflowIdQuery)
             }
         }
-        if (getAlertsRequest.workflowIds.isNullOrEmpty() == false) {
+        if (
+            getAlertsRequest.workflowIds.isNullOrEmpty() == false &&
+            !(getAlertsRequest.workflowIds!!.size == 1 && getAlertsRequest.workflowIds!![0] == "")
+        ) {
             queryBuilder.must(QueryBuilders.termsQuery("workflow_id", getAlertsRequest.workflowIds))
         }
         if (!tableProp.searchString.isNullOrBlank()) {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
@@ -41,6 +41,7 @@ import org.opensearch.core.action.ActionListener
 import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.core.xcontent.XContentParser
 import org.opensearch.core.xcontent.XContentParserUtils
+import org.opensearch.index.query.BoolQueryBuilder
 import org.opensearch.index.query.Operator
 import org.opensearch.index.query.QueryBuilders
 import org.opensearch.search.builder.SearchSourceBuilder
@@ -115,24 +116,10 @@ class TransportGetAlertsAction @Inject constructor(
 
         if (getAlertsRequest.monitorId != null) {
             queryBuilder.filter(QueryBuilders.termQuery("monitor_id", getAlertsRequest.monitorId))
-            if (
-                getAlertsRequest.workflowIds != null && getAlertsRequest.workflowIds!!.size == 1 && getAlertsRequest.workflowIds!![0] == ""
-            ) {
-                val noWorkflowIdQuery = QueryBuilders.boolQuery()
-                    .should(QueryBuilders.boolQuery().mustNot(QueryBuilders.existsQuery(Alert.WORKFLOW_ID_FIELD)))
-                    .should(QueryBuilders.termsQuery(Alert.WORKFLOW_ID_FIELD, ""))
-                queryBuilder.must(noWorkflowIdQuery)
-            }
+            addWorkflowIdNullOrEmptyCheck(getAlertsRequest, queryBuilder)
         } else if (getAlertsRequest.monitorIds.isNullOrEmpty() == false) {
             queryBuilder.filter(QueryBuilders.termsQuery("monitor_id", getAlertsRequest.monitorIds))
-            if (
-                getAlertsRequest.workflowIds != null && getAlertsRequest.workflowIds!!.size == 1 && getAlertsRequest.workflowIds!![0] == ""
-            ) {
-                val noWorkflowIdQuery = QueryBuilders.boolQuery()
-                    .should(QueryBuilders.boolQuery().mustNot(QueryBuilders.existsQuery(Alert.WORKFLOW_ID_FIELD)))
-                    .should(QueryBuilders.termsQuery(Alert.WORKFLOW_ID_FIELD, ""))
-                queryBuilder.must(noWorkflowIdQuery)
-            }
+            addWorkflowIdNullOrEmptyCheck(getAlertsRequest, queryBuilder)
         }
         if (
             getAlertsRequest.workflowIds.isNullOrEmpty() == false &&
@@ -172,6 +159,21 @@ class TransportGetAlertsAction @Inject constructor(
                     }
                 }
             }
+        }
+    }
+
+    // we add this check when we want to fetch alerts for monitors not generated as part of a workflow i.e. non-delegate monitor alerts
+    private fun addWorkflowIdNullOrEmptyCheck(
+        getAlertsRequest: GetAlertsRequest,
+        queryBuilder: BoolQueryBuilder,
+    ) {
+        if (
+            getAlertsRequest.workflowIds != null && getAlertsRequest.workflowIds!!.size == 1 && getAlertsRequest.workflowIds!![0] == ""
+        ) {
+            val noWorkflowIdQuery = QueryBuilders.boolQuery()
+                .should(QueryBuilders.boolQuery().mustNot(QueryBuilders.existsQuery(Alert.WORKFLOW_ID_FIELD)))
+                .should(QueryBuilders.termsQuery(Alert.WORKFLOW_ID_FIELD, ""))
+            queryBuilder.must(noWorkflowIdQuery)
         }
     }
 


### PR DESCRIPTION
add workflow null or empty check only when empty workflow id passed in transport get alerts request.

In Rest get alert action,  add empty string singleton list for workflow ids when none is passed. This is to support returning non-Audit alerts on Alert Dashboard.

