### PR TITLE
Register system index descriptors through SystemIndexPlugin.getSystemIndexDescriptors

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -105,6 +105,7 @@ import org.opensearch.commons.alerting.model.DocumentLevelTrigger
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.QueryLevelTrigger
 import org.opensearch.commons.alerting.model.ScheduledJob
+import org.opensearch.commons.alerting.model.ScheduledJob.Companion.SCHEDULED_JOBS_INDEX
 import org.opensearch.commons.alerting.model.SearchInput
 import org.opensearch.commons.alerting.model.Workflow
 import org.opensearch.commons.alerting.model.remote.monitors.RemoteMonitorTrigger
@@ -434,7 +435,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
     override fun getSystemIndexDescriptors(settings: Settings): Collection<SystemIndexDescriptor> {
         return listOf(
             SystemIndexDescriptor(ALL_ALERT_INDEX_PATTERN, "Alerting Plugin system index pattern"),
-            SystemIndexDescriptor(ALERT_CONFIG_INDEX, "Alerting Plugin Configuration index")
+            SystemIndexDescriptor(SCHEDULED_JOBS_INDEX, "Alerting Plugin Configuration index")
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -15,7 +15,6 @@ import org.opensearch.alerting.action.GetRemoteIndexesAction
 import org.opensearch.alerting.action.SearchEmailAccountAction
 import org.opensearch.alerting.action.SearchEmailGroupAction
 import org.opensearch.alerting.alerts.AlertIndices
-import org.opensearch.alerting.alerts.AlertIndices.Companion.ALERT_CONFIG_INDEX
 import org.opensearch.alerting.alerts.AlertIndices.Companion.ALL_ALERT_INDEX_PATTERN
 import org.opensearch.alerting.comments.CommentsIndices
 import org.opensearch.alerting.core.JobSweeper

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -143,7 +143,8 @@ import java.util.function.Supplier
  * It also adds [Monitor.XCONTENT_REGISTRY], [SearchInput.XCONTENT_REGISTRY], [QueryLevelTrigger.XCONTENT_REGISTRY],
  * [BucketLevelTrigger.XCONTENT_REGISTRY], [ClusterMetricsInput.XCONTENT_REGISTRY] to the [NamedXContentRegistry] so that we are able to deserialize the custom named objects.
  */
-internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, ReloadablePlugin, SearchPlugin, SystemIndexPlugin, PercolatorPluginExt() {
+internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, ReloadablePlugin,
+    SearchPlugin, SystemIndexPlugin, PercolatorPluginExt() {
 
     override fun getContextAllowlists(): Map<ScriptContext<*>, List<Allowlist>> {
         val whitelist = AllowlistLoader.loadFromResourceFiles(javaClass, "org.opensearch.alerting.txt")

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -430,7 +430,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
         return listOf(TriggerScript.CONTEXT)
     }
 
-    override fun getSystemIndexDescriptors(settings : Settings): Collection<SystemIndexDescriptor> {
+    override fun getSystemIndexDescriptors(settings: Settings): Collection<SystemIndexDescriptor> {
         return listOf(
             SystemIndexDescriptor(ALL_ALERT_INDEX_PATTERN, "Alerting Plugin system index pattern"),
             SystemIndexDescriptor(ALERT_CONFIG_INDEX, "Alerting Plugin Configuration index")

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -122,7 +122,12 @@ import org.opensearch.painless.spi.Allowlist
 import org.opensearch.painless.spi.AllowlistLoader
 import org.opensearch.painless.spi.PainlessExtension
 import org.opensearch.percolator.PercolatorPluginExt
-import org.opensearch.plugins.*
+import org.opensearch.plugins.ActionPlugin
+import org.opensearch.plugins.ExtensiblePlugin
+import org.opensearch.plugins.ReloadablePlugin
+import org.opensearch.plugins.ScriptPlugin
+import org.opensearch.plugins.SearchPlugin
+import org.opensearch.plugins.SystemIndexPlugin
 import org.opensearch.repositories.RepositoriesService
 import org.opensearch.rest.RestController
 import org.opensearch.rest.RestHandler

--- a/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
@@ -117,8 +117,6 @@ class AlertIndices(
         /** The in progress alert history index. */
         const val ALERT_INDEX = ".opendistro-alerting-alerts"
 
-        const val ALERT_CONFIG_INDEX = ".opendistro-alerting-config"
-
         /** The alias of the index in which to write alert history */
         const val ALERT_HISTORY_WRITE_INDEX = ".opendistro-alerting-alert-history-write"
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
@@ -117,6 +117,8 @@ class AlertIndices(
         /** The in progress alert history index. */
         const val ALERT_INDEX = ".opendistro-alerting-alerts"
 
+        const val ALERT_CONFIG_INDEX = ".opendistro-alerting-config"
+
         /** The alias of the index in which to write alert history */
         const val ALERT_HISTORY_WRITE_INDEX = ".opendistro-alerting-alert-history-write"
 


### PR DESCRIPTION
*Issue #, if available:*

This PR registers the system indices in this plugin through the SystemIndexPlugin extension point in core. These indices will not be functionally different than they are today, its just a formal registration as a system index.

Related to: https://github.com/opensearch-project/security/issues/4439

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).