### PR TITLE
Backport #1325 to 2.11 (#1351)

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetFindingsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetFindingsAction.kt
@@ -222,8 +222,9 @@ class TransportGetFindingsSearchAction @Inject constructor(
         val documents: MutableMap<String, FindingDocument> = mutableMapOf()
         response.responses.forEach {
             val key = "${it.index}|${it.id}"
-            val docData = if (it.isFailed) "" else it.response.sourceAsString
-            val findingDocument = FindingDocument(it.index, it.id, !it.isFailed, docData)
+            val isDocFound = !(it.isFailed || it.response.sourceAsString == null)
+            val docData = if (isDocFound) it.response.sourceAsString else ""
+            val findingDocument = FindingDocument(it.index, it.id, isDocFound, docData)
             documents[key] = findingDocument
         }
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/FindingsRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/FindingsRestApiIT.kt
@@ -31,6 +31,33 @@ class FindingsRestApiIT : AlertingRestTestCase() {
         assertFalse(response.findings[0].documents[0].found)
     }
 
+    fun `test find Finding where source docData is null`() {
+        val testIndex = createTestIndex()
+        val testDoc = """{
+            "message" : "This is an error from IAD region",
+            "test_field" : "us-west-2"
+        }"""
+        indexDoc(testIndex, "someId", testDoc)
+
+        val docQuery = DocLevelQuery(query = "test_field:\"us-west-2\"", name = "3")
+        val docLevelInput = DocLevelMonitorInput("description", listOf(testIndex), listOf(docQuery))
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val trueMonitor = createMonitor(randomDocumentLevelMonitor(inputs = listOf(docLevelInput), triggers = listOf(trigger)))
+        executeMonitor(trueMonitor.id, mapOf(Pair("dryrun", "true")))
+
+        createFinding(matchingDocIds = listOf("someId"), index = testIndex)
+        val responseBeforeDelete = searchFindings()
+        assertEquals(1, responseBeforeDelete.totalFindings)
+        assertEquals(1, responseBeforeDelete.findings[0].documents.size)
+        assertTrue(responseBeforeDelete.findings[0].documents[0].found)
+
+        deleteDoc(testIndex, "someId")
+        val responseAfterDelete = searchFindings()
+        assertEquals(1, responseAfterDelete.totalFindings)
+        assertEquals(1, responseAfterDelete.findings[0].documents.size)
+        assertFalse(responseAfterDelete.findings[0].documents[0].found)
+    }
+
     fun `test find Finding where doc is retrieved`() {
         val testIndex = createTestIndex()
         val testDoc = """{


### PR DESCRIPTION
* Set docData to empty string if actual is null (#1325)


(cherry picked from commit 008e076e52c4b549f0260554fc2c6fd04269a896)


* Remove not yet introduced parameter fields



---------




(cherry picked from commit 63689794bd51d7a8178a92bbea9d06996e2a3596)

*Issue #, if available:*

*Description of changes:*

*CheckList:*
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).