### PR TITLE
Limit verbose log line on scheduled migration cancellation

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/DestinationMigrationCoordinator.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/DestinationMigrationCoordinator.kt
@@ -62,8 +62,10 @@ class DestinationMigrationCoordinator(
                 runningLock = false
             }
         } else if (!event.localNodeClusterManager()) {
-            logger.info("Cancelling the migration process.")
-            scheduledMigration?.cancel()
+            if (scheduledMigration != null && !scheduledMigration!!.isCancelled) {
+                logger.info("Cancelling the migration process.")
+                scheduledMigration?.cancel()
+            }
         }
     }
 


### PR DESCRIPTION
### Description

Small change to only limit the `Cancelling the migration process.` log line if a scheduled migration exists.

This log line can be seen whenever an index is created regardless if scheduledMigration is null or non-null.

I ran into this log line when doing performance testing with the security plugin in scenarios where clusters contain a lot of indices and wrote a script to quickly create indices. This log line is pervasive when index creation is occurring.

### Related Issues

Related to: https://github.com/opensearch-project/alerting/issues/1183

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
