### PR TITLE
[Backport 2.11] Enhance per bucket, and per document monitor notification message ctx. (#1450)

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/BucketLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/BucketLevelMonitorRunner.kt
@@ -13,10 +13,12 @@ import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.WriteRequest
 import org.opensearch.alerting.model.ActionRunResult
+import org.opensearch.alerting.model.AlertContext
 import org.opensearch.alerting.model.BucketLevelTriggerRunResult
 import org.opensearch.alerting.model.InputRunResults
 import org.opensearch.alerting.model.MonitorRunResult
 import org.opensearch.alerting.opensearchapi.InjectorContextElement
+import org.opensearch.alerting.opensearchapi.convertToMap
 import org.opensearch.alerting.opensearchapi.retry
 import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.opensearchapi.withClosableContext
@@ -25,7 +27,9 @@ import org.opensearch.alerting.util.defaultToPerExecutionAction
 import org.opensearch.alerting.util.getActionExecutionPolicy
 import org.opensearch.alerting.util.getBucketKeysHash
 import org.opensearch.alerting.util.getCombinedTriggerRunResult
+import org.opensearch.alerting.util.printsSampleDocData
 import org.opensearch.alerting.workflow.WorkflowRunContext
+import org.opensearch.client.Client
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.alerting.model.Alert
@@ -221,6 +225,8 @@ object BucketLevelMonitorRunner : MonitorRunner() {
             }
         }
 
