### PR TITLE
acknowledge api unresponsive when plugins.alerting.filter_by_backend_roles is enabled

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
@@ -20,7 +20,9 @@ import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.action.update.UpdateRequest
+import org.opensearch.alerting.opensearchapi.InjectorContextElement
 import org.opensearch.alerting.opensearchapi.suspendUntil
+import org.opensearch.alerting.opensearchapi.withClosableContext
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.util.AlertingException
 import org.opensearch.alerting.util.use
@@ -66,11 +68,18 @@ class TransportAcknowledgeAlertAction @Inject constructor(
     val xContentRegistry: NamedXContentRegistry,
     val transportGetMonitorAction: TransportGetMonitorAction
 ) : HandledTransportAction<ActionRequest, AcknowledgeAlertResponse>(
-    AlertingActions.ACKNOWLEDGE_ALERTS_ACTION_NAME, transportService, actionFilters, ::AcknowledgeAlertRequest
-) {
+    AlertingActions.ACKNOWLEDGE_ALERTS_ACTION_NAME,
+    transportService,
+    actionFilters,
+    ::AcknowledgeAlertRequest
+),
+    SecureTransportAction {
 
     @Volatile
     private var isAlertHistoryEnabled = AlertingSettings.ALERT_HISTORY_ENABLED.get(settings)
+
+    @Volatile
+    override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
 
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.ALERT_HISTORY_ENABLED) { isAlertHistoryEnabled = it }
@@ -83,8 +92,9 @@ class TransportAcknowledgeAlertAction @Inject constructor(
     ) {
         val request = acknowledgeAlertRequest as? AcknowledgeAlertRequest
             ?: recreateObject(acknowledgeAlertRequest) { AcknowledgeAlertRequest(it) }
-        client.threadPool().threadContext.stashContext().use {
-            scope.launch {
+        val user = readUserFromThreadContext(client)
+        scope.launch {
+            withClosableContext(InjectorContextElement(request.monitorId, settings, client.threadPool().threadContext, user?.roles)) {
                 val getMonitorResponse: GetMonitorResponse =
                     transportGetMonitorAction.client.suspendUntil {
                         val getMonitorRequest = GetMonitorRequest(
@@ -108,7 +118,9 @@ class TransportAcknowledgeAlertAction @Inject constructor(
                         )
                     )
                 } else {
-                    AcknowledgeHandler(client, actionListener, request).start(getMonitorResponse.monitor!!)
+                    client.threadPool().threadContext.stashContext().use {
+                        AcknowledgeHandler(client, actionListener, request).start(getMonitorResponse.monitor!!)
+                    }
                 }
             }
         }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -1274,6 +1274,24 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
+    fun `test ack alert with enabled filter by`() {
+        enableFilterBy()
+        putAlertMappings()
+        val adminUser = User(ADMIN, listOf(ADMIN), listOf(ALL_ACCESS_ROLE), listOf())
+        val monitor = createRandomMonitor(refresh = true).copy(user = adminUser)
+        val alert = createAlert(randomAlert(monitor).copy(state = Alert.State.ACTIVE))
+
+        val inputMap = HashMap<String, Any>()
+        inputMap["missing"] = "_last"
+        inputMap["monitorId"] = monitor.id
+
+        // search as "admin" - must get 4 docs
+        val adminResponseMap = getAlerts(client(), inputMap).asMap()
+        assertEquals(1, adminResponseMap["totalAlerts"])
+
+        acknowledgeAlerts(monitor, alert)
+    }
+
     fun `test get alerts with an user with get alerts role`() {
 
         putAlertMappings()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`Acknowledge Alerts` transport action internally makes a call to `Get monitor` transport action to get the corresponding monitor object belonging to the alert. https://github.com/opensearch-project/alerting/blob/main/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt#L88

the `Get monitor` transport action first validates the backend roles before proceeding. https://github.com/opensearch-project/alerting/blob/main/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetMonitorAction.kt#L87 
But `Acknowledge Alerts` transport action already `stashes the threadcontext` before making  `Get monitor` transport action call. https://github.com/opensearch-project/alerting/blob/main/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt#L86 
So, the user received from threadcontext by `Get monitor` transport action is `null`. https://github.com/opensearch-project/alerting/blob/main/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetMonitorAction.kt#L81

hence it throws following exception:
```
AlertingException[Filter by user backend roles is enabled with security disabled.]; nested: Exception[org.opensearch.OpenSearchStatusException: Filter by user backend roles is enabled with security disabled.];
    at org.opensearch.alerting.util.AlertingException$Companion.wrap(AlertingException.kt:70)
    at org.opensearch.alerting.transport.SecureTransportAction$DefaultImpls.validateUserBackendRoles(SecureTransportAction.kt:82)
    at org.opensearch.alerting.transport.TransportGetMonitorAction.validateUserBackendRoles(TransportGetMonitorAction.kt:50)
    at org.opensearch.alerting.transport.TransportGetMonitorAction.doExecute(TransportGetMonitorAction.kt:79)
    at org.opensearch.alerting.transport.TransportGetMonitorAction.doExecute(TransportGetMonitorAction.kt:50)
    at org.opensearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:219)
    at org.opensearch.indexmanagement.controlcenter.notification.filter.IndexOperationActionFilter.apply(IndexOperationActionFilter.kt:39)
    at org.opensearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:217)
    at org.opensearch.indexmanagement.rollup.actionfilter.FieldCapsFilter.apply(FieldCapsFilter.kt:118)
    at org.opensearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:217)
    at org.opensearch.performanceanalyzer.action.PerformanceAnalyzerActionFilter.apply(PerformanceAnalyzerActionFilter.java:78)
    at org.opensearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:217)
    at org.opensearch.security.filter.SecurityFilter.apply0(SecurityFilter.java:320)
    at org.opensearch.security.filter.SecurityFilter.apply(SecurityFilter.java:165)
    at org.opensearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:217)
    at org.opensearch.action.support.TransportAction.execute(TransportAction.java:189)
    at org.opensearch.action.support.TransportAction.execute(TransportAction.java:108)
    at org.opensearch.client.node.NodeClient.executeLocally(NodeClient.java:110)
    at org.opensearch.client.node.NodeClient.doExecute(NodeClient.java:97)
    at org.opensearch.client.support.AbstractClient.execute(AbstractClient.java:476)
    at org.opensearch.alerting.transport.TransportAcknowledgeAlertAction$doExecute$1$1$getMonitorResponse$1.invoke(TransportAcknowledgeAlertAction.kt:99)
```
& call becomes unresponsive.

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).