### PR TITLE
Add token to chime URL used in tests to adhere to new Notifications validation

### DIFF
--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
@@ -436,7 +436,7 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
     }
 
     fun getChimeDestination(): Destination {
-        val chime = Chime("https://hooks.chime.aws/incomingwebhooks/chimeId")
+        val chime = Chime("https://hooks.chime.aws/incomingwebhooks/chimeId?token=abcdef")
         return Destination(
             type = DestinationType.CHIME,
             name = "test",


### PR DESCRIPTION
*Description of changes:*
Notifications added validation to the Chime webhook URL a few weeks ago. This PR updates the webhook URL used in tests to adhere to the validation requirements to fix a broken test.

Notification validation was added as part of this commit: https://github.com/opensearch-project/notifications/commit/1163d542a6028faeb7941349ea9232f1c490a45d

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).