### PR TITLE
Add validation check for doc level query name during monitor creation

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt
@@ -49,8 +49,8 @@ class RestIndexMonitorAction : BaseRestHandler() {
 
     // allowed characters [- : , ( ) [ ] ' _]
     private val allowedChars = "-:,\\(\\)\\[\\]\'_"
-    // regex to restrict string to alphanumeric and allowed chars, must be between 1 - 256 characters
-    val regex = "[\\w\\s$allowedChars]{1,256}"
+    // regex to restrict string to alphanumeric and allowed chars, must be between 0 - 256 characters
+    val regex = "[\\w\\s$allowedChars]{0,256}"
 
     override fun getName(): String {
         return "index_monitor_action"

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -26,6 +26,8 @@ import org.opensearch.alerting.randomAnomalyDetector
 import org.opensearch.alerting.randomAnomalyDetectorWithUser
 import org.opensearch.alerting.randomBucketLevelMonitor
 import org.opensearch.alerting.randomBucketLevelTrigger
+import org.opensearch.alerting.randomDocLevelMonitorInput
+import org.opensearch.alerting.randomDocLevelQuery
 import org.opensearch.alerting.randomDocumentLevelMonitor
 import org.opensearch.alerting.randomDocumentLevelTrigger
 import org.opensearch.alerting.randomQueryLevelMonitor
@@ -1282,6 +1284,48 @@ class MonitorRestApiIT : AlertingRestTestCase() {
                 "Incompatible trigger [${trigger.id}] for monitor type [${Monitor.MonitorType.QUERY_LEVEL_MONITOR}]",
                 e.message
             )
+        }
+    }
+
+    fun `test creating and updating a document monitor with invalid query name`() {
+        // creating a monitor with an invalid query name
+        val invalidQueryName = "Invalid @ query ! name"
+        val queries = listOf(randomDocLevelQuery(name = invalidQueryName))
+        val randomDocLevelMonitorInput = randomDocLevelMonitorInput(queries = queries)
+        val inputs = listOf(randomDocLevelMonitorInput)
+        val trigger = randomDocumentLevelTrigger()
+        var monitor = randomDocumentLevelMonitor(inputs = inputs, triggers = listOf(trigger))
+
+        try {
+            client().makeRequest("POST", ALERTING_BASE_URI, emptyMap(), monitor.toHttpEntity())
+            fail("Doc level monitor with invalid query name should be rejected")
+        } catch (e: ResponseException) {
+            assertEquals("Unexpected status", RestStatus.BAD_REQUEST, e.response.restStatus())
+            val expectedMessage = "Doc level query name, $invalidQueryName, may only contain alphanumeric values"
+            e.message?.let { assertTrue(it.contains(expectedMessage)) }
+        }
+
+        // successfully creating monitor with valid query name
+        val testIndex = createTestIndex()
+        val docQuery = DocLevelQuery(query = "test_field:\"us-west-2\"", name = "valid name", fields = listOf())
+        val docLevelInput = DocLevelMonitorInput("description", listOf(testIndex), listOf(docQuery))
+
+        monitor = createMonitor(randomDocumentLevelMonitor(inputs = listOf(docLevelInput), triggers = listOf(trigger)))
+
+        // updating monitor with invalid query name
+        val updatedDocQuery = DocLevelQuery(query = "test_field:\"us-west-2\"", name = invalidQueryName, fields = listOf())
+        val updatedDocLevelInput = DocLevelMonitorInput("description", listOf(testIndex), listOf(updatedDocQuery))
+
+        try {
+            client().makeRequest(
+                "PUT", monitor.relativeUrl(),
+                emptyMap(), monitor.copy(inputs = listOf(updatedDocLevelInput)).toHttpEntity()
+            )
+            fail("Doc level monitor with invalid query name should be rejected")
+        } catch (e: ResponseException) {
+            assertEquals("Unexpected status", RestStatus.BAD_REQUEST, e.response.restStatus())
+            val expectedMessage = "Doc level query name, $invalidQueryName, may only contain alphanumeric values"
+            e.message?.let { assertTrue(it.contains(expectedMessage)) }
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*
PR related to: https://github.com/opensearch-project/common-utils/pull/630
CI's will fail until common utils PR is merged in

*Description of changes:*
Adds validation check for doc level query name during monitor creation. Doc level query is restricted so that it may not start with: `[_, +, -]`, contain `..`, or contain: `[* ? < > | #]`

*CheckList:*
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).