### PR TITLE
Disabled non-security tests from executing during security-enabled CI workflows.

### DIFF
--- a/sample-remote-monitor-plugin/build.gradle
+++ b/sample-remote-monitor-plugin/build.gradle
@@ -69,6 +69,12 @@ task integTest(type: RestIntegTestTask) {
     description = "Run tests against a cluster"
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
+
+    if (System.getProperty("https") != null || System.getProperty("https") != "false") {
+        filter {
+            excludeTestsMatching "org.opensearch.alerting.SampleRemoteMonitorIT"
+        }
+    }
 }
 tasks.named("check").configure { dependsOn(integTest) }
 

--- a/sample-remote-monitor-plugin/build.gradle
+++ b/sample-remote-monitor-plugin/build.gradle
@@ -70,7 +70,11 @@ task integTest(type: RestIntegTestTask) {
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
 
-    if (System.getProperty("https") != null || System.getProperty("https") != "false") {
+    if (System.getProperty("https") == null || System.getProperty("https") == "false") {
+        filter {
+            includeTestsMatching '**/*IT.class'
+        }
+    } else {
         filter {
             excludeTestsMatching "org.opensearch.alerting.SampleRemoteMonitorIT"
         }

--- a/sample-remote-monitor-plugin/build.gradle
+++ b/sample-remote-monitor-plugin/build.gradle
@@ -72,11 +72,7 @@ task integTest(type: RestIntegTestTask) {
 
     if (System.getProperty("https") == null || System.getProperty("https") == "false") {
         filter {
-            includeTestsMatching '**/*IT.class'
-        }
-    } else {
-        filter {
-            excludeTestsMatching "org.opensearch.alerting.SampleRemoteMonitorIT"
+            includeTestsMatching "org.opensearch.alerting.SampleRemoteMonitorIT"
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opensearch-project/alerting/issues/1617

*Description of changes:*
Disabled non-security tests from executing during security-enabled CI workflows.

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).