### PR TITLE
Add an _exists_ check to document level monitor queries

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
@@ -396,7 +396,14 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
             var query = it.query
             conflictingPaths.forEach { conflictingPath ->
                 if (query.contains(conflictingPath)) {
-                    query = query.replace("$conflictingPath:", "${conflictingPath}_<index>_$monitorId:")
+                    if (query.contains("_exists_")) {
+                        // 1. append the key field "field:"
+                        query = query.replace("$conflictingPath:", "${conflictingPath}_<index>_$monitorId:")
+                        // 2. append the val field "_exists_field"
+                        query = query.replace("_exists_$conflictingPath", "${conflictingPath}_<index>_$monitorId")
+                    } else {
+                        query = query.replace("$conflictingPath:", "${conflictingPath}_<index>_$monitorId:")
+                    }
                     filteredConcreteIndices.addAll(conflictingPathToConcreteIndices[conflictingPath]!!)
                 }
             }
@@ -418,7 +425,14 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
             var query = it.query
             flattenPaths.forEach { fieldPath ->
                 if (!conflictingPaths.contains(fieldPath.first)) {
-                    query = query.replace("${fieldPath.first}:", "${fieldPath.first}_${sourceIndex}_$monitorId:")
+                    if (query.contains("_exists_")) {
+                        // 1. append the key field "field:"
+                        query = query.replace("${fieldPath.first}:", "${fieldPath.first}_${sourceIndex}_$monitorId:")
+                        // 2. append the val field "_exists_field"
+                        query = query.replace("_exists_${fieldPath.first}", "${fieldPath.first}_${sourceIndex}_$monitorId")
+                    } else {
+                        query = query.replace("${fieldPath.first}:", "${fieldPath.first}_${sourceIndex}_$monitorId:")
+                    }
                 }
             }
             val indexRequest = IndexRequest(concreteQueryIndex)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
@@ -396,14 +396,7 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
             var query = it.query
             conflictingPaths.forEach { conflictingPath ->
                 if (query.contains(conflictingPath)) {
-                    if (query.contains("_exists_")) {
-                        // 1. append the key field "field:"
-                        query = query.replace("$conflictingPath:", "${conflictingPath}_<index>_$monitorId:")
-                        // 2. append the val field "_exists_field"
-                        query = query.replace("_exists_$conflictingPath", "${conflictingPath}_<index>_$monitorId")
-                    } else {
-                        query = query.replace("$conflictingPath:", "${conflictingPath}_<index>_$monitorId:")
-                    }
+                    query = transformQuery(query, conflictingPath, "<index>", monitorId)
                     filteredConcreteIndices.addAll(conflictingPathToConcreteIndices[conflictingPath]!!)
                 }
             }
@@ -425,14 +418,7 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
             var query = it.query
             flattenPaths.forEach { fieldPath ->
                 if (!conflictingPaths.contains(fieldPath.first)) {
-                    if (query.contains("_exists_")) {
-                        // 1. append the key field "field:"
-                        query = query.replace("${fieldPath.first}:", "${fieldPath.first}_${sourceIndex}_$monitorId:")
-                        // 2. append the val field "_exists_field"
-                        query = query.replace("_exists_${fieldPath.first}", "${fieldPath.first}_${sourceIndex}_$monitorId")
-                    } else {
-                        query = query.replace("${fieldPath.first}:", "${fieldPath.first}_${sourceIndex}_$monitorId:")
-                    }
+                    query = transformQuery(query, fieldPath.first, sourceIndex, monitorId)
                 }
             }
             val indexRequest = IndexRequest(concreteQueryIndex)
@@ -459,6 +445,18 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
                 }
             }
         }
+    }
+    private fun transformQuery(query: String, conflictingPath: String, indexName: String, monitorId: String): String {
+        var newQuery = query
+        if (newQuery.contains("_exists_")) {
+            // 1. append the key field "field:"
+            newQuery = newQuery.replace("$conflictingPath:", "${conflictingPath}_${indexName}_$monitorId:")
+            // 2. append the val field "_exists_field"
+            newQuery = newQuery.replace("_exists_$conflictingPath", "${conflictingPath}_${indexName}_$monitorId")
+        } else {
+            newQuery = newQuery.replace("$conflictingPath:", "${conflictingPath}_${indexName}_$monitorId:")
+        }
+        return newQuery
     }
 
     private suspend fun updateQueryIndexMappings(

--- a/alerting/src/test/kotlin/org/opensearch/alerting/DocumentMonitorRunnerIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/DocumentMonitorRunnerIT.kt
@@ -1950,6 +1950,349 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
         assertEquals(1, output.objectMap("trigger_results").values.size)
     }
 
