### PR TITLE
Update source and target compatibility for java 21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,6 @@ allprojects {
         targetCompatibility = JavaVersion.VERSION_21
     }
     plugins.withId('org.jetbrains.kotlin.jvm') {
-        compileKotlin.kotlinOptions.jvmTarget = compileTestKotlin.kotlinOptions.jvmTarget = JavaVersion.VERSION_21
         compileJava.sourceCompatibility = JavaVersion.VERSION_21
         compileJava.targetCompatibility = JavaVersion.VERSION_21
         compileTestJava.sourceCompatibility = JavaVersion.VERSION_21

--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,12 @@ allprojects {
     }
     plugins.withId('org.jetbrains.kotlin.jvm') {
         compileKotlin.kotlinOptions.jvmTarget = compileTestKotlin.kotlinOptions.jvmTarget = JavaVersion.VERSION_21
+        compileJava.sourceCompatibility = JavaVersion.VERSION_21
+        compileJava.targetCompatibility = JavaVersion.VERSION_21
+        compileTestJava.sourceCompatibility = JavaVersion.VERSION_21
+        compileTestJava.targetCompatibility = JavaVersion.VERSION_21
+        compileKotlin.kotlinOptions.jvmTarget = "21"
+        compileTestKotlin.kotlinOptions.jvmTarget = "21"
         compileKotlin.dependsOn ktlint
     }
     tasks.withType(AbstractArchiveTask).configureEach {


### PR DESCRIPTION
### Description
Update source and target compability to fix CI similar to what was done in [notifications](https://github.com/opensearch-project/notifications/commit/a5462515e61f3bf3fa6ce337879e20174e4004da#diff-232324819823e60412e89cc1e10e80565edd179e022040c597282b32a6951c47L65:~:text=compileJava.sourceCompatibility%20%3D%20JavaVersion.VERSION_21,compileTestKotlin.kotlinOptions.jvmTarget%20%3D%20%2221%22)

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
