### PR TITLE
[Backport 2.10] fix workflow execution for first run (#1220)

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/workflow/CompositeWorkflowRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/workflow/CompositeWorkflowRunner.kt
@@ -281,7 +281,7 @@ object CompositeWorkflowRunner : WorkflowRunner() {
         }
     }
 
-    private fun generateExecutionId(
+    fun generateExecutionId(
         isTempWorkflow: Boolean,
         workflow: Workflow,
     ): String {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
@@ -3152,8 +3152,8 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
             searchWorkflowMetadata(id = workflowId)
         } catch (ex: java.lang.Exception) {
             exception = ex
+            assertTrue(exception is java.util.NoSuchElementException)
         }
-        assertTrue(exception is java.util.NoSuchElementException)
     }
 
     fun `test execute workflow with custom alerts and finding index with bucket and doc monitor bucket monitor used as chained finding`() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Backport #1220 to 2.10

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).