+    fun `test execute monitor generates alerts and findings with NOT query`() {
+        val testIndex = createTestIndex()
+        val testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now().truncatedTo(MILLIS))
+        val testDoc = """{
+            "message" : "This is an error from IAD region",
+            "test_strict_date_time" : "$testTime",
+            "test_field" : "us-west-2"
+        }"""
+
+        val docQuery = DocLevelQuery(query = "NOT test_field:\"us-east-1\" AND _exists_: _exists_test_field", name = "3", fields = listOf())
+        val docLevelInput = DocLevelMonitorInput("description", listOf(testIndex), listOf(docQuery))
+
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val monitor = createMonitor(randomDocumentLevelMonitor(inputs = listOf(docLevelInput), triggers = listOf(trigger)))
+        assertNotNull(monitor.id)
+
+        indexDoc(testIndex, "1", testDoc)
+        indexDoc(testIndex, "5", testDoc)
+
+        val response = executeMonitor(monitor.id)
+
+        val output = entityAsMap(response)
+
+        assertEquals(monitor.name, output["monitor_name"])
+        @Suppress("UNCHECKED_CAST")
+        val searchResult = (output.objectMap("input_results")["results"] as List<Map<String, Any>>).first()
+        @Suppress("UNCHECKED_CAST")
+        val matchingDocsToQuery = searchResult[docQuery.id] as List<String>
+        assertEquals("Incorrect search result", 2, matchingDocsToQuery.size)
+        assertTrue("Incorrect search result", matchingDocsToQuery.containsAll(listOf("1|$testIndex", "5|$testIndex")))
+
+        val alerts = searchAlertsWithFilter(monitor)
+        assertEquals("Alert saved for test monitor", 2, alerts.size)
+
+        val findings = searchFindings(monitor)
+        assertEquals("Findings saved for test monitor", 2, findings.size)
+        assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("1"))
+        assertTrue("Findings saved for test monitor", findings[1].relatedDocIds.contains("5"))
+    }
+
+    fun `test document-level monitor when index alias contain docs that do match a NOT EQUALS query and EXISTS query`() {
+        val aliasName = "test-alias"
+        createIndexAlias(
+            aliasName,
+            """
+                "properties" : {
+                  "test_strict_date_time" : { "type" : "date", "format" : "strict_date_time" },
+                  "test_field" : { "type" : "keyword" },
+                  "number" : { "type" : "keyword" }
+                }
+            """.trimIndent()
+        )
+
+        val docQuery = DocLevelQuery(query = "NOT test_field:\"us-east-1\" AND _exists_: _exists_test_field", name = "3", fields = listOf())
+        val docLevelInput = DocLevelMonitorInput("description", listOf("$aliasName"), listOf(docQuery))
+
+        val action = randomAction(template = randomTemplateScript("Hello {{ctx.monitor.name}}"), destinationId = createDestination().id)
+        val monitor = createMonitor(
+            randomDocumentLevelMonitor(
+                inputs = listOf(docLevelInput),
+                triggers = listOf(randomDocumentLevelTrigger(condition = ALWAYS_RUN, actions = listOf(action)))
+            )
+        )
+
+        val testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now().truncatedTo(MILLIS))
+        val testDoc = """{
+            "@timestamp": "$testTime",
+            "message" : "This is an error from IAD region",
+            "test_strict_date_time" : "$testTime",
+            "test_field" : "us-west-2"
+        }"""
+        indexDoc(aliasName, "1", testDoc)
+        var response = executeMonitor(monitor.id)
+        var output = entityAsMap(response)
+        var searchResult = (output.objectMap("input_results")["results"] as List<Map<String, Any>>).first()
+        @Suppress("UNCHECKED_CAST")
+        var matchingDocsToQuery = searchResult[docQuery.id] as List<String>
+        assertEquals("Incorrect search result", 1, matchingDocsToQuery.size)
+
+        rolloverDatastream(aliasName)
+        indexDoc(aliasName, "2", testDoc)
+        response = executeMonitor(monitor.id)
+        output = entityAsMap(response)
+        searchResult = (output.objectMap("input_results")["results"] as List<Map<String, Any>>).first()
+        @Suppress("UNCHECKED_CAST")
+        matchingDocsToQuery = searchResult[docQuery.id] as List<String>
+        assertEquals("Incorrect search result", 1, matchingDocsToQuery.size)
+
+        deleteIndexAlias(aliasName)
+    }
+
+    fun `test execute monitor with wildcard index that generates alerts and findings for NOT EQUALS and EXISTS query operator`() {
+        val testIndexPrefix = "test-index-${randomAlphaOfLength(10).lowercase(Locale.ROOT)}"
+        val testQueryName = "wildcard-test-query"
+        val testIndex = createTestIndex("${testIndexPrefix}1")
+        val testIndex2 = createTestIndex("${testIndexPrefix}2")
+
+        val testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now().truncatedTo(MILLIS))
+        val testDoc = """{
+            "message" : "This is an error from IAD region",
+            "test_strict_date_time" : "$testTime",
+            "test_field" : "us-west-2"
+        }"""
+
+        val query = "NOT test_field:\"us-west-1\" AND _exists_: _exists_test_field"
+        val docQuery = DocLevelQuery(query = query, name = testQueryName, fields = listOf())
+        val docLevelInput = DocLevelMonitorInput("description", listOf("$testIndexPrefix*"), listOf(docQuery))
+
+        val trigger = randomDocumentLevelTrigger(condition = Script("query[name=$testQueryName]"))
+        val monitor = createMonitor(randomDocumentLevelMonitor(inputs = listOf(docLevelInput), triggers = listOf(trigger)))
+        assertNotNull(monitor.id)
+
+        indexDoc(testIndex, "1", testDoc)
+        indexDoc(testIndex2, "5", testDoc)
+
+        val response = executeMonitor(monitor.id)
+
+        val output = entityAsMap(response)
+
+        assertEquals(monitor.name, output["monitor_name"])
+        @Suppress("UNCHECKED_CAST")
+        val searchResult = (output.objectMap("input_results")["results"] as List<Map<String, Any>>).first()
+        @Suppress("UNCHECKED_CAST")
+        val matchingDocsToQuery = searchResult[docQuery.id] as List<String>
+        assertEquals("Incorrect search result", 2, matchingDocsToQuery.size)
+        assertTrue("Incorrect search result", matchingDocsToQuery.containsAll(listOf("1|$testIndex", "5|$testIndex2")))
+
+        val alerts = searchAlertsWithFilter(monitor)
+        assertEquals("Alert saved for test monitor", 2, alerts.size)
+
+        val findings = searchFindings(monitor)
+        assertEquals("Findings saved for test monitor", 2, findings.size)
+        val foundFindings = findings.filter { it.relatedDocIds.contains("1") || it.relatedDocIds.contains("5") }
+        assertEquals("Didn't find findings for docs 1 and 5", 2, foundFindings.size)
+    }
+
+    fun `test execute monitor with indices having fields with same name different field mappings in multiple indices with NOT EQUALS`() {
+        val testIndex = createTestIndex(
+            "test1",
+            """"properties": {
+                    "source": {
+                        "properties": {
+                            "device": {
+                                "properties": {
+                                    "hwd": {
+                                        "properties": {
+                                            "id": {
+                                                "type":"text",
+                                                "analyzer":"whitespace" 
+                                            }
+                                        }
+                                    } 
+                                }
+                            }
+                        }
+                    },
+                   "test_field" : {
+                        "type":"text" 
+                    }
+                }
+            """.trimIndent()
+        )
+
+        val testIndex2 = createTestIndex(
+            "test2",
+            """"properties": {
+                    "test_field" : {
+                        "type":"keyword"
+                    }
+                }
+            """.trimIndent()
+        )
+
+        val testIndex4 = createTestIndex(
+            "test4",
+            """"properties": {
+                   "source": {
+                        "properties": {
+                            "device": {
+                                "properties": {
+                                    "hwd": {
+                                        "properties": {
+                                            "id": {
+                                                "type":"text"
+                                            }
+                                        }
+                                    } 
+                                }
+                            }
+                        }
+                    },
+                   "test_field" : {
+                        "type":"text" 
+                    }
+                }
+            """.trimIndent()
+        )
+
+        val testDoc1 = """{
+            "source" : {"device" : {"hwd" : {"id" : "123456"}} },
+            "nested_field": { "test1": "some text" }
+        }"""
+        val testDoc2 = """{
+            "nested_field": { "test1": "some text" },
+            "test_field": "123456"
+        }"""
+
+        val docQuery1 = DocLevelQuery(
+            query = "NOT test_field:\"12345\" AND _exists_: _exists_test_field",
+            name = "4",
+            fields = listOf()
+        )
+        val docQuery2 = DocLevelQuery(
+            query = "NOT source.device.hwd.id:\"12345\" AND _exists_: _exists_source.device.hwd.id",
+            name = "5",
+            fields = listOf()
+        )
+
+        val docLevelInput = DocLevelMonitorInput("description", listOf("test*"), listOf(docQuery1, docQuery2))
+
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val monitor = createMonitor(randomDocumentLevelMonitor(inputs = listOf(docLevelInput), triggers = listOf(trigger)))
+        assertNotNull(monitor.id)
+
+        indexDoc(testIndex4, "1", testDoc1)
+        indexDoc(testIndex2, "1", testDoc2)
+        indexDoc(testIndex, "1", testDoc1)
+        indexDoc(testIndex, "2", testDoc2)
+
+        executeMonitor(monitor.id)
+
+        val alerts = searchAlertsWithFilter(monitor)
+        assertEquals("Alert saved for test monitor", 4, alerts.size)
+
+        val findings = searchFindings(monitor)
+        assertEquals("Findings saved for test monitor", 4, findings.size)
+
+        val request = """{
+            "size": 0,
+            "query": {
+                "match_all": {}
+            }
+        }"""
+        val httpResponse = adminClient().makeRequest(
+            "GET", "/${monitor.dataSources.queryIndex}/_search",
+            StringEntity(request, ContentType.APPLICATION_JSON)
+        )
+        assertEquals("Search failed", RestStatus.OK, httpResponse.restStatus())
+
+        val searchResponse = SearchResponse.fromXContent(createParser(JsonXContent.jsonXContent, httpResponse.entity.content))
+        searchResponse.hits.totalHits?.let { assertEquals(5L, it.value) }
+    }
+
+    fun `test execute monitor with indices having fields with same name but different field mappings with NOT EQUALS`() {
+        val testIndex = createTestIndex(
+            "test1",
+            """"properties": {
+                    "source": {
+                        "properties": {
+                            "id": {
+                                "type":"text",
+                                "analyzer":"whitespace" 
+                            }
+                        }
+                    },
+                   "test_field" : {
+                        "type":"text",
+                        "analyzer":"whitespace"
+                    }
+                }
+            """.trimIndent()
+        )
+
+        val testIndex2 = createTestIndex(
+            "test2",
+            """"properties": {
+                    "source": {
+                        "properties": {
+                            "id": {
+                                "type":"text"
+                            }
+                        }
+                    },
+                   "test_field" : {
+                        "type":"text"
+                    }
+                }
+            """.trimIndent()
+        )
+        val testDoc = """{
+            "source" : {"id" : "12345" },
+            "nested_field": { "test1": "some text" },
+            "test_field": "12345"
+        }"""
+
+        val docQuery = DocLevelQuery(
+            query = "(NOT test_field:\"123456\" AND _exists_: _exists_test_field) AND source.id:\"12345\"",
+            name = "5",
+            fields = listOf()
+        )
+        val docLevelInput = DocLevelMonitorInput("description", listOf("test*"), listOf(docQuery))
+
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val monitor = createMonitor(randomDocumentLevelMonitor(inputs = listOf(docLevelInput), triggers = listOf(trigger)))
+        assertNotNull(monitor.id)
+
+        indexDoc(testIndex, "1", testDoc)
+        indexDoc(testIndex2, "1", testDoc)
+
+        executeMonitor(monitor.id)
+
+        val alerts = searchAlertsWithFilter(monitor)
+        assertEquals("Alert saved for test monitor", 2, alerts.size)
+
+        val findings = searchFindings(monitor)
+        assertEquals("Findings saved for test monitor", 2, findings.size)
+
+        // as mappings of source.id & test_field are different so, both of them expands
+        val expectedQueries = listOf(
+            "(NOT test_field_test2_${monitor.id}:\"123456\" AND _exists_: test_field_test2_${monitor.id}) " +
+                "AND source.id_test2_${monitor.id}:\"12345\"",
+            "(NOT test_field_test1_${monitor.id}:\"123456\" AND _exists_: test_field_test1_${monitor.id}) " +
+                "AND source.id_test1_${monitor.id}:\"12345\""
+        )
+
+        val request = """{
+            "size": 10,
+            "query": {
+                "match_all": {}
+            }
+        }"""
+        var httpResponse = adminClient().makeRequest(
+            "GET", "/${monitor.dataSources.queryIndex}/_search",
+            StringEntity(request, ContentType.APPLICATION_JSON)
+        )
+        assertEquals("Search failed", RestStatus.OK, httpResponse.restStatus())
+        var searchResponse = SearchResponse.fromXContent(createParser(JsonXContent.jsonXContent, httpResponse.entity.content))
+        searchResponse.hits.forEach { hit ->
+            val query = ((hit.sourceAsMap["query"] as Map<String, Any>)["query_string"] as Map<String, Any>)["query"]
+            assertTrue(expectedQueries.contains(query))
+        }
+    }
+
     @Suppress("UNCHECKED_CAST")
     /** helper that returns a field in a json map whose values are all json objects */
     private fun Map<String, Any>.objectMap(key: String): Map<String, Map<String, Any>> {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/DocumentMonitorRunnerIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/DocumentMonitorRunnerIT.kt
@@ -1959,7 +1959,8 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
             "test_field" : "us-west-2"
         }"""
 
-        val docQuery = DocLevelQuery(query = "NOT test_field:\"us-east-1\" AND _exists_: _exists_test_field", name = "3", fields = listOf())
+        val query = "NOT test_field: \"us-east-1\" AND _exists_: test_field"
+        val docQuery = DocLevelQuery(query = query, name = "3", fields = listOf())
         val docLevelInput = DocLevelMonitorInput("description", listOf(testIndex), listOf(docQuery))
 
         val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
@@ -2003,7 +2004,7 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
             """.trimIndent()
         )
 
