### PR TITLE
Removed log entry regarding destination migration

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/DestinationMigrationCoordinator.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/DestinationMigrationCoordinator.kt
@@ -45,7 +45,6 @@ class DestinationMigrationCoordinator(
     }
 
     override fun clusterChanged(event: ClusterChangedEvent) {
-        logger.info("Detected cluster change event for destination migration")
         if (DestinationMigrationUtilService.finishFlag) {
             logger.info("Reset destination migration process.")
             scheduledMigration?.cancel()
@@ -63,6 +62,7 @@ class DestinationMigrationCoordinator(
                 runningLock = false
             }
         } else if (!event.localNodeClusterManager()) {
+            logger.info("Cancelling the migration process.")
             scheduledMigration?.cancel()
         }
     }


### PR DESCRIPTION
*Issue #1183 *

*There was a specific log that keeps on appearing quite frequently on all OpenSearch clusters (even fresh installations). 

`[INFO ][o.o.a.u.d.DestinationMigrationCoordinator] [my-node-name] Detected cluster change event for destination migration`* 



*CheckList:*
- [x]  Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).