### PR TITLE
fix integ test failures 

### DIFF
--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/GetRemoteIndexesActionIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/GetRemoteIndexesActionIT.kt
@@ -102,8 +102,6 @@ class GetRemoteIndexesActionIT : AlertingRestTestCase() {
             assertNotNull(clusterDetails[ClusterIndexes.INDEXES_FIELD])
             val indexes = clusterDetails[ClusterIndexes.INDEXES_FIELD] as Map<String, Map<String, Any>>
 
-            // Skipping this assert when security is enabled as it doesn't consider the existence of system indexes.
-            if (!securityEnabled()) assertEquals(expectedNames.size, indexes.keys.size)
 
             // Validate index-level response details
             expectedNames.forEach { indexName ->
@@ -152,8 +150,6 @@ class GetRemoteIndexesActionIT : AlertingRestTestCase() {
             assertNotNull(clusterDetails[ClusterIndexes.INDEXES_FIELD])
             val indexes = clusterDetails[ClusterIndexes.INDEXES_FIELD] as Map<String, Map<String, Any>>
 
-            // Skipping this assert when security is enabled as it doesn't consider the existence of system indexes.
-            if (!securityEnabled()) assertEquals(expectedNames.size, indexes.keys.size)
 
             // Validate index-level response details
             expectedNames.forEach { indexName ->
@@ -201,8 +197,6 @@ class GetRemoteIndexesActionIT : AlertingRestTestCase() {
 
             assertNotNull(clusterDetails[ClusterIndexes.INDEXES_FIELD])
             val indexes = clusterDetails[ClusterIndexes.INDEXES_FIELD] as Map<String, Map<String, Any>>
-            // Skipping this assert when security is enabled as it doesn't consider the existence of system indexes.
-            if (!securityEnabled()) assertEquals(expectedNames.size, indexes.keys.size)
 
             // Validate index-level response details
             expectedNames.forEach { indexName ->


### PR DESCRIPTION
*Removed assertion from integ tests causing build failure in jenking*

https://build.ci.opensearch.org/blue/organizations/jenkins/integ-test/detail/integ-test/8329/pipeline/126

If the tests are running on a cluster that has more than just the alerting plugin installed on it, there might be indexes for those plugins created as well, the subsequent assertions are more important, so removed the assertion that checks how many indices exist

Test faIlures in jenkins integ test:

```
Suite: Test class org.opensearch.alerting.transport.GetRemoteIndexesActionIT

  2> REPRODUCE WITH: ./gradlew ':alerting:integTest' --tests "org.opensearch.alerting.transport.GetRemoteIndexesActionIT.test with TRUE include_mappings param" -Dtests.seed=C75572776830D42C -Dtests.security.manager=false -Dtests.locale=ro -Dtests.timezone=Pacific/Enderbury -Druntime.java=21

  2> java.lang.AssertionError: expected:<2> but was:<3>

        at __randomizedtesting.SeedInfo.seed([C75572776830D42C:273B758717CBD74]:0)

        at org.junit.Assert.fail(Assert.java:89)

        at org.junit.Assert.failNotEquals(Assert.java:835)

        at org.junit.Assert.assertEquals(Assert.java:120)

        at org.junit.Assert.assertEquals(Assert.java:146)

        at org.opensearch.alerting.transport.GetRemoteIndexesActionIT.test with TRUE include_mappings param(GetRemoteIndexesActionIT.kt:205)

  2> REPRODUCE WITH: ./gradlew ':alerting:integTest' --tests "org.opensearch.alerting.transport.GetRemoteIndexesActionIT.test with FALSE include_mappings param" -Dtests.seed=C75572776830D42C -Dtests.security.manager=false -Dtests.locale=ro -Dtests.timezone=Pacific/Enderbury -Druntime.java=21

  2> java.lang.AssertionError: expected:<2> but was:<3>

        at __randomizedtesting.SeedInfo.seed([C75572776830D42C:5240C08E4E2190E6]:0)

        at org.junit.Assert.fail(Assert.java:89)

        at org.junit.Assert.failNotEquals(Assert.java:835)

        at org.junit.Assert.assertEquals(Assert.java:120)

        at org.junit.Assert.assertEquals(Assert.java:146)

        at org.opensearch.alerting.transport.GetRemoteIndexesActionIT.test with FALSE include_mappings param(GetRemoteIndexesActionIT.kt:156)

  2> REPRODUCE WITH: ./gradlew ':alerting:integTest' --tests "org.opensearch.alerting.transport.GetRemoteIndexesActionIT.test with blank include_mappings param" -Dtests.seed=C75572776830D42C -Dtests.security.manager=false -Dtests.locale=ro -Dtests.timezone=Pacific/Enderbury -Druntime.java=21

  2> java.lang.AssertionError: expected:<2> but was:<3>

        at __randomizedtesting.SeedInfo.seed([C75572776830D42C:21E8F236EC2DDBF]:0)

        at org.junit.Assert.fail(Assert.java:89)

        at org.junit.Assert.failNotEquals(Assert.java:835)

        at org.junit.Assert.assertEquals(Assert.java:120)

        at org.junit.Assert.assertEquals(Assert.java:146)

        at org.opensearch.alerting.transport.GetRemoteIndexesActionIT.test with blank include_mappings param(GetRemoteIndexesActionIT.kt:106)

  2> NOTE: leaving temporary files on disk at: /tmp/tmpk47m_ab0/alerting/alerting/build/testrun/integTest/temp/org.opensearch.alerting.transport.GetRemoteIndexesActionIT_C75572776830D42C-001

  2> NOTE: test params are: codec=Asserting(Lucene99): {}, docValues:{}, maxPointsInLeafNode=705, maxMBSortInHeap=5.417424553640299, sim=Asserting(RandomSimilarity(queryNorm=true): {}), locale=ro, timezone=Pacific/Enderbury

```

*CheckList:*
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).