### PR TITLE
fix CVE-2023-2976 and upgrade guava

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,10 @@ configurations {
           force "ch.qos.logback:logback-core:1.3.14"
       }
    }
+
+   configurations.all {
+      resolutionStrategy.force "com.google.guava:guava:32.1.2-jre"
+   }
 }
 
 dependencies {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation('com.google.googlejavaformat:google-java-format:1.10.0')  {
         exclude group: 'com.google.guava'
     }
-    implementation 'com.google.guava:guava:32.0.1-jre'
+    implementation 'com.google.guava:guava:32.1.2-jre'
     api "org.opensearch:common-utils:${common_utils_version}@jar"
     implementation 'commons-validator:commons-validator:1.7'
 


### PR DESCRIPTION
*Description of changes:*
Fixed CVE-2023-2976 for google guava vulnerability. #1217 

*CheckList:*
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).