### PR TITLE
create query index at the time of monitor creation

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -537,8 +537,7 @@ class TransportIndexMonitorAction @Inject constructor(
                     if (
                         request.monitor.isMonitorOfStandardType() &&
                         Monitor.MonitorType.valueOf(request.monitor.monitorType.uppercase(Locale.ROOT)) ==
-                        Monitor.MonitorType.DOC_LEVEL_MONITOR &&
-                        request.monitor.deleteQueryIndexInEveryRun == false
+                        Monitor.MonitorType.DOC_LEVEL_MONITOR
                     ) {
                         indexDocLevelMonitorQueries(request.monitor, indexResponse.id, metadata, request.refreshPolicy)
                     }
@@ -711,14 +710,12 @@ class TransportIndexMonitorAction @Inject constructor(
                                 .execute(it)
                         }
                     }
-                    if (currentMonitor.deleteQueryIndexInEveryRun == false) {
-                        indexDocLevelMonitorQueries(
-                            request.monitor,
-                            currentMonitor.id,
-                            updatedMetadata,
-                            request.refreshPolicy
-                        )
-                    }
+                    indexDocLevelMonitorQueries(
+                        request.monitor,
+                        currentMonitor.id,
+                        updatedMetadata,
+                        request.refreshPolicy
+                    )
                     MonitorMetadataService.upsertMetadata(updatedMetadata, updating = true)
                 }
                 actionListener.onResponse(


### PR DESCRIPTION
### Description
create query index at the time of monitor creation
continuing #1673 

### Related Issues

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
