### PR TITLE
add support for dynamic monitor metadata updates in remote monitors

### DIFF
--- a/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/SampleRemoteMonitorRestHandler.java
+++ b/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/SampleRemoteMonitorRestHandler.java
@@ -208,13 +208,15 @@ public class SampleRemoteMonitorRestHandler extends BaseRestHandler {
                 );
             };
         } else {
+            String indices = restRequest.param("index", "index");
+            List<String> index = List.of(indices.split(","));
             SampleRemoteDocLevelMonitorInput sampleRemoteDocLevelMonitorInput =
                     new SampleRemoteDocLevelMonitorInput("hello", Map.of("world", 1), 2);
             BytesStreamOutput out2 = new BytesStreamOutput();
             sampleRemoteDocLevelMonitorInput.writeTo(out2);
             BytesReference sampleRemoteDocLevelMonitorInputSerialized = out2.bytes();
 
-            DocLevelMonitorInput docLevelMonitorInput = new DocLevelMonitorInput("description", List.of("index"), emptyList());
+            DocLevelMonitorInput docLevelMonitorInput = new DocLevelMonitorInput("description", index, emptyList());
             RemoteDocLevelMonitorInput remoteDocLevelMonitorInput = new RemoteDocLevelMonitorInput(sampleRemoteDocLevelMonitorInputSerialized, docLevelMonitorInput);
 
             Monitor remoteDocLevelMonitor = new Monitor(

--- a/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/fanouts/TransportRemoteDocLevelMonitorFanOutAction.java
+++ b/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/fanouts/TransportRemoteDocLevelMonitorFanOutAction.java
@@ -83,7 +83,12 @@ public class TransportRemoteDocLevelMonitorFanOutAction extends HandledTransport
             SampleRemoteMonitorTrigger1 remoteMonitorTrigger = new SampleRemoteMonitorTrigger1(triggerSin);
 
 
-            ((Map<String, Object>) lastRunContext.get(index)).put("0", 0);
+            if (lastRunContext.containsKey(index)) {
+                ((Map<String, Object>) lastRunContext.get(index)).put("2", 0);
+            }
+            if (docLevelMonitorInput.getIndices().size() > 1 && lastRunContext.containsKey(docLevelMonitorInput.getIndices().get(1))) {
+                ((Map<String, Object>) lastRunContext.get(docLevelMonitorInput.getIndices().get(1))).put("4", 0);
+            }
             IndexRequest indexRequest = new IndexRequest(SampleRemoteDocLevelMonitorRunner.SAMPLE_REMOTE_DOC_LEVEL_MONITOR_RUNNER_INDEX)
                     .source(Map.of(sampleRemoteDocLevelMonitorInput.getA(), remoteMonitorTrigger.getA())).setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL);
             this.client.index(indexRequest, new ActionListener<>() {


### PR DESCRIPTION
*Issue #, if available:*
#1546 

*Description of changes:*
add support for dynamic monitor metadata updates in remote monitors

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).