### PR TITLE
changed alertContext field name to alert

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt
@@ -158,7 +158,7 @@ class AlertService(
         workflorwRunContext: WorkflowRunContext?
     ): Alert? {
         val currentTime = Instant.now()
-        val currentAlert = ctx.alertContext?.alert
+        val currentAlert = ctx.alert?.alert
 
         val updatedActionExecutionResults = mutableListOf<ActionExecutionResult>()
         val currentActionIds = mutableSetOf<String>()

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
@@ -56,7 +56,7 @@ abstract class MonitorRunner {
         dryrun: Boolean
     ): ActionRunResult {
         return try {
-            if (ctx is QueryLevelTriggerExecutionContext && !MonitorRunnerService.isActionActionable(action, ctx.alertContext?.alert)) {
+            if (ctx is QueryLevelTriggerExecutionContext && !MonitorRunnerService.isActionActionable(action, ctx.alert?.alert)) {
                 return ActionRunResult(action.id, action.name, mapOf(), true, null, null)
             }
             val actionOutput = mutableMapOf<String, String>()

--- a/alerting/src/main/kotlin/org/opensearch/alerting/TriggerService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/TriggerService.kt
@@ -53,7 +53,7 @@ class TriggerService(val scriptService: ScriptService) {
     ): Boolean {
         if (workflowRunContext?.auditDelegateMonitorAlerts == true) return false
         // Suppress actions if the current alert is acknowledged and there are no errors.
-        val suppress = ctx.alertContext?.alert?.state == Alert.State.ACKNOWLEDGED && result.error == null && ctx.error == null
+        val suppress = ctx.alert?.alert?.state == Alert.State.ACKNOWLEDGED && result.error == null && ctx.error == null
         return result.triggered && !suppress
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/script/QueryLevelTriggerExecutionContext.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/script/QueryLevelTriggerExecutionContext.kt
@@ -18,7 +18,7 @@ data class QueryLevelTriggerExecutionContext(
     override val results: List<Map<String, Any>>,
     override val periodStart: Instant,
     override val periodEnd: Instant,
-    val alertContext: AlertContext? = null,
+    val alert: AlertContext? = null,
     override val error: Exception? = null
 ) : TriggerExecutionContext(monitor, results, periodStart, periodEnd, error) {
 
@@ -39,7 +39,7 @@ data class QueryLevelTriggerExecutionContext(
     override fun asTemplateArg(): Map<String, Any?> {
         val tempArg = super.asTemplateArg().toMutableMap()
         tempArg["trigger"] = trigger.asTemplateArg()
-        tempArg["alert"] = alertContext?.asTemplateArg() // map "alert" templateArg field to AlertContext wrapper instead of Alert object
+        tempArg["alert"] = alert?.asTemplateArg() // map "alert" templateArg field to AlertContext wrapper instead of Alert object
         return tempArg
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
@@ -577,7 +577,7 @@ class TransportDocLevelMonitorFanOutAction
         dryrun: Boolean
     ): ActionRunResult {
         return try {
-            if (ctx is QueryLevelTriggerExecutionContext && !MonitorRunnerService.isActionActionable(action, ctx.alertContext?.alert)) {
+            if (ctx is QueryLevelTriggerExecutionContext && !MonitorRunnerService.isActionActionable(action, ctx.alert?.alert)) {
                 return ActionRunResult(action.id, action.name, mapOf(), true, null, null)
             }
             val actionOutput = mutableMapOf<String, String>()

--- a/alerting/src/main/resources/org/opensearch/alerting/org.opensearch.alerting.txt
+++ b/alerting/src/main/resources/org/opensearch/alerting/org.opensearch.alerting.txt
@@ -27,7 +27,7 @@ class org.opensearch.alerting.script.QueryLevelTriggerExecutionContext {
     List getResults()
     java.time.Instant getPeriodStart()
     java.time.Instant getPeriodEnd()
-    AlertContext getAlertContext()
+    AlertContext getAlert()
     Exception getError()
 }
 


### PR DESCRIPTION
*Issue #, if available:*
A follow-up PR to this main PR #1561 for Alerting Comments to address IT failures.

*Description of changes:*
Changed the name of the AlertContext field in QueryLevelTriggerExecutionContext from `alertContext` to `alert`.

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).