### PR TITLE
Revert "Revert "[Backport 2.15] [Backport] Enable cross-cluster monitor cluster setting #1612""

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
@@ -211,7 +211,7 @@ class AlertingSettings {
 
         val CROSS_CLUSTER_MONITORING_ENABLED = Setting.boolSetting(
             "plugins.alerting.cross_cluster_monitoring_enabled",
-            false,
+            true,
             Setting.Property.NodeScope, Setting.Property.Dynamic
         )
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/GetRemoteIndexesActionIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/GetRemoteIndexesActionIT.kt
@@ -26,7 +26,7 @@ import java.util.*
 
 @Suppress("UNCHECKED_CAST")
 class GetRemoteIndexesActionIT : AlertingRestTestCase() {
-    private var remoteMonitoringEnabled = false
+    private var remoteMonitoringEnabled = true
     private var remoteClusters = listOf<String>()
 
     private val mappingFieldToTypePairs1 = listOf(


### PR DESCRIPTION
Reverts opensearch-project/alerting#1624

Reverting we will revert this change separately.