### PR TITLE
fix fieldLimit exception in  docLevelMonitor

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
@@ -87,8 +87,16 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
             monitorCtx.alertIndices!!.createOrUpdateInitialFindingHistoryIndex(monitor.dataSources)
         } catch (e: Exception) {
             val id = if (monitor.id.trim().isEmpty()) "_na_" else monitor.id
-            logger.error("Error setting up alerts and findings indices for monitor: $id", e)
-            monitorResult = monitorResult.copy(error = AlertingException.wrap(e))
+            val unwrappedException = ExceptionsHelper.unwrapCause(e) as Exception
+            if (unwrappedException is IllegalArgumentException && unwrappedException.message?.contains("Limit of total fields") == true) {
+                val errorMessage =
+                    "Monitor [$id] can't process index [$monitor.dataSources] due to field mapping limit"
+                logger.error(errorMessage)
+                monitorResult = monitorResult.copy(error = AlertingException(errorMessage, RestStatus.INTERNAL_SERVER_ERROR, e))
+            } else {
+                logger.error("Error setting up alerts and findings indices for monitor: $id", e)
+                monitorResult = monitorResult.copy(error = AlertingException.wrap(e))
+            }
         }
 
         try {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
@@ -87,11 +87,11 @@ object DocumentLevelMonitorRunner : MonitorRunner() {
             monitorCtx.alertIndices!!.createOrUpdateInitialFindingHistoryIndex(monitor.dataSources)
         } catch (e: Exception) {
             val id = if (monitor.id.trim().isEmpty()) "_na_" else monitor.id
-            val unwrappedException = ExceptionsHelper.unwrapCause(e) as Exception
+            val unwrappedException = ExceptionsHelper.unwrapCause(e)
             if (unwrappedException is IllegalArgumentException && unwrappedException.message?.contains("Limit of total fields") == true) {
                 val errorMessage =
                     "Monitor [$id] can't process index [$monitor.dataSources] due to field mapping limit"
-                logger.error(errorMessage)
+                logger.error("Exception: ${unwrappedException.message}")
                 monitorResult = monitorResult.copy(error = AlertingException(errorMessage, RestStatus.INTERNAL_SERVER_ERROR, e))
             } else {
                 logger.error("Error setting up alerts and findings indices for monitor: $id", e)


### PR DESCRIPTION
*#825*

*Resurface actual field limit error in DocLevelMonitorRunner when updating index Mappings*

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).