### PR TITLE
adding tracking_total_hits in search query for findings

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetFindingsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetFindingsAction.kt
@@ -131,7 +131,7 @@ class TransportGetFindingsSearchAction @Inject constructor(
                     )
                 )
         }
-        searchSourceBuilder.query(queryBuilder)
+        searchSourceBuilder.query(queryBuilder).trackTotalHits(true)
 
         client.threadPool().threadContext.stashContext().use {
             scope.launch {


### PR DESCRIPTION
*Track_total_hits to true *

* This PR intends to get total_count of findings if they are more than 10,000 by introducing  `track_total_hits: true` i.e if findings are more than 10,000 it will fetch the actual count. For [ref](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/search-your-data.html#track-total-hits)

*CheckList:*
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).