### PR TITLE
remove PRs reverted commit from release notes

### DIFF
--- a/release-notes/opensearch-alerting.release-notes-2.11.1.0.md
+++ b/release-notes/opensearch-alerting.release-notes-2.11.1.0.md
@@ -7,9 +7,5 @@ Compatible with OpenSearch 2.11.1
 ### Bug Fixes
 * Fix for ConcurrentModificationException with linkedHashmap. ([#1255](https://github.com/opensearch-project/alerting/pull/1255))
 
-### Refactoring
-* Handle Doc level query 'fields' param for query string query. ([#1240](https://github.com/opensearch-project/alerting/pull/1240))
-* Add nested fields param mapping findings index for doc level queries. ([#1276](https://github.com/opensearch-project/alerting/pull/1276))
-
 ### Documentation
 * Added 2.11.1 release notes. ([#1306](https://github.com/opensearch-project/alerting/pull/1306))


### PR DESCRIPTION
*Description of changes:*
Commits reverted:  c00c86d360b80b8e3b91795b799e2f5b7f590a3b. 
*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).