### PR TITLE
fix monitor renew lock issue

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunnerService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunnerService.kt
@@ -331,12 +331,12 @@ object MonitorRunnerService : JobRunner, CoroutineScope, AbstractLifecycleCompon
         when (job) {
             is Workflow -> {
                 launch {
-                    var lock: LockModel? = null
+                    var workflowLock: LockModel? = null
                     try {
-                        lock = monitorCtx.client!!.suspendUntil<Client, LockModel?> {
+                        workflowLock = monitorCtx.client!!.suspendUntil<Client, LockModel?> {
                             monitorCtx.lockService!!.acquireLock(job, it)
                         } ?: return@launch
-                        logger.debug("lock ${lock!!.lockId} acquired")
+                        logger.debug("lock ${workflowLock.lockId} acquired")
 
                         monitorCtx.client!!.suspendUntil<Client, ExecuteWorkflowResponse> {
                             monitorCtx.client!!.execute(
@@ -352,19 +352,19 @@ object MonitorRunnerService : JobRunner, CoroutineScope, AbstractLifecycleCompon
                             )
                         }
                     } finally {
-                        monitorCtx.client!!.suspendUntil<Client, Boolean> { monitorCtx.lockService!!.release(lock, it) }
-                        logger.debug("lock ${lock?.lockId} released")
+                        monitorCtx.client!!.suspendUntil<Client, Boolean> { monitorCtx.lockService!!.release(workflowLock, it) }
+                        logger.debug("lock ${workflowLock?.lockId} released")
                     }
                 }
             }
             is Monitor -> {
                 launch {
-                    var lock: LockModel? = null
+                    var monitorLock: LockModel? = null
                     try {
-                        lock = monitorCtx.client!!.suspendUntil<Client, LockModel?> {
+                        monitorLock = monitorCtx.client!!.suspendUntil<Client, LockModel?> {
                             monitorCtx.lockService!!.acquireLock(job, it)
                         } ?: return@launch
-                        logger.debug("lock ${lock!!.lockId} acquired")
+                        logger.debug("lock ${monitorLock.lockId} acquired")
                         logger.debug(
                             "PERF_DEBUG: executing ${job.monitorType} ${job.id} on node " +
                                 monitorCtx.clusterService!!.state().nodes().localNode.id
@@ -384,8 +384,8 @@ object MonitorRunnerService : JobRunner, CoroutineScope, AbstractLifecycleCompon
                             )
                         }
                     } finally {
-                        monitorCtx.client!!.suspendUntil<Client, Boolean> { monitorCtx.lockService!!.release(lock, it) }
-                        logger.debug("lock ${lock?.lockId} released")
+                        monitorCtx.client!!.suspendUntil<Client, Boolean> { monitorCtx.lockService!!.release(monitorLock, it) }
+                        logger.debug("lock ${monitorLock?.lockId} released")
                     }
                 }
             }


### PR DESCRIPTION
*Issue #, if available:*

If a particular monitor run fails to release the lock, the lock can never be renewed and every monitor run is skipped.
*Description of changes:*

If a particular monitor run fails to release the lock, the lock can be renewed and acquired after a fixed timeout of `5 mins.`.

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).