### PR TITLE
fix for MapperException[the [enabled] parameter can't be updated for the object mapping [metadata.source_to_query_index_mapping]

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -324,6 +324,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             AlertingSettings.MAX_ACTION_THROTTLE_VALUE,
             AlertingSettings.FILTER_BY_BACKEND_ROLES,
             AlertingSettings.MAX_ACTIONABLE_ALERT_COUNT,
+            AlertingSettings.TEST_MONITOR_NAME,
             LegacyOpenDistroAlertingSettings.INPUT_TIMEOUT,
             LegacyOpenDistroAlertingSettings.INDEX_TIMEOUT,
             LegacyOpenDistroAlertingSettings.BULK_TIMEOUT,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
@@ -168,5 +168,11 @@ class AlertingSettings {
             1,
             Setting.Property.NodeScope, Setting.Property.Dynamic
         )
+
+        val TEST_MONITOR_NAME = Setting.simpleString(
+            "plugins.alerting.integ_test.test_monitor_name",
+            "__delete_config_index_monitor__",
+            Setting.Property.NodeScope, Setting.Property.Dynamic
+        )
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -302,6 +302,16 @@ class TransportIndexMonitorAction @Inject constructor(
         }
 
         fun start() {
+            /**
+             * this happens in a multi-node scenario when in 1 node
+             * IndexUtils.scheduledJobIndexUpdated is set to true but
+             * in another node where the new monitor creation request
+             * is received & the flag IndexUtils.scheduledJobIndexUpdated
+             * is set to false.
+             */
+            if (request.monitor.name == AlertingSettings.TEST_MONITOR_NAME.getDefault(settings)) {
+                IndexUtils.scheduledJobIndexUpdated = false
+            }
             if (!scheduledJobIndices.scheduledJobIndexExists()) {
                 scheduledJobIndices.initScheduledJobIndex(object : ActionListener<CreateIndexResponse> {
                     override fun onResponse(response: CreateIndexResponse) {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/IndexUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/IndexUtils.kt
@@ -39,7 +39,7 @@ class IndexUtils {
             private set
 
         var scheduledJobIndexUpdated: Boolean = false
-            private set
+            public set
         var alertIndexUpdated: Boolean = false
             private set
         var findingIndexUpdated: Boolean = false


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
```
when the source_to_query_index_mapping field is upserted without the .opendistro-alerting-config index present, the mapping for it gets corrupted.

"source_to_query_index_mapping": {
  "properties": {
    "ocsf_api_activityXnRAfI0B9Qgmh2Pzq4q4": {
      "type": "text",
      "fields": {
        "keyword": {
          "type": "keyword",
          "ignore_above": 256
        }
      }
    }
  }
}
```
the correct mapping for the field is,
```
"source_to_query_index_mapping": {
  "type": "object",
  "enabled": false
}
```

this pr ensures that the `upsert` doesn't happen if the index is not present.

the test case will be removed before merging the pr once pr review is complete.

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).