### PR TITLE
Fixing build script to only publish alerting zip

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -64,15 +64,12 @@ fi
 [[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
-mkdir -p $OUTPUT/plugins
 
 ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.version_qualifier=$QUALIFIER -Dbuild.snapshot=$SNAPSHOT
 
-zipPath=$(find . -path \*build/distributions/*.zip)
-distributions="$(dirname "${zipPath}")"
-
-echo "COPY ${distributions}/*.zip"
-cp ${distributions}/*.zip ./$OUTPUT/plugins
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+mkdir -p $OUTPUT/plugins
+cp ./alerting/build/distributions/*.zip $OUTPUT/plugins
 
 ./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 ./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER


### PR DESCRIPTION
*Issue #, if available:*
#1599

*Description of changes:*
PR #1604 fixes the issue of publishing the zip to maven, but it had a side-effect of also publishing the remote monitor plugin zip to the artifacts folder. This PR fixes this issue, attaching the output of the build.

```
➜  alerting git:(2.15) ✗ ./scripts/build.sh -v 2.15.0 -s true
+ getopts :h:v:q:s:o:p:a: arg
+ case $arg in
+ VERSION=2.15.0
+ getopts :h:v:q:s:o:p:a: arg
+ case $arg in
+ SNAPSHOT=true
+ getopts :h:v:q:s:o:p:a: arg
+ '[' -z 2.15.0 ']'
+ [[ ! -z '' ]]
+ [[ true == \t\r\u\e ]]
+ VERSION=2.15.0-SNAPSHOT
+ '[' -z '' ']'
+ OUTPUT=artifacts
+ ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=2.15.0-SNAPSHOT -Dbuild.version_qualifier= -Dbuild.snapshot=true
To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/8.5/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.
Daemon will be stopped at the end of the build
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.5
  OS Info               : Mac OS X 14.3.1 (aarch64)
  JDK Version           : 11 (Amazon Corretto JDK)
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/amazon-corretto-11.jdk/Contents/Home
  Random Testing Seed   : A2C283035A6579AA
  In FIPS 140 mode      : false
=======================================

> Task :alerting-core:compileKotlin
w: file:///Volumes/workplace/SecurityAnalytics/alerting/core/src/main/kotlin/org/opensearch/alerting/core/action/node/ScheduledJobsStatsTransportAction.kt:11:44 'BaseNodeRequest' is deprecated. Deprecated in Java
w: file:///Volumes/workplace/SecurityAnalytics/alerting/core/src/main/kotlin/org/opensearch/alerting/core/action/node/ScheduledJobsStatsTransportAction.kt:119:39 'BaseNodeRequest' is deprecated. Deprecated in Java
w: file:///Volumes/workplace/SecurityAnalytics/alerting/core/src/main/kotlin/org/opensearch/alerting/core/lock/LockModel.kt:96:9 '@JvmOverloads' annotation has no effect for methods without default arguments
w: file:///Volumes/workplace/SecurityAnalytics/alerting/core/src/main/kotlin/org/opensearch/alerting/opensearchapi/OpenSearchExtensions.kt:41:41 'toXContent(ToXContent!, XContentType!, Boolean): BytesReference!' is deprecated. Deprecated in Java
w: file:///Volumes/workplace/SecurityAnalytics/alerting/core/src/main/kotlin/org/opensearch/alerting/opensearchapi/OpenSearchExtensions.kt:42:27 'convertToMap(BytesReference!, Boolean, XContentType!): Tuple<XContentType!, (Mutable)Map<String!, Any!>!>!' is deprecated. Deprecated in Java

> Task :alerting-sample-remote-monitor-plugin:compileJava
Note: /Volumes/workplace/SecurityAnalytics/alerting/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/monitor/fanouts/TransportRemoteDocLevelMonitorFanOutAction.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :alerting:compileKotlin
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt:503:13 Unsafe use of a nullable receiver of type TotalHits?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt:504:17 Unsafe use of a nullable receiver of type TotalHits?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt:505:43 Unsafe use of a nullable receiver of type TotalHits?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt:557:17 Unsafe use of a nullable receiver of type TotalHits?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt:563:21 Unsafe use of a nullable receiver of type TotalHits?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt:564:43 Unsafe use of a nullable receiver of type TotalHits?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt:594:111 'detailedMessage(Throwable!): String!' is deprecated. Deprecated in Java
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt:619:17 Unsafe use of a nullable receiver of type TotalHits?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt:676:99 'detailedMessage(Throwable!): String!' is deprecated. Deprecated in Java
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/BucketLevelMonitorRunner.kt:73:9 The corresponding parameter in the supertype 'MonitorRunner' is named 'dryRun'. This may cause problems when calling this function with named arguments.
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt:61:9 The corresponding parameter in the supertype 'MonitorRunner' is named 'dryRun'. This may cause problems when calling this function with named arguments.
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt:108:60 Unchecked cast: MutableMap<String, Any> to MutableMap<String, MutableMap<String, Any>>
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt:380:49 'detailedMessage(Throwable!): String!' is deprecated. Deprecated in Java
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt:512:91 Unchecked cast: Any? to Collection<String>
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt:562:59 Unnecessary non-null assertion (!!) on a non-null receiver of type ClusterService
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt:197:76 Unchecked cast: Map<String, Any> to MutableMap<String, MutableMap<String, Any>>
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt:213:9 Parameter 'createWithRunContext' is never used
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunnerService.kt:339:50 Unnecessary non-null assertion (!!) on a non-null receiver of type LockModel
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/QueryLevelMonitorRunner.kt:33:9 The corresponding parameter in the supertype 'MonitorRunner' is named 'dryRun'. This may cause problems when calling this function with named arguments.
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt:241:42 'getter for isLocalNodeElectedMaster: Boolean' is deprecated. Deprecated in Java
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt:249:42 'getter for isLocalNodeElectedMaster: Boolean' is deprecated. Deprecated in Java
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt:296:60 Unnecessary non-null assertion (!!) on a non-null receiver of type String
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt:298:43 Unnecessary non-null assertion (!!) on a non-null receiver of type String
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/comments/CommentsIndices.kt:152:42 'getter for isLocalNodeElectedMaster: Boolean' is deprecated. Deprecated in Java
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/remote/monitors/RemoteDocumentLevelMonitorRunner.kt:67:60 Unchecked cast: MutableMap<String, Any> to MutableMap<String, MutableMap<String, Any>>
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/remote/monitors/RemoteDocumentLevelMonitorRunner.kt:185:49 'detailedMessage(Throwable!): String!' is deprecated. Deprecated in Java
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/remote/monitors/RemoteDocumentLevelMonitorRunner.kt:253:59 Unnecessary non-null assertion (!!) on a non-null receiver of type ClusterService
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/remote/monitors/RemoteDocumentLevelMonitorRunner.kt:270:68 Unchecked cast: Any? to Map<String, Any>
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/remote/monitors/RemoteDocumentLevelMonitorRunner.kt:355:91 Unchecked cast: Any? to Collection<String>
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestDeleteWorkflowAction.kt:49:13 Variable 'refreshPolicy' is never used
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetWorkflowAction.kt:48:13 Variable 'srcContext' is assigned but never accessed
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetWorkflowAction.kt:50:13 The value 'FetchSourceContext.DO_NOT_FETCH_SOURCE' assigned to 'var srcContext: FetchSourceContext? defined in org.opensearch.alerting.resthandler.RestGetWorkflowAction.prepareRequest' is never used
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt:98:69 Unchecked cast: Any? to List<String>?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt:103:17 Variable 'monitorType' is never used
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt:174:13 Condition 'monitor.dataSources != null' is always 'true'
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexWorkflowAction.kt:64:69 Unchecked cast: Any? to List<String>?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/script/ChainedAlertTriggerExecutionContext.kt:30:5 'open' has no effect in a final class
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/service/DeleteMonitorService.kt:123:21 Unsafe use of a nullable receiver of type TotalHits?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/service/DeleteMonitorService.kt:135:25 Variable 'response' is never used
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeChainedAlertAction.kt:172:72 Parameter 'workflow' is never used
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt:177:29 Variable 'deleteMonitorWorkflowMetadataResponse' is never used
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt:343:17 Variable 'deleteResponse' is never used
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt:412:89 Elvis operator (?:) always returns the left operand of non-nullable type List<DocLevelQuery>
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt:990:33 Unchecked cast: Any to MutableMap<String, Any>
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt:650:41 The expression is unused
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:217:38 Unchecked cast: Any to MutableMap<String, Any>
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:224:90 Unchecked cast: Any to MutableMap<String, Any>
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:228:65 Unchecked cast: Any? to MutableMap<String, Any>
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:288:33 Unchecked cast: Any? to MutableMap<String, Any>
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:325:43 Unchecked cast: Any to Map<String, Any>
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:326:43 Unchecked cast: Any to Map<String, Any>
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:331:67 Unchecked cast: Any? to Map<String, Any>
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:332:50 Unchecked cast: Any to Map<String, Any>
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:498:37 Variable 'updateMappingResponse' initializer is redundant
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:517:25 Name shadowed: updateMappingRequest
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:526:25 Name shadowed: unwrappedException
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:539:21 Name shadowed: unwrappedException
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:564:57 Unchecked cast: Any to Map<String, Any>
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:564:95 Unchecked cast: Any? to Map<String, Any>
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:593:29 Unchecked cast: Any? to MutableMap<String, Any>
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt:639:17 Variable 'updateSettingsResponse' is never used
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatIndicesHelpers.kt:268:63 'getter for zeroMemory: ByteSizeValue!' is deprecated. Deprecated in Java
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatIndicesHelpers.kt:269:68 'getter for zeroMemory: ByteSizeValue!' is deprecated. Deprecated in Java
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:131:69 Type mismatch: inferred type is KFunction1<DocsStats, Long> but (DocsStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:132:71 Type mismatch: inferred type is KFunction1<StoreStats, ByteSizeValue!> but (StoreStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:135:85 Type mismatch: inferred type is KFunction1<CompletionStats, ByteSizeValue!> but (CompletionStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:136:85 Type mismatch: inferred type is KFunction1<FieldDataStats, ByteSizeValue!> but (FieldDataStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:137:88 Type mismatch: inferred type is KFunction1<FieldDataStats, Long> but (FieldDataStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:138:76 Type mismatch: inferred type is KFunction1<FlushStats, Long> but (FlushStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:139:80 Type mismatch: inferred type is KFunction1<FlushStats, TimeValue!> but (FlushStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:140:74 Type mismatch: inferred type is KFunction1<GetStats, Long> but (GetStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:141:71 Type mismatch: inferred type is KFunction1<GetStats, TimeValue!> but (GetStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:142:72 Type mismatch: inferred type is KFunction1<GetStats, Long> but (GetStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:143:77 Type mismatch: inferred type is KFunction1<GetStats, TimeValue!> but (GetStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:144:78 Type mismatch: inferred type is KFunction1<GetStats, Long> but (GetStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:145:78 Type mismatch: inferred type is KFunction1<GetStats, TimeValue!> but (GetStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:146:79 Type mismatch: inferred type is KFunction1<GetStats, Long> but (GetStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:147:92 Unsafe use of a nullable receiver of type IndexingStats?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:148:89 Unsafe use of a nullable receiver of type IndexingStats?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:149:90 Unsafe use of a nullable receiver of type IndexingStats?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:150:91 Unsafe use of a nullable receiver of type IndexingStats?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:151:88 Unsafe use of a nullable receiver of type IndexingStats?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:152:89 Unsafe use of a nullable receiver of type IndexingStats?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:153:90 Unsafe use of a nullable receiver of type IndexingStats?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:154:79 Type mismatch: inferred type is KFunction1<MergeStats, Long> but (MergeStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:155:83 Type mismatch: inferred type is KFunction1<MergeStats, Long> but (MergeStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:156:83 Type mismatch: inferred type is KFunction1<MergeStats, ByteSizeValue!> but (MergeStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:157:77 Type mismatch: inferred type is KFunction1<MergeStats, Long> but (MergeStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:158:81 Type mismatch: inferred type is KFunction1<MergeStats, Long> but (MergeStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:159:81 Type mismatch: inferred type is KFunction1<MergeStats, ByteSizeValue!> but (MergeStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:160:81 Type mismatch: inferred type is KFunction1<MergeStats, TimeValue!> but (MergeStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:161:87 Type mismatch: inferred type is KFunction1<QueryCacheStats, ByteSizeValue!> but (QueryCacheStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:162:90 Type mismatch: inferred type is KFunction1<QueryCacheStats, Long> but (QueryCacheStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:164:80 Type mismatch: inferred type is KFunction1<RefreshStats, Long> but (RefreshStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:165:79 Type mismatch: inferred type is KFunction1<RefreshStats, TimeValue!> but (RefreshStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:166:87 Unsafe use of a nullable receiver of type SearchStats?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:167:84 Unsafe use of a nullable receiver of type SearchStats?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:168:85 Unsafe use of a nullable receiver of type SearchStats?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:169:85 Type mismatch: inferred type is KFunction1<SearchStats, Long> but (SearchStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:170:87 Unsafe use of a nullable receiver of type SearchStats?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:171:84 Unsafe use of a nullable receiver of type SearchStats?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:172:85 Unsafe use of a nullable receiver of type SearchStats?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:173:88 Unsafe use of a nullable receiver of type SearchStats?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:174:85 Unsafe use of a nullable receiver of type SearchStats?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:175:86 Unsafe use of a nullable receiver of type SearchStats?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:176:82 Type mismatch: inferred type is KFunction1<SegmentsStats, Long> but (SegmentsStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:177:83 Type mismatch: inferred type is KFunction1<SegmentsStats, ByteSizeValue!> but (SegmentsStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:177:98 'getZeroMemory(): ByteSizeValue!' is deprecated. Deprecated in Java
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:179:66 Type mismatch: inferred type is KFunction1<SegmentsStats, ByteSizeValue!> but (SegmentsStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:180:93 Type mismatch: inferred type is KFunction1<SegmentsStats, ByteSizeValue!> but (SegmentsStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:181:86 Type mismatch: inferred type is KFunction1<SegmentsStats, ByteSizeValue!> but (SegmentsStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:182:85 Type mismatch: inferred type is KFunction1<SeqNoStats, Long> but (SeqNoStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:183:84 Type mismatch: inferred type is KFunction1<SeqNoStats, Long> but (SeqNoStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:184:77 Type mismatch: inferred type is KFunction1<SeqNoStats, Long> but (SeqNoStats?) -> Any was expected
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:213:59 Unsafe use of a nullable receiver of type UnassignedInfo?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:215:40 Unsafe use of a nullable receiver of type UnassignedInfo?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:218:76 Unsafe use of a nullable receiver of type UnassignedInfo?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:219:41 Unsafe use of a nullable receiver of type UnassignedInfo?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/clusterMetricsMonitorHelpers/CatShardsHelpers.kt:225:42 Unsafe use of a nullable receiver of type RecoverySource?
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/DestinationMigrationCoordinator.kt:77:45 'getter for isLocalNodeElectedMaster: Boolean' is deprecated. Deprecated in Java
w: file:///Volumes/workplace/SecurityAnalytics/alerting/alerting/src/main/kotlin/org/opensearch/alerting/workflow/CompositeWorkflowRunner.kt:242:43 Unnecessary non-null assertion (!!) on a non-null receiver of type DataSources

> Task :alerting:compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.5/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 1m 2s
28 actionable tasks: 28 executed
+ '[' -z artifacts ']'
+ mkdir -p artifacts/plugins
+ cp ./alerting/build/distributions/opensearch-alerting-2.15.0.0-SNAPSHOT.zip artifacts/plugins
+ ./gradlew publishToMavenLocal -Dopensearch.version=2.15.0-SNAPSHOT -Dbuild.snapshot=true -Dbuild.version_qualifier=
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.5
  OS Info               : Mac OS X 14.3.1 (aarch64)
  JDK Version           : 11 (Amazon Corretto JDK)
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/amazon-corretto-11.jdk/Contents/Home
  Random Testing Seed   : CB7A3355F1445F10
  In FIPS 140 mode      : false
=======================================

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.5/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 5s
34 actionable tasks: 14 executed, 20 up-to-date
+ ./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=2.15.0-SNAPSHOT -Dbuild.snapshot=true -Dbuild.version_qualifier=
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.5
  OS Info               : Mac OS X 14.3.1 (aarch64)
  JDK Version           : 11 (Amazon Corretto JDK)
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/amazon-corretto-11.jdk/Contents/Home
  Random Testing Seed   : E8C372EB984ECA3E
  In FIPS 140 mode      : false
=======================================

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.5/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 4s
16 actionable tasks: 3 executed, 13 up-to-date
+ mkdir -p artifacts/maven/org/opensearch
+ cp -r ./build/local-staging-repo/org/opensearch/. artifacts/maven/org/opensearch
➜  alerting git:(2.15) ✗ cd artifacts/plugins
➜  plugins git:(2.15) ✗ ls
opensearch-alerting-2.15.0.0-SNAPSHOT.zip

```

*CheckList:*
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).