### PR TITLE
fix pluginzippublish issue

### DIFF
--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - "*"
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   Get-CI-Image-Tag:

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - "*"
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   Get-CI-Image-Tag:

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,4 +13,3 @@ project(":spi").name = 'alerting-spi'
 
 include 'sample-remote-monitor-plugin'
 project(":sample-remote-monitor-plugin").name = "alerting-sample-remote-monitor-plugin"
-startParameter.excludedTaskNames=["publishPluginZipPublicationToMavenLocal", "publishPluginZipPublicationToZipStagingRepository"]


### PR DESCRIPTION
*Issue #, if available:*
#1599 

*Description of changes:*

Re-enable publishing zip to staging repo.
Solves the problem
```
+ mkdir -p builds/maven/org/opensearch
+ cp -r ./build/local-staging-repo/org/opensearch/. builds/maven/org/opensearch
cp: cannot stat './build/local-staging-repo/org/opensearch/.': No such file or directory
2024-07-02 02:16:38 ERROR    ERROR: Command 'bash /tmp/tmp3bqjkb5d/alerting/scripts/build.sh -v 3.0.0 -p linux -a x64 -s false -o builds' returned non-zero exit status 1.
2024-07-02 02:16:38 ERROR    Error building alerting, retry with: ./build.sh manifests/3.0.0/opensearch-3.0.0.yml --component alerting
```

