### PR TITLE
Backport 1325 to 2.1

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetFindingsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetFindingsAction.kt
@@ -174,8 +174,9 @@ class TransportGetFindingsSearchAction @Inject constructor(
         val documents: MutableMap<String, FindingDocument> = mutableMapOf()
         response.responses.forEach {
             val key = "${it.index}|${it.id}"
-            val docData = if (it.isFailed) "" else it.response.sourceAsString
-            val findingDocument = FindingDocument(it.index, it.id, !it.isFailed, docData)
+            val isDocFound = !(it.isFailed || it.response.sourceAsString == null)
+            val docData = if (isDocFound) it.response.sourceAsString else ""
+            val findingDocument = FindingDocument(it.index, it.id, isDocFound, docData)
             documents[key] = findingDocument
         }
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/FindingsRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/FindingsRestApiIT.kt
@@ -39,7 +39,7 @@ class FindingsRestApiIT : AlertingRestTestCase() {
         }"""
         indexDoc(testIndex, "someId", testDoc)
 
-        val docQuery = DocLevelQuery(query = "test_field:\"us-west-2\"", name = "3", fields = listOf())
+        val docQuery = DocLevelQuery(query = "test_field:\"us-west-2\"", name = "3")
         val docLevelInput = DocLevelMonitorInput("description", listOf(testIndex), listOf(docQuery))
         val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
         val trueMonitor = createMonitor(randomDocumentLevelMonitor(inputs = listOf(docLevelInput), triggers = listOf(trigger)))


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opensearch-project/security-analytics/issues/718

*Description of changes:*
Manually resolves backport of #1325 

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).