-        val docQuery = DocLevelQuery(query = "NOT test_field:\"us-east-1\" AND _exists_: _exists_test_field", name = "3", fields = listOf())
+        val docQuery = DocLevelQuery(query = "NOT test_field:\"us-east-1\" AND _exists_: test_field", name = "3", fields = listOf())
         val docLevelInput = DocLevelMonitorInput("description", listOf("$aliasName"), listOf(docQuery))
 
         val action = randomAction(template = randomTemplateScript("Hello {{ctx.monitor.name}}"), destinationId = createDestination().id)
@@ -2054,7 +2055,7 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
             "test_field" : "us-west-2"
         }"""
 
-        val query = "NOT test_field:\"us-west-1\" AND _exists_: _exists_test_field"
+        val query = "NOT test_field:\"us-west-1\" AND _exists_: test_field"
         val docQuery = DocLevelQuery(query = query, name = testQueryName, fields = listOf())
         val docLevelInput = DocLevelMonitorInput("description", listOf("$testIndexPrefix*"), listOf(docQuery))
 
@@ -2158,12 +2159,12 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
         }"""
 
         val docQuery1 = DocLevelQuery(
-            query = "NOT test_field:\"12345\" AND _exists_: _exists_test_field",
+            query = "NOT test_field:\"12345\" AND _exists_: test_field",
             name = "4",
             fields = listOf()
         )
         val docQuery2 = DocLevelQuery(
-            query = "NOT source.device.hwd.id:\"12345\" AND _exists_: _exists_source.device.hwd.id",
+            query = "NOT source.device.hwd.id:\"12345\" AND _exists_: source.device.hwd.id",
             name = "5",
             fields = listOf()
         )