+        // The alertSampleDocs map structure is Map<TriggerId, Map<BucketKeysHash, List<Alert>>>
+        val alertSampleDocs = mutableMapOf<String, Map<String, List<Map<String, Any>>>>()
         for (trigger in monitor.triggers) {
             val alertsToUpdate = mutableSetOf<Alert>()
             val completedAlertsToUpdate = mutableSetOf<Alert>()
@@ -231,6 +237,32 @@ object BucketLevelMonitorRunner : MonitorRunner() {
                 ?: mutableListOf()
             // Update nextAlerts so the filtered DEDUPED Alerts are reflected for PER_ALERT Action execution
             nextAlerts[trigger.id]?.set(AlertCategory.DEDUPED, dedupedAlerts)
+
+            // Only collect sample docs for triggered triggers, and only when at least 1 action prints sample doc data.
+            val isTriggered = !nextAlerts[trigger.id]?.get(AlertCategory.NEW).isNullOrEmpty()
+            if (isTriggered && printsSampleDocData(trigger)) {
+                try {
+                    val searchRequest = monitorCtx.inputService!!.getSearchRequest(
+                        monitor = monitor.copy(triggers = listOf(trigger)),
+                        searchInput = monitor.inputs[0] as SearchInput,
+                        periodStart = periodStart,
+                        periodEnd = periodEnd,
+                        prevResult = monitorResult.inputResults,
+                        matchingDocIdsPerIndex = null,
+                        returnSampleDocs = true
+                    )
+                    val sampleDocumentsByBucket = getSampleDocs(
+                        client = monitorCtx.client!!,
+                        monitorId = monitor.id,
+                        triggerId = trigger.id,
+                        searchRequest = searchRequest
+                    )
+                    alertSampleDocs[trigger.id] = sampleDocumentsByBucket
+                } catch (e: Exception) {
+                    logger.error("Error retrieving sample documents for trigger {} of monitor {}.", trigger.id, monitor.id, e)
+                }
+            }
+
             val newAlerts = nextAlerts[trigger.id]?.get(AlertCategory.NEW) ?: mutableListOf()
             val completedAlerts = nextAlerts[trigger.id]?.get(AlertCategory.COMPLETED) ?: mutableListOf()
 
@@ -256,9 +288,12 @@ object BucketLevelMonitorRunner : MonitorRunner() {
                     for (alertCategory in actionExecutionScope.actionableAlerts) {
                         val alertsToExecuteActionsFor = nextAlerts[trigger.id]?.get(alertCategory) ?: mutableListOf()
                         for (alert in alertsToExecuteActionsFor) {
+                            val alertContext = if (alertCategory != AlertCategory.NEW) AlertContext(alert = alert)
+                            else getAlertContext(alert = alert, alertSampleDocs = alertSampleDocs)
+
                             val actionCtx = getActionContextForAlertCategory(
                                 alertCategory,
-                                alert,
+                                alertContext,
                                 triggerCtx,
                                 monitorOrTriggerError
                             )
@@ -292,7 +327,9 @@ object BucketLevelMonitorRunner : MonitorRunner() {
 
                     val actionCtx = triggerCtx.copy(
                         dedupedAlerts = dedupedAlerts,
-                        newAlerts = newAlerts,
+                        newAlerts = newAlerts.map {
+                            getAlertContext(alert = it, alertSampleDocs = alertSampleDocs)
+                        },
                         completedAlerts = completedAlerts,
                         error = monitorResult.error ?: triggerResult.error
                     )
@@ -487,17 +524,93 @@ object BucketLevelMonitorRunner : MonitorRunner() {
 
     private fun getActionContextForAlertCategory(
         alertCategory: AlertCategory,
-        alert: Alert,
+        alertContext: AlertContext,
         ctx: BucketLevelTriggerExecutionContext,
         error: Exception?
     ): BucketLevelTriggerExecutionContext {
         return when (alertCategory) {
             AlertCategory.DEDUPED ->
-                ctx.copy(dedupedAlerts = listOf(alert), newAlerts = emptyList(), completedAlerts = emptyList(), error = error)
+                ctx.copy(dedupedAlerts = listOf(alertContext.alert), newAlerts = emptyList(), completedAlerts = emptyList(), error = error)
             AlertCategory.NEW ->
-                ctx.copy(dedupedAlerts = emptyList(), newAlerts = listOf(alert), completedAlerts = emptyList(), error = error)
+                ctx.copy(dedupedAlerts = emptyList(), newAlerts = listOf(alertContext), completedAlerts = emptyList(), error = error)
             AlertCategory.COMPLETED ->
-                ctx.copy(dedupedAlerts = emptyList(), newAlerts = emptyList(), completedAlerts = listOf(alert), error = error)
+                ctx.copy(dedupedAlerts = emptyList(), newAlerts = emptyList(), completedAlerts = listOf(alertContext.alert), error = error)
         }
+    }
+
+    private fun getAlertContext(
+        alert: Alert,
+        alertSampleDocs: Map<String, Map<String, List<Map<String, Any>>>>
+    ): AlertContext {
+        val bucketKey = alert.aggregationResultBucket?.getBucketKeysHash()
+        val sampleDocs = alertSampleDocs[alert.triggerId]?.get(bucketKey)
+        return if (!bucketKey.isNullOrEmpty() && !sampleDocs.isNullOrEmpty()) {
+            AlertContext(alert = alert, sampleDocs = sampleDocs)
+        } else {
+            logger.error(
+                "Failed to retrieve sample documents for alert {} from trigger {} of monitor {} during execution {}.",
+                alert.id,
+                alert.triggerId,
+                alert.monitorId,
+                alert.executionId
+            )
+            AlertContext(alert = alert, sampleDocs = listOf())
+        }
+    }
+
+    /**
+     * Executes the monitor's query with the addition of 2 top_hits aggregations that are used to return the top 5,
+     * and bottom 5 documents for each bucket.
+     *
+     * @return Map<BucketKeysHash, List<Alert>>
+     */
+    @Suppress("UNCHECKED_CAST")
+    private suspend fun getSampleDocs(
+        client: Client,
+        monitorId: String,
+        triggerId: String,
+        searchRequest: SearchRequest
+    ): Map<String, List<Map<String, Any>>> {
+        val sampleDocumentsByBucket = mutableMapOf<String, List<Map<String, Any>>>()
+        val searchResponse: SearchResponse = client.suspendUntil { client.search(searchRequest, it) }
+        val aggs = searchResponse.convertToMap().getOrDefault("aggregations", mapOf<String, Any>()) as Map<String, Any>
+        val compositeAgg = aggs.getOrDefault("composite_agg", mapOf<String, Any>()) as Map<String, Any>
+        val buckets = compositeAgg.getOrDefault("buckets", emptyList<Map<String, Any>>()) as List<Map<String, Any>>
+
+        buckets.forEach { bucket ->
+            val bucketKey = getBucketKeysHash((bucket.getOrDefault("key", mapOf<String, String>()) as Map<String, String>).values.toList())
+            if (bucketKey.isEmpty()) throw IllegalStateException("Cannot format bucket keys.")
+
+            val unwrappedTopHits = (bucket.getOrDefault("top_hits", mapOf<String, Any>()) as Map<String, Any>)
+                .getOrDefault("hits", mapOf<String, Any>()) as Map<String, Any>
+            val topHits = unwrappedTopHits.getOrDefault("hits", listOf<Map<String, Any>>()) as List<Map<String, Any>>
+
+            val unwrappedLowHits = (bucket.getOrDefault("low_hits", mapOf<String, Any>()) as Map<String, Any>)
+                .getOrDefault("hits", mapOf<String, Any>()) as Map<String, Any>
+            val lowHits = unwrappedLowHits.getOrDefault("hits", listOf<Map<String, Any>>()) as List<Map<String, Any>>
+
+            // Reversing the order of lowHits so allHits will be in descending order.
+            val allHits = topHits + lowHits.reversed()
+
+            if (allHits.isEmpty()) {
+                // We expect sample documents to be available for each bucket.
+                logger.error("Sample documents not found for trigger {} of monitor {}.", triggerId, monitorId)
+            }
+
+            // Removing duplicate hits. The top_hits, and low_hits results return a max of 5 docs each.
+            // The same document could be present in both hit lists if there are fewer than 10 documents in the bucket of data.
+            val uniqueHitIds = mutableSetOf<String>()
+            val dedupedHits = mutableListOf<Map<String, Any>>()
+            allHits.forEach { hit ->
+                val hitId = hit["_id"] as String
+                if (!uniqueHitIds.contains(hitId)) {
+                    uniqueHitIds.add(hitId)
+                    dedupedHits.add(hit)
+                }
+            }
+            sampleDocumentsByBucket[bucketKey] = dedupedHits
+        }
+
+        return sampleDocumentsByBucket
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/InputService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/InputService.kt
@@ -74,38 +74,15 @@ class InputService(
             monitor.inputs.forEach { input ->
                 when (input) {
                     is SearchInput -> {
-                        // TODO: Figure out a way to use SearchTemplateRequest without bringing in the entire TransportClient
-                        val searchParams = mapOf(
-                            "period_start" to periodStart.toEpochMilli(),
-                            "period_end" to periodEnd.toEpochMilli()
+                        val searchRequest = getSearchRequest(
+                            monitor = monitor,
+                            searchInput = input,
+                            periodStart = periodStart,
+                            periodEnd = periodEnd,
+                            prevResult = prevResult,
+                            matchingDocIdsPerIndex = matchingDocIdsPerIndex,
+                            returnSampleDocs = false
                         )
-
-                        // Deep copying query before passing it to rewriteQuery since otherwise, the monitor.input is modified directly
-                        // which causes a strange bug where the rewritten query persists on the Monitor across executions
-                        val rewrittenQuery = AggregationQueryRewriter.rewriteQuery(deepCopyQuery(input.query), prevResult, monitor.triggers)
-
-                        // Rewrite query to consider the doc ids per given index
-                        if (chainedFindingExist(matchingDocIdsPerIndex) && rewrittenQuery.query() != null) {
-                            val updatedSourceQuery = updateInputQueryWithFindingDocIds(rewrittenQuery.query(), matchingDocIdsPerIndex!!)
-                            rewrittenQuery.query(updatedSourceQuery)
-                        }
-
-                        val searchSource = scriptService.compile(
-                            Script(
-                                ScriptType.INLINE, Script.DEFAULT_TEMPLATE_LANG,
-                                rewrittenQuery.toString(), searchParams
-                            ),
-                            TemplateScript.CONTEXT
-                        )
-                            .newInstance(searchParams)
-                            .execute()
-
-                        val searchRequest = SearchRequest()
-                            .indices(*input.indices.toTypedArray())
-                            .preference(Preference.PRIMARY_FIRST.type())
-                        XContentType.JSON.xContent().createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, searchSource).use {
-                            searchRequest.source(SearchSourceBuilder.fromXContent(it))
-                        }
                         val searchResponse: SearchResponse = client.suspendUntil { client.search(searchRequest, it) }
                         aggTriggerAfterKey += AggregationQueryRewriter.getAfterKeysFromSearchResponse(
                             searchResponse,
@@ -222,5 +199,56 @@ class InputService(
             logger.info("Error collecting anomaly result inputs for monitor: ${monitor.id}", e)
             InputRunResults(emptyList(), e)
         }
+    }
+
+    fun getSearchRequest(
+        monitor: Monitor,
+        searchInput: SearchInput,
+        periodStart: Instant,
+        periodEnd: Instant,
+        prevResult: InputRunResults?,
+        matchingDocIdsPerIndex: Map<String, List<String>>?,
+        returnSampleDocs: Boolean = false
+    ): SearchRequest {
+        // TODO: Figure out a way to use SearchTemplateRequest without bringing in the entire TransportClient
+        val searchParams = mapOf(
+            "period_start" to periodStart.toEpochMilli(),
+            "period_end" to periodEnd.toEpochMilli()
+        )
+
+        // Deep copying query before passing it to rewriteQuery since otherwise, the monitor.input is modified directly
+        // which causes a strange bug where the rewritten query persists on the Monitor across executions
+        val rewrittenQuery = AggregationQueryRewriter.rewriteQuery(
+            deepCopyQuery(searchInput.query),
+            prevResult,
+            monitor.triggers,
+            returnSampleDocs
+        )
+
+        // Rewrite query to consider the doc ids per given index
+        if (chainedFindingExist(matchingDocIdsPerIndex) && rewrittenQuery.query() != null) {
+            val updatedSourceQuery = updateInputQueryWithFindingDocIds(rewrittenQuery.query(), matchingDocIdsPerIndex!!)
+            rewrittenQuery.query(updatedSourceQuery)
+        }
+
+        val searchSource = scriptService.compile(
+            Script(
+                ScriptType.INLINE, Script.DEFAULT_TEMPLATE_LANG,
+                rewrittenQuery.toString(), searchParams
+            ),
+            TemplateScript.CONTEXT
+        )
+            .newInstance(searchParams)
+            .execute()
+
+        val searchRequest = SearchRequest()
+            .indices(*searchInput.indices.toTypedArray())
+            .preference(Preference.PRIMARY_FIRST.type())
+
+        XContentType.JSON.xContent().createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, searchSource).use {
+            searchRequest.source(SearchSourceBuilder.fromXContent(it))
+        }
+
+        return searchRequest
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunnerExecutionContext.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunnerExecutionContext.kt
@@ -17,6 +17,7 @@ import org.opensearch.cluster.metadata.IndexNameExpressionResolver
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.unit.TimeValue
+import org.opensearch.commons.alerting.model.DocLevelQuery
 import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.monitor.jvm.JvmStats
 import org.opensearch.script.ScriptService
@@ -38,6 +39,7 @@ data class MonitorRunnerExecutionContext(
     var docLevelMonitorQueries: DocLevelMonitorQueries? = null,
     var workflowService: WorkflowService? = null,
     var jvmStats: JvmStats? = null,
+    var findingsToTriggeredQueries: Map<String, List<DocLevelQuery>>? = null,
 
     @Volatile var retryPolicy: BackoffPolicy? = null,
     @Volatile var moveAlertsRetryPolicy: BackoffPolicy? = null,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/model/AlertContext.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/model/AlertContext.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.model
+
+import org.opensearch.commons.alerting.model.Alert
+import org.opensearch.commons.alerting.model.DocLevelQuery
+
+/**
+ * This model is a wrapper for [Alert] that should only be used to create a more
+ * informative alert object to enrich mustache template notification messages.
+ */
+data class AlertContext(
+    val alert: Alert,
+    val associatedQueries: List<DocLevelQuery>? = null,
+    val sampleDocs: List<Map<String, Any?>>? = null
+) {
+    fun asTemplateArg(): Map<String, Any?> {
+        val queriesContext = associatedQueries?.map {
+            mapOf(
+                DocLevelQuery.QUERY_ID_FIELD to it.id,
+                DocLevelQuery.NAME_FIELD to it.name,
+                DocLevelQuery.TAGS_FIELD to it.tags
+            )
+        }
+
+        // Compile the custom context fields.
+        val customContextFields = mapOf(
+            ASSOCIATED_QUERIES_FIELD to queriesContext,
+            SAMPLE_DOCS_FIELD to sampleDocs
+        )
+
+        // Get the alert template args
+        val templateArgs = alert.asTemplateArg().toMutableMap()
+
+        // Add the non-null custom context fields to the alert templateArgs.
+        customContextFields.forEach { (key, value) ->
+            value?.let { templateArgs[key] = it }
+        }
+        return templateArgs
+    }
+
+    companion object {
+        const val ASSOCIATED_QUERIES_FIELD = "associated_queries"
+        const val SAMPLE_DOCS_FIELD = "sample_documents"
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/script/DocumentLevelTriggerExecutionContext.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/script/DocumentLevelTriggerExecutionContext.kt
@@ -5,7 +5,7 @@
 
 package org.opensearch.alerting.script
 
-import org.opensearch.commons.alerting.model.Alert
+import org.opensearch.alerting.model.AlertContext
 import org.opensearch.commons.alerting.model.DocumentLevelTrigger
 import org.opensearch.commons.alerting.model.Monitor
 import java.time.Instant
@@ -16,7 +16,7 @@ data class DocumentLevelTriggerExecutionContext(
     override val results: List<Map<String, Any>>,
     override val periodStart: Instant,
     override val periodEnd: Instant,
-    val alerts: List<Alert> = listOf(),
+    val alerts: List<AlertContext> = listOf(),
     val triggeredDocs: List<String>,
     val relatedFindings: List<String>,
     override val error: Exception? = null
@@ -25,7 +25,7 @@ data class DocumentLevelTriggerExecutionContext(
     constructor(
         monitor: Monitor,
         trigger: DocumentLevelTrigger,
-        alerts: List<Alert> = listOf()
+        alerts: List<AlertContext> = listOf()
     ) : this(
         monitor, trigger, emptyList(), Instant.now(), Instant.now(),
         alerts, emptyList(), emptyList(), null
@@ -37,8 +37,13 @@ data class DocumentLevelTriggerExecutionContext(
      */
     override fun asTemplateArg(): Map<String, Any?> {
         val tempArg = super.asTemplateArg().toMutableMap()
-        tempArg["trigger"] = trigger.asTemplateArg()
-        tempArg["alerts"] = alerts.map { it.asTemplateArg() }
+        tempArg[TRIGGER_FIELD] = trigger.asTemplateArg()
+        tempArg[ALERTS_FIELD] = alerts.map { it.asTemplateArg() }
         return tempArg
+    }
+
+    companion object {
+        const val TRIGGER_FIELD = "trigger"
+        const val ALERTS_FIELD = "alerts"
     }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/MonitorRunnerServiceIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/MonitorRunnerServiceIT.kt
@@ -45,6 +45,7 @@ import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder
 import org.opensearch.search.aggregations.metrics.CardinalityAggregationBuilder
 import org.opensearch.search.aggregations.support.MultiTermsValuesSourceConfig
 import org.opensearch.search.builder.SearchSourceBuilder
+import org.opensearch.test.OpenSearchTestCase
 import java.net.URLEncoder
 import java.time.Instant
 import java.time.ZonedDateTime
@@ -53,6 +54,7 @@ import java.time.temporal.ChronoUnit
 import java.time.temporal.ChronoUnit.DAYS
 import java.time.temporal.ChronoUnit.MILLIS
 import java.time.temporal.ChronoUnit.MINUTES
+import java.util.concurrent.TimeUnit
 import kotlin.collections.HashMap
 
 class MonitorRunnerServiceIT : AlertingRestTestCase() {
@@ -1903,6 +1905,7 @@ class MonitorRunnerServiceIT : AlertingRestTestCase() {
                 mutableMapOf(Pair(actionThrottleEnabled.id, 0), Pair(actionThrottleNotEnabled.id, 0))
             )
             assertEquals(notThrottledActionResults.size, 2)
+
             // Save the lastExecutionTimes of the actions for the Alert to be compared later against
             // the next Monitor execution run
             previousAlertExecutionTime[it.id] = mutableMapOf()
@@ -1946,6 +1949,88 @@ class MonitorRunnerServiceIT : AlertingRestTestCase() {
                 "Last execution time of a non-throttled action was not updated for one of the Alerts",
                 throttledActionResults[actionThrottleNotEnabled.id]!!.lastExecutionTime!! > prevNotThrottledActionLastExecutionTime
             )
+        }
+    }
+
+    fun `test bucket-level monitor notification message includes sample docs per bucket`() {
+        val testIndex = createTestIndex()
+        insertSampleTimeSerializedData(
+            testIndex,
+            listOf(
+                "test_value_1",
+                "test_value_1",
+                "test_value_2"
+            )
+        )
+
+        val messageSource = "{{#ctx.newAlerts}}\n{{#sample_documents}}\n (docId={{_id}}) \n{{/sample_documents}}\n{{/ctx.newAlerts}}"
+        val bucket1DocIds = listOf("(docId=1)", "(docId=2)")
+        val bucket2DocIds = listOf("(docId=3)")
+
+        OpenSearchTestCase.waitUntil({
+            return@waitUntil false
+        }, 200, TimeUnit.MILLISECONDS)
+
+        val query = QueryBuilders.rangeQuery("test_strict_date_time")
+            .gt("{{period_end}}||-10d")
+            .lte("{{period_end}}")
+            .format("epoch_millis")
+        val compositeSources = listOf(
+            TermsValuesSourceBuilder("test_field").field("test_field")
+        )
+        val compositeAgg = CompositeAggregationBuilder("composite_agg", compositeSources)
+        val input = SearchInput(indices = listOf(testIndex), query = SearchSourceBuilder().size(0).query(query).aggregation(compositeAgg))
+        val triggerScript = """
+            params.docCount > 1
+        """.trimIndent()
+
+        val action = randomAction(
+            template = randomTemplateScript(source = messageSource),
+            destinationId = createDestination().id
+        )
+        var trigger = randomBucketLevelTrigger(actions = listOf(action))
+        trigger = trigger.copy(
+            bucketSelector = BucketSelectorExtAggregationBuilder(
+                name = trigger.id,
+                bucketsPathsMap = mapOf("docCount" to "_count"),
+                script = Script(triggerScript),
+                parentBucketPath = "composite_agg",
+                filter = null
+            )
+        )
+        val monitor = createMonitor(randomBucketLevelMonitor(inputs = listOf(input), enabled = false, triggers = listOf(trigger)))
+
+        val output = entityAsMap(executeMonitor(monitor.id))
+        // The 'events' in this case are the bucketKeys hashes representing the Alert events
+        val expectedEvents = setOf("test_value_1", "test_value_2")
+
+        assertEquals(monitor.name, output["monitor_name"])
+        for (triggerResult in output.objectMap("trigger_results").values) {
+            for (alertEvent in triggerResult.objectMap("action_results")) {
+                assertTrue(expectedEvents.contains(alertEvent.key))
+                val actionResults = alertEvent.value.values as Collection<Map<String, Any>>
+                for (actionResult in actionResults) {
+                    val actionOutput = actionResult["output"] as Map<String, String>
+                    if (actionResult["name"] == action.name) {
+                        when (alertEvent.key) {
+                            "test_value_1" -> bucket1DocIds.forEach { docEntry ->
+                                assertTrue(
+                                    "The notification message is missing docEntry $docEntry",
+                                    !actionOutput["message"].isNullOrEmpty() && actionOutput["message"]!!.contains(docEntry)
+                                )
+                            }
+                            "test_value_2" -> bucket2DocIds.forEach { docEntry ->
+                                assertTrue(
+                                    "The notification message is missing docEntry $docEntry",
+                                    !actionOutput["message"].isNullOrEmpty() && actionOutput["message"]!!.contains(docEntry)
+                                )
+                            }
+                        }
+                    } else {
+                        fail("Unknown action: ${actionResult["name"]}")
+                    }
+                }
+            }
         }
     }
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
@@ -9,6 +9,7 @@ import junit.framework.TestCase.assertNull
 import org.apache.http.Header
 import org.apache.http.HttpEntity
 import org.opensearch.alerting.model.ActionRunResult
+import org.opensearch.alerting.model.AlertContext
 import org.opensearch.alerting.model.BucketLevelTriggerRunResult
 import org.opensearch.alerting.model.DocumentLevelTriggerRunResult
 import org.opensearch.alerting.model.InputRunResults
@@ -793,5 +794,24 @@ fun randomChainedAlertTrigger(
         actions = if (actions.isEmpty() && destinationId.isNotBlank()) {
             (0..randomInt(10)).map { randomAction(destinationId = destinationId) }
         } else actions
+    )
+}
+
+fun randomAlertContext(
+    alert: Alert = randomAlert(),
+    associatedQueries: List<DocLevelQuery>? = (-1..2).random().takeIf { it != -1 }?.let {
+        (0..it).map { randomDocLevelQuery() }
+    },
+    sampleDocs: List<Map<String, Any?>>? = (-1..2).random().takeIf { it != -1 }?.let {
+        (0..it).map {
+            // Using 'randomFinding' to mimic documents in an index.
+            randomFinding().asTemplateArg()
+        }
+    }
+): AlertContext {
+    return AlertContext(
+        alert = alert,
+        associatedQueries = associatedQueries,
+        sampleDocs = sampleDocs
     )
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/model/AlertContextTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/model/AlertContextTests.kt
@@ -1,0 +1,401 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.model
+
+import org.opensearch.alerting.randomAlertContext
+import org.opensearch.alerting.randomDocLevelQuery
+import org.opensearch.alerting.randomFinding
+import org.opensearch.commons.alerting.model.Alert
+import org.opensearch.commons.alerting.model.DocLevelQuery
+import org.opensearch.test.OpenSearchTestCase
+
+@Suppress("UNCHECKED_CAST")
+class AlertContextTests : OpenSearchTestCase() {
+
+    fun `test AlertContext asTemplateArg with null associatedQueries and null sampleDocs`() {
+        val associatedQueries: List<DocLevelQuery>? = null
+        val sampleDocs: List<Map<String, Any?>>? = null
+        val alertContext: AlertContext = randomAlertContext(
+            associatedQueries = associatedQueries,
+            sampleDocs = sampleDocs
+        )
+
+        val templateArgs = alertContext.asTemplateArg()
+
+        assertAlertIsEqual(alertContext = alertContext, templateArgs = templateArgs)
+        assertNull("Template associated queries should be null", templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD])
+        assertNull("Template sample docs should be null", templateArgs[AlertContext.SAMPLE_DOCS_FIELD])
+    }
+
+    fun `test AlertContext asTemplateArg with null associatedQueries and 0 sampleDocs`() {
+        val associatedQueries: List<DocLevelQuery>? = null
+        val sampleDocs: List<Map<String, Any?>> = listOf()
+        val alertContext: AlertContext = randomAlertContext(
+            associatedQueries = associatedQueries,
+            sampleDocs = sampleDocs
+        )
+
+        val templateArgs = alertContext.asTemplateArg()
+
+        assertAlertIsEqual(alertContext = alertContext, templateArgs = templateArgs)
+        assertNull("Template associated queries should be null", templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD])
+        assertEquals(
+            "Template args sample docs should have size ${sampleDocs!!.size}",
+            sampleDocs!!.size,
+            (templateArgs[AlertContext.SAMPLE_DOCS_FIELD] as List<Map<String, Any?>>).size
+        )
+        assertEquals("Template args sample docs do not match", alertContext.sampleDocs, templateArgs[AlertContext.SAMPLE_DOCS_FIELD])
+    }
+
+    fun `test AlertContext asTemplateArg with null associatedQueries and 1 sampleDocs`() {
+        val associatedQueries: List<DocLevelQuery>? = null
+        val sampleDocs: List<Map<String, Any?>> = listOf(randomFinding().asTemplateArg())
+        val alertContext: AlertContext = randomAlertContext(
+            associatedQueries = associatedQueries,
+            sampleDocs = sampleDocs
+        )
+
+        val templateArgs = alertContext.asTemplateArg()
+
+        assertAlertIsEqual(alertContext = alertContext, templateArgs = templateArgs)
+        assertNull("Template associated queries should be null", templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD])
+        assertEquals(
+            "Template args sample docs should have size ${sampleDocs.size}",
+            sampleDocs.size,
+            (templateArgs[AlertContext.SAMPLE_DOCS_FIELD] as List<Map<String, Any?>>).size
+        )
+        assertEquals("Template args sample docs do not match", alertContext.sampleDocs, templateArgs[AlertContext.SAMPLE_DOCS_FIELD])
+    }
+
+    fun `test AlertContext asTemplateArg with null associatedQueries and multiple sampleDocs`() {
+        val associatedQueries: List<DocLevelQuery>? = null
+        val sampleDocs: List<Map<String, Any?>> = (0..2).map { randomFinding().asTemplateArg() }
+        val alertContext: AlertContext = randomAlertContext(
+            associatedQueries = associatedQueries,
+            sampleDocs = sampleDocs
+        )
+
+        val templateArgs = alertContext.asTemplateArg()
+
+        assertAlertIsEqual(alertContext = alertContext, templateArgs = templateArgs)
+        assertNull("Template associated queries should be null", templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD])
+        assertEquals(
+            "Template args sample docs should have size ${sampleDocs.size}",
+            sampleDocs.size,
+            (templateArgs[AlertContext.SAMPLE_DOCS_FIELD] as List<Map<String, Any?>>).size
+        )
+        assertEquals("Template args sample docs do not match", alertContext.sampleDocs, templateArgs[AlertContext.SAMPLE_DOCS_FIELD])
+    }
+
+    fun `test AlertContext asTemplateArg with 0 associatedQueries and null sampleDocs`() {
+        val associatedQueries: List<DocLevelQuery> = listOf()
+        val sampleDocs: List<Map<String, Any?>>? = null
+        val alertContext: AlertContext = randomAlertContext(
+            associatedQueries = associatedQueries,
+            sampleDocs = sampleDocs
+        )
+
+        val templateArgs = alertContext.asTemplateArg()
+
+        assertAlertIsEqual(alertContext = alertContext, templateArgs = templateArgs)
+        assertEquals(
+            "Template args associated queries should have size ${associatedQueries.size}",
+            associatedQueries.size,
+            (templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD] as List<DocLevelQuery>).size
+        )
+        assertEquals(
+            "Template associated queries do not match",
+            formatAssociatedQueries(alertContext),
+            templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD]
+        )
+        assertNull("Template sample docs should be null", templateArgs[AlertContext.SAMPLE_DOCS_FIELD])
+    }
+
+    fun `test AlertContext asTemplateArg with 1 associatedQueries and null sampleDocs`() {
+        val associatedQueries: List<DocLevelQuery> = listOf(randomDocLevelQuery())
+        val sampleDocs: List<Map<String, Any?>>? = null
+        val alertContext: AlertContext = randomAlertContext(
+            associatedQueries = associatedQueries,
+            sampleDocs = sampleDocs
+        )
+
+        val templateArgs = alertContext.asTemplateArg()
+
+        assertAlertIsEqual(alertContext = alertContext, templateArgs = templateArgs)
+        assertEquals(
+            "Template args associated queries should have size ${associatedQueries.size}",
+            associatedQueries.size,
+            (templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD] as List<DocLevelQuery>).size
+        )
+        assertEquals(
+            "Template associated queries do not match",
+            formatAssociatedQueries(alertContext),
+            templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD]
+        )
+        assertNull("Template sample docs should be null", templateArgs[AlertContext.SAMPLE_DOCS_FIELD])
+    }
+
+    fun `test AlertContext asTemplateArg with multiple associatedQueries and null sampleDocs`() {
+        val associatedQueries: List<DocLevelQuery> = (0..2).map { randomDocLevelQuery() }
+        val sampleDocs: List<Map<String, Any?>>? = null
+        val alertContext: AlertContext = randomAlertContext(
+            associatedQueries = associatedQueries,
+            sampleDocs = sampleDocs
+        )
+
+        val templateArgs = alertContext.asTemplateArg()
+
+        assertAlertIsEqual(alertContext = alertContext, templateArgs = templateArgs)
+        assertEquals(
+            "Template args associated queries should have size ${associatedQueries.size}",
+            associatedQueries.size,
+            (templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD] as List<DocLevelQuery>).size
+        )
+        assertEquals(
+            "Template associated queries do not match",
+            formatAssociatedQueries(alertContext),
+            templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD]
+        )
+        assertNull("Template sample docs should be null", templateArgs[AlertContext.SAMPLE_DOCS_FIELD])
+    }
+
+    fun `test AlertContext asTemplateArg with 0 associatedQueries and 0 sampleDocs`() {
+        val associatedQueries: List<DocLevelQuery> = listOf()
+        val sampleDocs: List<Map<String, Any?>> = listOf()
+        val alertContext: AlertContext = randomAlertContext(
+            associatedQueries = associatedQueries,
+            sampleDocs = sampleDocs
+        )
+
+        val templateArgs = alertContext.asTemplateArg()
+
+        assertAlertIsEqual(alertContext = alertContext, templateArgs = templateArgs)
+        assertEquals(
+            "Template args associated queries should have size ${associatedQueries.size}",
+            associatedQueries.size,
+            (templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD] as List<DocLevelQuery>).size
+        )
+        assertEquals(
+            "Template associated queries do not match",
+            formatAssociatedQueries(alertContext),
+            templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD]
+        )
+
+        assertEquals(
+            "Template args sample docs should have size ${sampleDocs.size}",
+            sampleDocs.size,
+            (templateArgs[AlertContext.SAMPLE_DOCS_FIELD] as List<Map<String, Any?>>).size
+        )
+        assertEquals("Template args sample docs do not match", alertContext.sampleDocs, templateArgs[AlertContext.SAMPLE_DOCS_FIELD])
+    }
+
+    fun `test AlertContext asTemplateArg with 0 associatedQueries and 1 sampleDocs`() {
+        val associatedQueries: List<DocLevelQuery> = listOf()
+        val sampleDocs: List<Map<String, Any?>> = listOf(randomFinding().asTemplateArg())
+        val alertContext: AlertContext = randomAlertContext(
+            associatedQueries = associatedQueries,
+            sampleDocs = sampleDocs
+        )
+
+        val templateArgs = alertContext.asTemplateArg()
+
+        assertAlertIsEqual(alertContext = alertContext, templateArgs = templateArgs)
+        assertEquals(
+            "Template args associated queries should have size ${associatedQueries.size}",
+            associatedQueries.size,
+            (templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD] as List<DocLevelQuery>).size
+        )
+        assertEquals(
+            "Template associated queries do not match",
+            formatAssociatedQueries(alertContext),
+            templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD]
+        )
+
+        assertEquals(
+            "Template args sample docs should have size ${sampleDocs.size}",
+            sampleDocs.size,
+            (templateArgs[AlertContext.SAMPLE_DOCS_FIELD] as List<Map<String, Any?>>).size
+        )
+        assertEquals("Template args sample docs do not match", alertContext.sampleDocs, templateArgs[AlertContext.SAMPLE_DOCS_FIELD])
+    }
+
+    fun `test AlertContext asTemplateArg with 0 associatedQueries and multiple sampleDocs`() {
+        val associatedQueries: List<DocLevelQuery> = listOf()
+        val sampleDocs: List<Map<String, Any?>> = (0..2).map { randomFinding().asTemplateArg() }
+        val alertContext: AlertContext = randomAlertContext(
+            associatedQueries = associatedQueries,
+            sampleDocs = sampleDocs
+        )
+
+        val templateArgs = alertContext.asTemplateArg()
+
+        assertAlertIsEqual(alertContext = alertContext, templateArgs = templateArgs)
+        assertEquals(
+            "Template args associated queries should have size ${associatedQueries.size}",
+            associatedQueries.size,
+            (templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD] as List<DocLevelQuery>).size
+        )
+        assertEquals(
+            "Template associated queries do not match",
+            formatAssociatedQueries(alertContext),
+            templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD]
+        )
+
+        assertEquals(
+            "Template args sample docs should have size ${sampleDocs.size}",
+            sampleDocs.size,
+            (templateArgs[AlertContext.SAMPLE_DOCS_FIELD] as List<Map<String, Any?>>).size
+        )
+        assertEquals("Template args sample docs do not match", alertContext.sampleDocs, templateArgs[AlertContext.SAMPLE_DOCS_FIELD])
+    }
+
+    fun `test AlertContext asTemplateArg with 1 associatedQueries and 0 sampleDocs`() {
+        val associatedQueries: List<DocLevelQuery> = listOf(randomDocLevelQuery())
+        val sampleDocs: List<Map<String, Any?>> = listOf()
+        val alertContext: AlertContext = randomAlertContext(
+            associatedQueries = associatedQueries,
+            sampleDocs = sampleDocs
+        )
+
+        val templateArgs = alertContext.asTemplateArg()
+
+        assertAlertIsEqual(alertContext = alertContext, templateArgs = templateArgs)
+        assertEquals(
+            "Template args associated queries should have size ${associatedQueries.size}",
+            associatedQueries.size,
+            (templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD] as List<DocLevelQuery>).size
+        )
+        assertEquals(
+            "Template associated queries do not match",
+            formatAssociatedQueries(alertContext),
+            templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD]
+        )
+
+        assertEquals(
+            "Template args sample docs should have size ${sampleDocs.size}",
+            sampleDocs.size,
+            (templateArgs[AlertContext.SAMPLE_DOCS_FIELD] as List<Map<String, Any?>>).size
+        )
+        assertEquals("Template args sample docs do not match", alertContext.sampleDocs, templateArgs[AlertContext.SAMPLE_DOCS_FIELD])
+    }
+
+    fun `test AlertContext asTemplateArg with multiple associatedQueries and 0 sampleDocs`() {
+        val associatedQueries: List<DocLevelQuery> = (0..2).map { randomDocLevelQuery() }
+        val sampleDocs: List<Map<String, Any?>> = listOf()
+        val alertContext: AlertContext = randomAlertContext(
+            associatedQueries = associatedQueries,
+            sampleDocs = sampleDocs
+        )
+
+        val templateArgs = alertContext.asTemplateArg()
+
+        assertAlertIsEqual(alertContext = alertContext, templateArgs = templateArgs)
+        assertEquals(
+            "Template args associated queries should have size ${associatedQueries.size}",
+            associatedQueries.size,
+            (templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD] as List<DocLevelQuery>).size
+        )
+        assertEquals(
+            "Template associated queries do not match",
+            formatAssociatedQueries(alertContext),
+            templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD]
+        )
+
+        assertEquals(
+            "Template args sample docs should have size ${sampleDocs.size}",
+            sampleDocs.size,
+            (templateArgs[AlertContext.SAMPLE_DOCS_FIELD] as List<Map<String, Any?>>).size
+        )
+        assertEquals("Template args sample docs do not match", alertContext.sampleDocs, templateArgs[AlertContext.SAMPLE_DOCS_FIELD])
+    }
+
+    fun `test AlertContext asTemplateArg with 1 associatedQueries and 1 sampleDocs`() {
+        val associatedQueries: List<DocLevelQuery> = listOf(randomDocLevelQuery())
+        val sampleDocs: List<Map<String, Any?>> = listOf(randomFinding().asTemplateArg())
+        val alertContext: AlertContext = randomAlertContext(
+            associatedQueries = associatedQueries,
+            sampleDocs = sampleDocs
+        )
+
+        val templateArgs = alertContext.asTemplateArg()
+
+        assertAlertIsEqual(alertContext = alertContext, templateArgs = templateArgs)
+        assertEquals(
+            "Template args associated queries should have size ${associatedQueries.size}",
+            associatedQueries.size,
+            (templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD] as List<DocLevelQuery>).size
+        )
+        assertEquals(
+            "Template associated queries do not match",
+            formatAssociatedQueries(alertContext),
+            templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD]
+        )
+
+        assertEquals(
+            "Template args sample docs should have size ${sampleDocs.size}",
+            sampleDocs.size,
+            (templateArgs[AlertContext.SAMPLE_DOCS_FIELD] as List<Map<String, Any?>>).size
+        )
+        assertEquals("Template args sample docs do not match", alertContext.sampleDocs, templateArgs[AlertContext.SAMPLE_DOCS_FIELD])
+    }
+
+    fun `test AlertContext asTemplateArg with multiple associatedQueries and multiple sampleDocs`() {
+        val associatedQueries: List<DocLevelQuery> = (0..2).map { randomDocLevelQuery() }
+        val sampleDocs: List<Map<String, Any?>> = (0..2).map { randomFinding().asTemplateArg() }
+        val alertContext: AlertContext = randomAlertContext(
+            associatedQueries = associatedQueries,
+            sampleDocs = sampleDocs
+        )
+
+        val templateArgs = alertContext.asTemplateArg()
+
+        assertAlertIsEqual(alertContext = alertContext, templateArgs = templateArgs)
+        assertEquals(
+            "Template args associated queries should have size ${associatedQueries.size}",
+            associatedQueries.size,
+            (templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD] as List<DocLevelQuery>).size
+        )
+        assertEquals(
+            "Template associated queries do not match",
+            formatAssociatedQueries(alertContext),
+            templateArgs[AlertContext.ASSOCIATED_QUERIES_FIELD]
+        )
+
+        assertEquals(
+            "Template args sample docs should have size ${sampleDocs.size}",
+            sampleDocs.size,
+            (templateArgs[AlertContext.SAMPLE_DOCS_FIELD] as List<Map<String, Any?>>).size
+        )
+        assertEquals("Template args sample docs do not match", alertContext.sampleDocs, templateArgs[AlertContext.SAMPLE_DOCS_FIELD])
+    }
+
+    private fun assertAlertIsEqual(alertContext: AlertContext, templateArgs: Map<String, Any?>) {
+        assertEquals("Template args id does not match", alertContext.alert.id, templateArgs[Alert.ALERT_ID_FIELD])
+        assertEquals("Template args version does not match", alertContext.alert.version, templateArgs[Alert.ALERT_VERSION_FIELD])
+        assertEquals("Template args state does not match", alertContext.alert.state.toString(), templateArgs[Alert.STATE_FIELD])
+        assertEquals("Template args error message does not match", alertContext.alert.errorMessage, templateArgs[Alert.ERROR_MESSAGE_FIELD])
+        assertEquals("Template args acknowledged time does not match", null, templateArgs[Alert.ACKNOWLEDGED_TIME_FIELD])
+        assertEquals("Template args end time does not", alertContext.alert.endTime?.toEpochMilli(), templateArgs[Alert.END_TIME_FIELD])
+        assertEquals("Template args start time does not", alertContext.alert.startTime.toEpochMilli(), templateArgs[Alert.START_TIME_FIELD])
+        assertEquals("Template args last notification time does not match", templateArgs[Alert.LAST_NOTIFICATION_TIME_FIELD], null)
+        assertEquals("Template args severity does not match", alertContext.alert.severity, templateArgs[Alert.SEVERITY_FIELD])
+        assertEquals(
+            "Template args clusters does not match",
+            alertContext.alert.clusters?.joinToString(","),
+            templateArgs[Alert.CLUSTERS_FIELD]
+        )
+    }
+
+    private fun formatAssociatedQueries(alertContext: AlertContext): List<Map<String, Any>>? {
+        return alertContext.associatedQueries?.map {
+            mapOf(
+                DocLevelQuery.QUERY_ID_FIELD to it.id,
+                DocLevelQuery.NAME_FIELD to it.name,
+                DocLevelQuery.TAGS_FIELD to it.tags
+            )
+        }
+    }
+}

