### PR TITLE
fix workflow security tests in alerting

### DIFF
--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureWorkflowRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureWorkflowRestApiIT.kt
@@ -397,6 +397,7 @@ class SecureWorkflowRestApiIT : AlertingRestTestCase() {
             assertEquals("Get workflow failed", RestStatus.FORBIDDEN.status, e.response.statusLine.statusCode)
         } finally {
             deleteRoleAndRoleMapping(TEST_HR_ROLE)
+            deleteRoleMapping(ALERTING_FULL_ACCESS_ROLE)
             deleteUser(getUser)
             getUserClient?.close()
         }
@@ -447,6 +448,7 @@ class SecureWorkflowRestApiIT : AlertingRestTestCase() {
         } catch (e: ResponseException) {
             assertEquals("Create workflow failed", RestStatus.FORBIDDEN.status, e.response.statusLine.statusCode)
         } finally {
+            deleteRoleMapping(ALERTING_FULL_ACCESS_ROLE)
             deleteUser(userWithDifferentRole)
             userWithDifferentRoleClient?.close()
         }
@@ -1104,6 +1106,7 @@ class SecureWorkflowRestApiIT : AlertingRestTestCase() {
             assertEquals("Delete workflow failed", RestStatus.OK, response?.restStatus())
         } finally {
             deleteRoleAndRoleMapping(TEST_HR_ROLE)
+            deleteRoleMapping(ALERTING_FULL_ACCESS_ROLE)
             deleteUser(deleteUser)
             deleteUserClient?.close()
         }


### PR DESCRIPTION
*Issue #, if available:*
https://build.ci.opensearch.org/blue/organizations/jenkins/integ-test/detail/integ-test/6514/pipeline/118/

*Description of changes:*
fix workflow security tests in alerting

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).