### PR TITLE
Fix CVE-2023-6378

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,12 @@ apply plugin: 'jacoco'
 apply from: 'build-tools/merged-coverage.gradle'
 
 configurations {
-    ktlint
+    ktlint {
+      resolutionStrategy {
+          force "ch.qos.logback:logback-classic:1.3.14"
+          force "ch.qos.logback:logback-core:1.3.14"
+      }
+   }
 }
 
 dependencies {


### PR DESCRIPTION
*Description of changes:*

Bumps the ktlint dependency versions to fix a CVE

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).