--- a/alerting/src/test/kotlin/org/opensearch/alerting/model/AlertContextTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/model/AlertContextTests.kt
@@ -382,7 +382,6 @@ class AlertContextTests : OpenSearchTestCase() {
         assertEquals("Template args start time does not", alertContext.alert.startTime.toEpochMilli(), templateArgs[Alert.START_TIME_FIELD])
         assertEquals("Template args last notification time does not match", templateArgs[Alert.LAST_NOTIFICATION_TIME_FIELD], null)
         assertEquals("Template args severity does not match", alertContext.alert.severity, templateArgs[Alert.SEVERITY_FIELD])
-
     }
 
     private fun formatAssociatedQueries(alertContext: AlertContext): List<Map<String, Any>>? {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/model/AlertContextTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/model/AlertContextTests.kt
@@ -382,11 +382,7 @@ class AlertContextTests : OpenSearchTestCase() {
         assertEquals("Template args start time does not", alertContext.alert.startTime.toEpochMilli(), templateArgs[Alert.START_TIME_FIELD])
         assertEquals("Template args last notification time does not match", templateArgs[Alert.LAST_NOTIFICATION_TIME_FIELD], null)
         assertEquals("Template args severity does not match", alertContext.alert.severity, templateArgs[Alert.SEVERITY_FIELD])
-        assertEquals(
-            "Template args clusters does not match",
-            alertContext.alert.clusters?.joinToString(","),
-            templateArgs[Alert.CLUSTERS_FIELD]
-        )
+
     }
 
     private fun formatAssociatedQueries(alertContext: AlertContext): List<Map<String, Any>>? {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/util/AlertingUtilsTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/util/AlertingUtilsTests.kt
@@ -1,0 +1,179 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.util
+
+import org.opensearch.alerting.model.AlertContext
+import org.opensearch.alerting.randomAction
+import org.opensearch.alerting.randomBucketLevelTrigger
+import org.opensearch.alerting.randomChainedAlertTrigger
+import org.opensearch.alerting.randomDocumentLevelTrigger
+import org.opensearch.alerting.randomQueryLevelTrigger
+import org.opensearch.alerting.randomTemplateScript
+import org.opensearch.alerting.script.BucketLevelTriggerExecutionContext
+import org.opensearch.alerting.script.DocumentLevelTriggerExecutionContext
+import org.opensearch.test.OpenSearchTestCase
+
+class AlertingUtilsTests : OpenSearchTestCase() {
+    fun `test parseSampleDocTags only returns expected tags`() {
+        val expectedDocSourceTags = (0..3).map { "field$it" }
+        val unexpectedDocSourceTags = ((expectedDocSourceTags.size + 1)..(expectedDocSourceTags.size + 5))
+            .map { "field$it" }
+
+        val unexpectedTagsScriptSource = unexpectedDocSourceTags.joinToString { field -> "$field = {{$field}}" }
+        val expectedTagsScriptSource = unexpectedTagsScriptSource + """
+                ${unexpectedDocSourceTags.joinToString("\n") { field -> "$field = {{$field}}" }}
+                {{#alerts}}
+                {{#${AlertContext.SAMPLE_DOCS_FIELD}}}
+                    ${expectedDocSourceTags.joinToString("\n") { field -> "$field = {{_source.$field}}" }}
+                {{/${AlertContext.SAMPLE_DOCS_FIELD}}}
+                {{/alerts}}
+        """.trimIndent()
+
+        // Action that prints doc source data
+        val trigger1 = randomDocumentLevelTrigger(
+            actions = listOf(randomAction(template = randomTemplateScript(source = expectedTagsScriptSource)))
+        )
+
+        // Action that does not print doc source data
+        val trigger2 = randomDocumentLevelTrigger(
+            actions = listOf(randomAction(template = randomTemplateScript(source = unexpectedTagsScriptSource)))
+        )
+
+        // No actions
+        val trigger3 = randomDocumentLevelTrigger(actions = listOf())
+
+        val tags = parseSampleDocTags(listOf(trigger1, trigger2, trigger3))
+
+        assertEquals(expectedDocSourceTags.size, tags.size)
+        expectedDocSourceTags.forEach { tag -> assertTrue(tags.contains(tag)) }
+        unexpectedDocSourceTags.forEach { tag -> assertFalse(tags.contains(tag)) }
+    }
+
+    fun `test printsSampleDocData entire ctx tag returns TRUE`() {
+        val tag = "{{ctx}}"
+        val triggers = listOf(
+            randomBucketLevelTrigger(actions = listOf(randomAction(template = randomTemplateScript(source = tag)))),
+            randomDocumentLevelTrigger(actions = listOf(randomAction(template = randomTemplateScript(source = tag))))
+        )
+
+        triggers.forEach { trigger -> assertTrue(printsSampleDocData(trigger)) }
+    }
+
+    fun `test printsSampleDocData entire alerts tag returns TRUE`() {
+        val triggers = listOf(
+            randomBucketLevelTrigger(
+                actions = listOf(
+                    randomAction(
+                        template = randomTemplateScript(
+                            source = "{{ctx.${BucketLevelTriggerExecutionContext.NEW_ALERTS_FIELD}}}"
+                        )
+                    )
+                )
+            ),
+            randomDocumentLevelTrigger(
+                actions = listOf(
+                    randomAction(
+                        template = randomTemplateScript(
+                            source = "{{ctx.${DocumentLevelTriggerExecutionContext.ALERTS_FIELD}}}"
+                        )
+                    )
+                )
+            )
+        )
+
+        triggers.forEach { trigger -> assertTrue(printsSampleDocData(trigger)) }
+    }
+
+    fun `test printsSampleDocData entire sample_docs tag returns TRUE`() {
+        val triggers = listOf(
+            randomBucketLevelTrigger(
+                actions = listOf(
+                    randomAction(
+                        template = randomTemplateScript(
+                            source = """
+                                {{#ctx.${BucketLevelTriggerExecutionContext.NEW_ALERTS_FIELD}}}
+                                    {{${AlertContext.SAMPLE_DOCS_FIELD}}}
+                                {{/ctx.${BucketLevelTriggerExecutionContext.NEW_ALERTS_FIELD}}}
+                            """.trimIndent()
+                        )
+                    )
+                )
+            ),
+            randomDocumentLevelTrigger(
+                actions = listOf(
+                    randomAction(
+                        template = randomTemplateScript(
+                            source = """
+                                {{#ctx.${DocumentLevelTriggerExecutionContext.ALERTS_FIELD}}}
+                                    {{${AlertContext.SAMPLE_DOCS_FIELD}}}
+                                {{/ctx.${DocumentLevelTriggerExecutionContext.ALERTS_FIELD}}}
+                            """.trimIndent()
+                        )
+                    )
+                )
+            )
+        )
+
+        triggers.forEach { trigger -> assertTrue(printsSampleDocData(trigger)) }
+    }
+
+    fun `test printsSampleDocData sample_docs iteration block returns TRUE`() {
+        val triggers = listOf(
+            randomBucketLevelTrigger(
+                actions = listOf(
+                    randomAction(
+                        template = randomTemplateScript(
+                            source = """
+                                {{#ctx.${BucketLevelTriggerExecutionContext.NEW_ALERTS_FIELD}}}
+                                    "{{#${AlertContext.SAMPLE_DOCS_FIELD}}}"
+                                        {{_source.field}}
+                                    "{{/${AlertContext.SAMPLE_DOCS_FIELD}}}"
+                                {{/ctx.${BucketLevelTriggerExecutionContext.NEW_ALERTS_FIELD}}}
+                            """.trimIndent()
+                        )
+                    )
+                )
+            ),
+            randomDocumentLevelTrigger(
+                actions = listOf(
+                    randomAction(
+                        template = randomTemplateScript(
+                            source = """
+                                {{#ctx.${DocumentLevelTriggerExecutionContext.ALERTS_FIELD}}}
+                                    {{#${AlertContext.SAMPLE_DOCS_FIELD}}}
+                                        {{_source.field}}
+                                    {{/${AlertContext.SAMPLE_DOCS_FIELD}}}
+                                {{/ctx.${DocumentLevelTriggerExecutionContext.ALERTS_FIELD}}}
+                            """.trimIndent()
+                        )
+                    )
+                )
+            )
+        )
+
+        triggers.forEach { trigger -> assertTrue(printsSampleDocData(trigger)) }
+    }
+
+    fun `test printsSampleDocData unrelated tag returns FALSE`() {
+        val tag = "{{ctx.monitor.name}}"
+        val triggers = listOf(
+            randomBucketLevelTrigger(actions = listOf(randomAction(template = randomTemplateScript(source = tag)))),
+            randomDocumentLevelTrigger(actions = listOf(randomAction(template = randomTemplateScript(source = tag))))
+        )
+
+        triggers.forEach { trigger -> assertFalse(printsSampleDocData(trigger)) }
+    }
+
+    fun `test printsSampleDocData unsupported trigger types return FALSE`() {
+        val tag = "{{ctx}}"
+        val triggers = listOf(
+            randomQueryLevelTrigger(actions = listOf(randomAction(template = randomTemplateScript(source = tag)))),
+            randomChainedAlertTrigger(actions = listOf(randomAction(template = randomTemplateScript(source = tag))))
+        )
+
+        triggers.forEach { trigger -> assertFalse(printsSampleDocData(trigger)) }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Manual backport of PR https://github.com/opensearch-project/alerting/pull/1450

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).