@@ -2246,7 +2247,7 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
         }"""
 
         val docQuery = DocLevelQuery(
-            query = "(NOT test_field:\"123456\" AND _exists_: _exists_test_field) AND source.id:\"12345\"",
+            query = "(NOT test_field:\"123456\" AND _exists_:test_field) AND source.id:\"12345\"",
             name = "5",
             fields = listOf()
         )
@@ -2269,9 +2270,9 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
 
         // as mappings of source.id & test_field are different so, both of them expands
         val expectedQueries = listOf(
-            "(NOT test_field_test2_${monitor.id}:\"123456\" AND _exists_: test_field_test2_${monitor.id}) " +
+            "(NOT test_field_test2_${monitor.id}:\"123456\" AND _exists_:test_field_test2_${monitor.id}) " +
                 "AND source.id_test2_${monitor.id}:\"12345\"",
-            "(NOT test_field_test1_${monitor.id}:\"123456\" AND _exists_: test_field_test1_${monitor.id}) " +
+            "(NOT test_field_test1_${monitor.id}:\"123456\" AND _exists_:test_field_test1_${monitor.id}) " +
                 "AND source.id_test1_${monitor.id}:\"12345\""
         )
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/DocumentMonitorRunnerIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/DocumentMonitorRunnerIT.kt
@@ -1950,7 +1950,7 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
         assertEquals(1, output.objectMap("trigger_results").values.size)
     }
 
-    fun `test execute monitor generates alerts and findings with NOT query`() {
+    fun `test execute monitor generates alerts and findings with NOT EQUALS query and EXISTS query`() {
         val testIndex = createTestIndex()
         val testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now().truncatedTo(MILLIS))
         val testDoc = """{


### PR DESCRIPTION
*Issue #, if available:*
[#854](https://github.com/opensearch-project/security-analytics/issues/854)

*Description of changes:*
Related to https://github.com/opensearch-project/security-analytics/pull/852

Checks if `_exists_` is present in the query. If it is, then replace the value with the field name and the correctly appended index name and monitor id.

*CheckList:*
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).