### PR TITLE
Inject namedWriteableRegistry during ser/deser of SearchMonitorAction

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
@@ -27,6 +27,7 @@ import org.opensearch.commons.alerting.model.Workflow
 import org.opensearch.commons.authuser.User
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.action.ActionListener
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry
 import org.opensearch.index.query.BoolQueryBuilder
 import org.opensearch.index.query.ExistsQueryBuilder
 import org.opensearch.index.query.MatchQueryBuilder
@@ -41,7 +42,8 @@ class TransportSearchMonitorAction @Inject constructor(
     val settings: Settings,
     val client: Client,
     clusterService: ClusterService,
-    actionFilters: ActionFilters
+    actionFilters: ActionFilters,
+    val namedWriteableRegistry: NamedWriteableRegistry
 ) : HandledTransportAction<ActionRequest, SearchResponse>(
     AlertingActions.SEARCH_MONITORS_ACTION_NAME, transportService, actionFilters, ::SearchMonitorRequest
 ),
@@ -54,7 +56,7 @@ class TransportSearchMonitorAction @Inject constructor(
 
     override fun doExecute(task: Task, request: ActionRequest, actionListener: ActionListener<SearchResponse>) {
         val transformedRequest = request as? SearchMonitorRequest
-            ?: recreateObject(request) {
+            ?: recreateObject(request, namedWriteableRegistry) {
                 SearchMonitorRequest(it)
             }
 


### PR DESCRIPTION
*Description of changes:*
When calling the transport action from another plugin with a separate classloader, the casting will fail and it will hit `recreateObject` fn to perform serialization/deserialization of the request. During deserialization, without converting the `StreamInput` to `NamedWriteableAwareStreamInput`, this was causing failures. This PR adds the `NamedWriteableRegistry` as part of the transport action constructor and in `execute()` in order to resolve this.

Stack trace seen (example coming from `skills` plugin which is calling this transport action via `common-utils` `AlertingPluginInterface.searchMonitors()`:
```
»  java.lang.UnsupportedOperationException: can't read named writeable from StreamInput
»       at org.opensearch.core.common.io.stream.StreamInput.readNamedWriteable(StreamInput.java:1122) ~[opensearch-core-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
»       at org.opensearch.core.common.io.stream.StreamInput.readOptionalNamedWriteable(StreamInput.java:1149) ~[opensearch-core-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
»       at org.opensearch.search.builder.SearchSourceBuilder.<init>(SearchSourceBuilder.java:240) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
»       at org.opensearch.core.common.io.stream.StreamInput.readOptionalWriteable(StreamInput.java:974) ~[opensearch-core-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
»       at org.opensearch.action.search.SearchRequest.<init>(SearchRequest.java:232) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
»       at org.opensearch.commons.alerting.action.SearchMonitorRequest.<init>(SearchMonitorRequest.kt:27) ~[?:?]
»       at org.opensearch.alerting.transport.TransportSearchMonitorAction.doExecute(TransportSearchMonitorAction.kt:58) ~[?:?]
```

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).