- Full output
```
bash scripts/build.sh -v 3.0.0 -s true
+ getopts :h:v:q:s:o:p:a: arg
+ case $arg in
+ VERSION=3.0.0
+ getopts :h:v:q:s:o:p:a: arg
+ case $arg in
+ SNAPSHOT=true
+ getopts :h:v:q:s:o:p:a: arg
+ '[' -z 3.0.0 ']'
+ [[ ! -z '' ]]
+ [[ true == \t\r\u\e ]]
+ VERSION=3.0.0-SNAPSHOT
+ '[' -z '' ']'
+ OUTPUT=artifacts
+ mkdir -p artifacts/plugins
+ ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=3.0.0-SNAPSHOT -Dbuild.version_qualifier= -Dbuild.snapshot=true
To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/8.5/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.
Daemon will be stopped at the end of the build 
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.5
  OS Info               : Linux 5.10.220-187.867.amzn2int.x86_64 (amd64)
  JDK Version           : 17 (Azul Zulu JDK)
  JAVA_HOME             : /usr/lib/jvm/zulu-17
  Random Testing Seed   : 86F252D4394D548E
  In FIPS 140 mode      : false
=======================================

> Task :alerting-core:compileKotlin
w: file:///local/home/deysubho/Documents/programs/github/alerting/core/src/main/kotlin/org/opensearch/alerting/core/lock/LockModel.kt:96:9 '@JvmOverloads' annotation has no effect for methods without default arguments
w: file:///local/home/deysubho/Documents/programs/github/alerting/core/src/main/kotlin/org/opensearch/alerting/opensearchapi/OpenSearchExtensions.kt:41:41 'toXContent(ToXContent!, XContentType!, Boolean): BytesReference!' is deprecated. Deprecated in Java
w: file:///local/home/deysubho/Documents/programs/github/alerting/core/src/main/kotlin/org/opensearch/alerting/opensearchapi/OpenSearchExtensions.kt:42:27 'convertToMap(BytesReference!, Boolean, XContentType!): Tuple<XContentType!, (Mutable)Map<String!, Any!>!>!' is deprecated. Deprecated in Java

> Task :alerting-sample-remote-monitor-plugin:compileJava
Note: /local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/fanouts/TransportRemoteDocLevelMonitorFanOutAction.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :alerting-sample-remote-monitor-plugin:javadoc
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/inputs/SampleRemoteDocLevelMonitorInput.java:15: warning: no comment
public class SampleRemoteDocLevelMonitorInput implements Writeable {
       ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/inputs/SampleRemoteDocLevelMonitorInput.java:23: warning: no comment
    public SampleRemoteDocLevelMonitorInput(String a, Map<String, Object> b, int c) {
           ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/inputs/SampleRemoteDocLevelMonitorInput.java:29: warning: no comment
    public SampleRemoteDocLevelMonitorInput(StreamInput sin) throws IOException {
           ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/inputs/SampleRemoteDocLevelMonitorInput.java:52: warning: no comment
    public String getA() {
                  ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/inputs/SampleRemoteDocLevelMonitorInput.java:48: warning: no comment
    public Map<String, Object> getB() {
                               ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/inputs/SampleRemoteDocLevelMonitorInput.java:44: warning: no comment
    public int getC() {
               ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/runners/SampleRemoteDocLevelMonitorRunner.java:12: warning: no comment
public class SampleRemoteDocLevelMonitorRunner extends RemoteMonitorRunner {
       ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/runners/SampleRemoteDocLevelMonitorRunner.java:18: warning: no comment
    public static final ActionType<DocLevelMonitorFanOutResponse> REMOTE_DOC_LEVEL_MONITOR_ACTION_INSTANCE = new ActionType<>(REMOTE_DOC_LEVEL_MONITOR_ACTION_NAME,
                                                                  ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/runners/SampleRemoteDocLevelMonitorRunner.java:14: warning: no comment
    public static final String REMOTE_DOC_LEVEL_MONITOR_ACTION_NAME = "cluster:admin/opensearch/alerting/remote_monitor/fanout";
                               ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/runners/SampleRemoteDocLevelMonitorRunner.java:16: warning: no comment
    public static final String SAMPLE_REMOTE_DOC_LEVEL_MONITOR_RUNNER_INDEX = ".opensearch-alerting-sample-remote-doc-level-monitor";
                               ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/runners/SampleRemoteDocLevelMonitorRunner.java:23: warning: no comment
    public static SampleRemoteDocLevelMonitorRunner getMonitorRunner() {
                                                    ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/inputs/SampleRemoteMonitorInput1.java:15: warning: no comment
public class SampleRemoteMonitorInput1 implements Writeable {
       ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/inputs/SampleRemoteMonitorInput1.java:23: warning: no comment
    public SampleRemoteMonitorInput1(String a, Map<String, Object> b, int c) {
           ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/inputs/SampleRemoteMonitorInput1.java:29: warning: no comment
    public SampleRemoteMonitorInput1(StreamInput sin) throws IOException {
           ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/inputs/SampleRemoteMonitorInput1.java:52: warning: no comment
    public String getA() {
                  ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/inputs/SampleRemoteMonitorInput1.java:48: warning: no comment
    public Map<String, Object> getB() {
                               ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/inputs/SampleRemoteMonitorInput1.java:44: warning: no comment
    public int getC() {
               ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/inputs/SampleRemoteMonitorInput2.java:15: warning: no comment
public class SampleRemoteMonitorInput2 implements Writeable {
       ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/inputs/SampleRemoteMonitorInput2.java:21: warning: no comment
    public SampleRemoteMonitorInput2(String a, DocLevelMonitorInput b) {
           ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/inputs/SampleRemoteMonitorInput2.java:26: warning: no comment
    public SampleRemoteMonitorInput2(StreamInput sin) throws IOException {
           ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/inputs/SampleRemoteMonitorInput2.java:39: warning: no comment
    public String getA() {
                  ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/inputs/SampleRemoteMonitorInput2.java:43: warning: no comment
    public DocLevelMonitorInput getB() {
                                ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/SampleRemoteMonitorPlugin.java:46: warning: no comment
public class SampleRemoteMonitorPlugin extends Plugin implements ActionPlugin, RemoteMonitorRunnerExtension {
       ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/SampleRemoteMonitorPlugin.java:52: warning: no comment
    public static final String SAMPLE_REMOTE_DOC_LEVEL_MONITOR = "remote_doc_level_monitor";
                               ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/SampleRemoteMonitorPlugin.java:48: warning: no comment
    public static final String SAMPLE_REMOTE_MONITOR1 = "sample_remote_monitor1";
                               ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/SampleRemoteMonitorPlugin.java:50: warning: no comment
    public static final String SAMPLE_REMOTE_MONITOR2 = "sample_remote_monitor2";
                               ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/SampleRemoteMonitorRestHandler.java:51: warning: no comment
public class SampleRemoteMonitorRestHandler extends BaseRestHandler {
       ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/runners/SampleRemoteMonitorRunner1.java:32: warning: no comment
public class SampleRemoteMonitorRunner1 extends RemoteMonitorRunner {
       ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/runners/SampleRemoteMonitorRunner1.java:34: warning: no comment
    public static final String SAMPLE_MONITOR_RUNNER1_INDEX = ".opensearch-alerting-sample-remote-monitor1";
                               ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/runners/SampleRemoteMonitorRunner1.java:42: warning: no comment
    public static SampleRemoteMonitorRunner1 getMonitorRunner() {
                                             ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/runners/SampleRemoteMonitorRunner1.java:55: warning: no comment
    public void setClient(Client client) {
                ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/runners/SampleRemoteMonitorRunner2.java:29: warning: no comment
public class SampleRemoteMonitorRunner2 extends RemoteMonitorRunner {
       ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/runners/SampleRemoteMonitorRunner2.java:31: warning: no comment
    public static final String SAMPLE_MONITOR_RUNNER2_INDEX = ".opensearch-alerting-sample-remote-monitor2";
                               ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/runners/SampleRemoteMonitorRunner2.java:39: warning: no comment
    public static SampleRemoteMonitorRunner2 getMonitorRunner() {
                                             ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/runners/SampleRemoteMonitorRunner2.java:52: warning: no comment
    public void setClient(Client client) {
                ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/triggers/SampleRemoteMonitorTrigger1.java:15: warning: no comment
public class SampleRemoteMonitorTrigger1 implements Writeable {
       ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/triggers/SampleRemoteMonitorTrigger1.java:23: warning: no comment
    public SampleRemoteMonitorTrigger1(String a, Map<String, Object> b, int c) {
           ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/triggers/SampleRemoteMonitorTrigger1.java:29: warning: no comment
    public SampleRemoteMonitorTrigger1(StreamInput sin) throws IOException {
           ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/triggers/SampleRemoteMonitorTrigger1.java:52: warning: no comment
    public String getA() {
                  ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/triggers/SampleRemoteMonitorTrigger1.java:48: warning: no comment
    public Map<String, Object> getB() {
                               ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/triggers/SampleRemoteMonitorTrigger1.java:44: warning: no comment
    public int getC() {
               ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/trigger/results/SampleRemoteMonitorTriggerRunResult.java:19: warning: no comment
public class SampleRemoteMonitorTriggerRunResult extends TriggerRunResult {
       ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/trigger/results/SampleRemoteMonitorTriggerRunResult.java:23: warning: no comment
    public SampleRemoteMonitorTriggerRunResult(String triggerName,
           ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/trigger/results/SampleRemoteMonitorTriggerRunResult.java:30: warning: no comment
    public SampleRemoteMonitorTriggerRunResult readFrom(StreamInput sin) throws IOException {
                                               ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/fanouts/TransportRemoteDocLevelMonitorFanOutAction.java:38: warning: no comment
public class TransportRemoteDocLevelMonitorFanOutAction extends HandledTransportAction<DocLevelMonitorFanOutRequest, DocLevelMonitorFanOutResponse> {
       ^
/local/home/deysubho/Documents/programs/github/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/fanouts/TransportRemoteDocLevelMonitorFanOutAction.java:49: warning: no comment
    public TransportRemoteDocLevelMonitorFanOutAction(
           ^
46 warnings

> Task :alerting:compileKotlin
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt:501:13 Unsafe use of a nullable receiver of type TotalHits?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt:502:17 Unsafe use of a nullable receiver of type TotalHits?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt:503:43 Unsafe use of a nullable receiver of type TotalHits?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt:555:17 Unsafe use of a nullable receiver of type TotalHits?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt:561:21 Unsafe use of a nullable receiver of type TotalHits?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt:562:43 Unsafe use of a nullable receiver of type TotalHits?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt:592:111 'detailedMessage(Throwable!): String!' is deprecated. Deprecated in Java
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt:617:17 Unsafe use of a nullable receiver of type TotalHits?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt:674:99 'detailedMessage(Throwable!): String!' is deprecated. Deprecated in Java
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/BucketLevelMonitorRunner.kt:73:9 The corresponding parameter in the supertype 'MonitorRunner' is named 'dryRun'. This may cause problems when calling this function with named arguments.
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt:61:9 The corresponding parameter in the supertype 'MonitorRunner' is named 'dryRun'. This may cause problems when calling this function with named arguments.
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt:108:60 Unchecked cast: MutableMap<String, Any> to MutableMap<String, MutableMap<String, Any>>
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt:380:49 'detailedMessage(Throwable!): String!' is deprecated. Deprecated in Java
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt:512:91 Unchecked cast: Any? to Collection<String>
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt:562:59 Unnecessary non-null assertion (!!) on a non-null receiver of type ClusterService
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt:195:76 Unchecked cast: Map<String, Any> to MutableMap<String, MutableMap<String, Any>>
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt:211:9 Parameter 'createWithRunContext' is never used
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunnerService.kt:339:50 Unnecessary non-null assertion (!!) on a non-null receiver of type LockModel
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/QueryLevelMonitorRunner.kt:34:9 The corresponding parameter in the supertype 'MonitorRunner' is named 'dryRun'. This may cause problems when calling this function with named arguments.
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt:241:42 'getter for isLocalNodeElectedMaster: Boolean' is deprecated. Deprecated in Java
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt:249:42 'getter for isLocalNodeElectedMaster: Boolean' is deprecated. Deprecated in Java
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt:296:60 Unnecessary non-null assertion (!!) on a non-null receiver of type String
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt:298:43 Unnecessary non-null assertion (!!) on a non-null receiver of type String
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/comments/CommentsIndices.kt:152:42 'getter for isLocalNodeElectedMaster: Boolean' is deprecated. Deprecated in Java
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/remote/monitors/RemoteDocumentLevelMonitorRunner.kt:67:60 Unchecked cast: MutableMap<String, Any> to MutableMap<String, MutableMap<String, Any>>
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/remote/monitors/RemoteDocumentLevelMonitorRunner.kt:185:49 'detailedMessage(Throwable!): String!' is deprecated. Deprecated in Java
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/remote/monitors/RemoteDocumentLevelMonitorRunner.kt:253:59 Unnecessary non-null assertion (!!) on a non-null receiver of type ClusterService
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/remote/monitors/RemoteDocumentLevelMonitorRunner.kt:270:68 Unchecked cast: Any? to Map<String, Any>
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/remote/monitors/RemoteDocumentLevelMonitorRunner.kt:355:91 Unchecked cast: Any? to Collection<String>
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteWorkflowAction.kt:49:13 Variable 'refreshPolicy' is never used
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetWorkflowAction.kt:48:13 Variable 'srcContext' is assigned but never accessed
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetWorkflowAction.kt:50:13 The value 'FetchSourceContext.DO_NOT_FETCH_SOURCE' assigned to 'var srcContext: FetchSourceContext? defined in org.opensearch.alerting.resthandler.RestGetWorkflowAction.prepareRequest' is never used
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt:98:69 Unchecked cast: Any? to List<String>?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt:101:17 Variable 'monitorType' is never used
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt:172:13 Condition 'monitor.dataSources != null' is always 'true'
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexWorkflowAction.kt:64:69 Unchecked cast: Any? to List<String>?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/script/ChainedAlertTriggerExecutionContext.kt:30:5 'open' has no effect in a final class
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/service/DeleteMonitorService.kt:124:21 Unsafe use of a nullable receiver of type TotalHits?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/service/DeleteMonitorService.kt:136:25 Variable 'response' is never used
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeChainedAlertAction.kt:173:72 Parameter 'workflow' is never used
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt:177:29 Variable 'deleteMonitorWorkflowMetadataResponse' is never used
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt:343:17 Variable 'deleteResponse' is never used
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt:413:89 Elvis operator (?:) always returns the left operand of non-nullable type List<DocLevelQuery>
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt:991:33 Unchecked cast: Any to MutableMap<String, Any>
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt:652:41 The expression is unused
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:217:38 Unchecked cast: Any to MutableMap<String, Any>
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:224:90 Unchecked cast: Any to MutableMap<String, Any>
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:228:65 Unchecked cast: Any? to MutableMap<String, Any>
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:288:33 Unchecked cast: Any? to MutableMap<String, Any>
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:325:43 Unchecked cast: Any to Map<String, Any>
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:326:43 Unchecked cast: Any to Map<String, Any>
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:331:67 Unchecked cast: Any? to Map<String, Any>
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:332:50 Unchecked cast: Any to Map<String, Any>
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:497:37 Variable 'updateMappingResponse' initializer is redundant
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:516:25 Name shadowed: updateMappingRequest
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:525:25 Name shadowed: unwrappedException
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:538:21 Name shadowed: unwrappedException
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:563:57 Unchecked cast: Any to Map<String, Any>
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:563:95 Unchecked cast: Any? to Map<String, Any>
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:592:29 Unchecked cast: Any? to MutableMap<String, Any>
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:638:17 Variable 'updateSettingsResponse' is never used
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatIndicesHelpers.kt:268:63 'getter for zeroMemory: ByteSizeValue!' is deprecated. Deprecated in Java
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatIndicesHelpers.kt:269:68 'getter for zeroMemory: ByteSizeValue!' is deprecated. Deprecated in Java
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:131:69 Type mismatch: inferred type is KFunction1<DocsStats, Long> but (DocsStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:132:71 Type mismatch: inferred type is KFunction1<StoreStats, ByteSizeValue!> but (StoreStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:135:85 Type mismatch: inferred type is KFunction1<CompletionStats, ByteSizeValue!> but (CompletionStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:136:85 Type mismatch: inferred type is KFunction1<FieldDataStats, ByteSizeValue!> but (FieldDataStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:137:88 Type mismatch: inferred type is KFunction1<FieldDataStats, Long> but (FieldDataStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:138:76 Type mismatch: inferred type is KFunction1<FlushStats, Long> but (FlushStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:139:80 Type mismatch: inferred type is KFunction1<FlushStats, TimeValue!> but (FlushStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:140:74 Type mismatch: inferred type is KFunction1<GetStats, Long> but (GetStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:141:71 Type mismatch: inferred type is KFunction1<GetStats, TimeValue!> but (GetStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:142:72 Type mismatch: inferred type is KFunction1<GetStats, Long> but (GetStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:143:77 Type mismatch: inferred type is KFunction1<GetStats, TimeValue!> but (GetStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:144:78 Type mismatch: inferred type is KFunction1<GetStats, Long> but (GetStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:145:78 Type mismatch: inferred type is KFunction1<GetStats, TimeValue!> but (GetStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:146:79 Type mismatch: inferred type is KFunction1<GetStats, Long> but (GetStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:147:92 Unsafe use of a nullable receiver of type IndexingStats?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:148:89 Unsafe use of a nullable receiver of type IndexingStats?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:149:90 Unsafe use of a nullable receiver of type IndexingStats?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:150:91 Unsafe use of a nullable receiver of type IndexingStats?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:151:88 Unsafe use of a nullable receiver of type IndexingStats?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:152:89 Unsafe use of a nullable receiver of type IndexingStats?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:153:90 Unsafe use of a nullable receiver of type IndexingStats?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:154:79 Type mismatch: inferred type is KFunction1<MergeStats, Long> but (MergeStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:155:83 Type mismatch: inferred type is KFunction1<MergeStats, Long> but (MergeStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:156:83 Type mismatch: inferred type is KFunction1<MergeStats, ByteSizeValue!> but (MergeStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:157:77 Type mismatch: inferred type is KFunction1<MergeStats, Long> but (MergeStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:158:81 Type mismatch: inferred type is KFunction1<MergeStats, Long> but (MergeStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:159:81 Type mismatch: inferred type is KFunction1<MergeStats, ByteSizeValue!> but (MergeStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:160:81 Type mismatch: inferred type is KFunction1<MergeStats, TimeValue!> but (MergeStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:161:87 Type mismatch: inferred type is KFunction1<QueryCacheStats, ByteSizeValue!> but (QueryCacheStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:162:90 Type mismatch: inferred type is KFunction1<QueryCacheStats, Long> but (QueryCacheStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:164:80 Type mismatch: inferred type is KFunction1<RefreshStats, Long> but (RefreshStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:165:79 Type mismatch: inferred type is KFunction1<RefreshStats, TimeValue!> but (RefreshStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:166:87 Unsafe use of a nullable receiver of type SearchStats?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:167:84 Unsafe use of a nullable receiver of type SearchStats?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:168:85 Unsafe use of a nullable receiver of type SearchStats?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:169:85 Type mismatch: inferred type is KFunction1<SearchStats, Long> but (SearchStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:170:87 Unsafe use of a nullable receiver of type SearchStats?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:171:84 Unsafe use of a nullable receiver of type SearchStats?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:172:85 Unsafe use of a nullable receiver of type SearchStats?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:173:88 Unsafe use of a nullable receiver of type SearchStats?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:174:85 Unsafe use of a nullable receiver of type SearchStats?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:175:86 Unsafe use of a nullable receiver of type SearchStats?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:176:82 Type mismatch: inferred type is KFunction1<SegmentsStats, Long> but (SegmentsStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:177:83 Type mismatch: inferred type is KFunction1<SegmentsStats, ByteSizeValue!> but (SegmentsStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:177:98 'getZeroMemory(): ByteSizeValue!' is deprecated. Deprecated in Java
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:179:66 Type mismatch: inferred type is KFunction1<SegmentsStats, ByteSizeValue!> but (SegmentsStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:180:93 Type mismatch: inferred type is KFunction1<SegmentsStats, ByteSizeValue!> but (SegmentsStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:181:86 Type mismatch: inferred type is KFunction1<SegmentsStats, ByteSizeValue!> but (SegmentsStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:182:85 Type mismatch: inferred type is KFunction1<SeqNoStats, Long> but (SeqNoStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:183:84 Type mismatch: inferred type is KFunction1<SeqNoStats, Long> but (SeqNoStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:184:77 Type mismatch: inferred type is KFunction1<SeqNoStats, Long> but (SeqNoStats?) -> Any was expected
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:213:59 Unsafe use of a nullable receiver of type UnassignedInfo?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:215:40 Unsafe use of a nullable receiver of type UnassignedInfo?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:218:76 Unsafe use of a nullable receiver of type UnassignedInfo?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:219:41 Unsafe use of a nullable receiver of type UnassignedInfo?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:225:42 Unsafe use of a nullable receiver of type RecoverySource?
w: file:///local/home/deysubho/Documents/programs/github/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/DestinationMigrationCoordinator.kt:77:45 'getter for isLocalNodeElectedMaster: Boolean' is deprecated. Deprecated in Java

> Task :alerting:compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.5/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 1m 3s
28 actionable tasks: 28 executed
++ find . -path '*build/distributions/*.zip'
+ zipPath='./sample-remote-monitor-plugin/build/distributions/sample-remote-monitor-plugin-3.0.0.0-SNAPSHOT.zip
./alerting/build/distributions/opensearch-alerting-3.0.0.0-SNAPSHOT.zip'
++ dirname './sample-remote-monitor-plugin/build/distributions/sample-remote-monitor-plugin-3.0.0.0-SNAPSHOT.zip
./alerting/build/distributions/opensearch-alerting-3.0.0.0-SNAPSHOT.zip'
+ distributions='./sample-remote-monitor-plugin/build/distributions/sample-remote-monitor-plugin-3.0.0.0-SNAPSHOT.zip
./alerting/build/distributions'
+ echo 'COPY ./sample-remote-monitor-plugin/build/distributions/sample-remote-monitor-plugin-3.0.0.0-SNAPSHOT.zip
./alerting/build/distributions/*.zip'
COPY ./sample-remote-monitor-plugin/build/distributions/sample-remote-monitor-plugin-3.0.0.0-SNAPSHOT.zip
./alerting/build/distributions/*.zip
+ cp ./sample-remote-monitor-plugin/build/distributions/sample-remote-monitor-plugin-3.0.0.0-SNAPSHOT.zip ./alerting/build/distributions/opensearch-alerting-3.0.0.0-SNAPSHOT.zip ./artifacts/plugins
+ ./gradlew publishToMavenLocal -Dopensearch.version=3.0.0-SNAPSHOT -Dbuild.snapshot=true -Dbuild.version_qualifier=
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.5
  OS Info               : Linux 5.10.220-187.867.amzn2int.x86_64 (amd64)
  JDK Version           : 17 (Azul Zulu JDK)
  JAVA_HOME             : /usr/lib/jvm/zulu-17
  Random Testing Seed   : 89CE897B25F6CEBD
  In FIPS 140 mode      : false
=======================================

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.5/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 8s
34 actionable tasks: 14 executed, 20 up-to-date
+ ./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=3.0.0-SNAPSHOT -Dbuild.snapshot=true -Dbuild.version_qualifier=
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.5
  OS Info               : Linux 5.10.220-187.867.amzn2int.x86_64 (amd64)
  JDK Version           : 17 (Azul Zulu JDK)
  JAVA_HOME             : /usr/lib/jvm/zulu-17
  Random Testing Seed   : D0EC20FB16066635
  In FIPS 140 mode      : false
=======================================

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.5/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 8s
16 actionable tasks: 3 executed, 13 up-to-date
+ mkdir -p artifacts/maven/org/opensearch
+ cp -r ./build/local-staging-repo/org/opensearch/. artifacts/maven/org/opensearch
```

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).