### PR TITLE
fix compilation error in 1.3

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/aggregation/bucketselectorext/BucketSelectorExtAggregator.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/aggregation/bucketselectorext/BucketSelectorExtAggregator.kt
@@ -143,7 +143,7 @@ class BucketSelectorExtAggregator : SiblingPipelineAggregator {
     private fun isAccepted(obj: Any, filter: IncludeExclude?): Boolean {
         return when (obj.javaClass) {
             String::class.java -> {
-                val stringFilter = filter!!.convertToStringFilter(DocValueFormat.RAW)
+                val stringFilter = filter!!.convertToStringFilter(DocValueFormat.RAW, null)
                 stringFilter.accept(BytesRef(obj as String))
             }
             java.lang.Long::class.java, Long::class.java -> {


### PR DESCRIPTION
### Description
This is to fix the compile issue caused by commit in opensearch core https://github.com/opensearch-project/OpenSearch/commit/242827837e7f22e13c2577fc5a15e0932bb66565#diff-82a53ae6a34c3d0e45623b804d761e1fa077c2cea74c1110d92bc808b7d8c5d2

As per the commit convertToStringFilter filter now accepts two params -> https://github.com/opensearch-project/OpenSearch/blame/1.3/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/IncludeExclude.java#L625

### Related Issues
https://github.com/opensearch-project/alerting/issues/1697
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
