### PR TITLE
Reduce log level for informative message

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
@@ -477,7 +477,7 @@ class AlertIndices(
     }
 
     private fun deleteOldIndices(tag: String, indices: String) {
-        logger.error("info deleteOldIndices")
+        logger.info("info deleteOldIndices")
         val clusterStateRequest = ClusterStateRequest()
             .clear()
             .indices(indices)


### PR DESCRIPTION
*Description of changes:*
In org.opensearch.alerting.alerts/AlertIndices there is a log message "info deleteOldIndices" which is more of a trace but it is logged with level error.

In my logs see the following entries (repeated every 12 hours):
```
Oct  2 07:47:08 hostname opensearch[414]: [2023-10-02T07:47:08,760][ERROR][o.o.a.a.AlertIndices     ] [n1-name] info deleteOldIndices
Oct  2 07:47:08 hostname opensearch[414]: [2023-10-02T07:47:08,823][ERROR][o.o.a.a.AlertIndices     ] [n1-name] info deleteOldIndices
Oct  2 19:47:08 hostname opensearch[414]: [2023-10-02T19:47:08,761][ERROR][o.o.a.a.AlertIndices     ] [n1-name] info deleteOldIndices
Oct  2 19:47:08 hostname opensearch[414]: [2023-10-02T19:47:08,825][ERROR][o.o.a.a.AlertIndices     ] [n1-name] info deleteOldIndices
```
This is fine except the "info deleteOldIndices" which is logged as error but seems like an info or debug message.

Basically the same as in https://github.com/opensearch-project/security-analytics/pull/203, I don't know if the code was copied or moved.

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).