### PR TITLE
Adjusted maven publish workflow to execute automatically when merging a PR.

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -3,11 +3,10 @@ name: Publish snapshots to maven
 on:
   workflow_dispatch:
   push:
-    branches: [
-        main
-          1.*
-          2.*
-    ]
+    branches:
+      - main
+      - '[0-9]+.[0-9]+'
+      - '[0-9]+.x'
 
 jobs:
   build-and-publish-snapshots:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adjusted maven publish workflow to execute automatically when merging a PR.

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).