### PR TITLE
Delete workflow metadata on deleting a detector

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt
@@ -137,11 +137,12 @@ class TransportDeleteWorkflowAction @Inject constructor(
                 if (canDelete) {
                     val delegateMonitorIds = (workflow.inputs[0] as CompositeInput).getMonitorIds()
                     var deletableMonitors = listOf<Monitor>()
+                    val delegateMonitors = getDeletableDelegates(workflowId, delegateMonitorIds, user)
                     // User can only delete the delegate monitors only in the case if all monitors can be deleted
                     // if there are monitors in this workflow that are referenced in other workflows, we cannot delete the monitors.
                     // We will not partially delete monitors. we delete them all or fail the request.
                     if (deleteDelegateMonitors == true) {
-                        deletableMonitors = getDeletableDelegates(workflowId, delegateMonitorIds, user)
+                        deletableMonitors = delegateMonitors
                         val monitorsDiff = delegateMonitorIds.toMutableList()
                         monitorsDiff.removeAll(deletableMonitors.map { it.id })
 
@@ -168,10 +169,11 @@ class TransportDeleteWorkflowAction @Inject constructor(
                         val failedMonitorIds = tryDeletingMonitors(deletableMonitors, RefreshPolicy.IMMEDIATE)
                         // Update delete workflow response
                         deleteWorkflowResponse.nonDeletedMonitors = failedMonitorIds
-                        // Delete monitors workflow metadata
-                        // Monitor metadata will be in workflowId-monitorId-metadata format
-                        metadataIdsToDelete.addAll(deletableMonitors.map { MonitorMetadata.getId(it, workflowMetadataId) })
                     }
+
+                    // Delete monitors workflow metadata
+                    // Monitor metadata will be in workflowId-monitorId-metadata format
+                    metadataIdsToDelete.addAll(delegateMonitors.map { MonitorMetadata.getId(it, workflowMetadataId) })
                     try {
                         // Delete the monitors workflow metadata
                         val deleteMonitorWorkflowMetadataResponse: BulkByScrollResponse = client.suspendUntil {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt
@@ -172,7 +172,7 @@ class TransportDeleteWorkflowAction @Inject constructor(
                     }
 
                     // Delete monitors workflow metadata
-                    // Monitor metadata will be in workflowId-monitorId-metadata format
+                    // Monitor metadata will be in workflowId-metadata-monitorId-metadata format
                     metadataIdsToDelete.addAll(delegateMonitors.map { MonitorMetadata.getId(it, workflowMetadataId) })
                     try {
                         // Delete the monitors workflow metadata

--- a/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
@@ -5053,6 +5053,9 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
         assertNotNull(getWorkflowResponse)
         assertEquals(workflowId, getWorkflowResponse.id)
 
+        // Verify that monitor workflow metadata exists
+        assertNotNull(searchMonitorMetadata("${workflowResponse.id}-metadata-${monitorResponse.id}-metadata"))
+
         deleteWorkflow(workflowId, false)
         // Verify that the workflow is deleted
         try {
@@ -5068,6 +5071,19 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
         // Verify that the monitor is not deleted
         val existingDelegate = getMonitorResponse(monitorResponse.id)
         assertNotNull(existingDelegate)
+
+        // Verify that the monitor workflow metadata is deleted
+        try {
+            searchMonitorMetadata("${workflowResponse.id}-metadata-${monitorResponse.id}-metadata")
+            fail("expected searchMonitorMetadata method to throw exception")
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning GetMonitor Action error ",
+                    it.contains("List is empty")
+                )
+            }
+        }
     }
 
     fun `test delete workflow delegate monitor deleted`() {
@@ -5093,6 +5109,9 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
         assertNotNull(getWorkflowResponse)
         assertEquals(workflowId, getWorkflowResponse.id)
 
+        // Verify that monitor workflow metadata exists
+        assertNotNull(searchMonitorMetadata("${workflowResponse.id}-metadata-${monitorResponse.id}-metadata"))
+
         deleteWorkflow(workflowId, true)
         // Verify that the workflow is deleted
         try {
@@ -5113,6 +5132,18 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
                 assertTrue(
                     "Exception not returning GetMonitor Action error ",
                     it.contains("Monitor not found")
+                )
+            }
+        }
+        // Verify that the monitor workflow metadata is deleted
+        try {
+            searchMonitorMetadata("${workflowResponse.id}-metadata-${monitorResponse.id}-metadata")
+            fail("expected searchMonitorMetadata method to throw exception")
+        } catch (e: Exception) {
+            e.message?.let {
+                assertTrue(
+                    "Exception not returning GetMonitor Action error ",
+                    it.contains("List is empty")
                 )
             }
         }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
@@ -5119,7 +5119,7 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
         } catch (e: Exception) {
             e.message?.let {
                 assertTrue(
-                    "Expected 0 hits for searchMonitorMetadata, got non-0 results.",
+                    "Exception not returning GetWorkflow Action error ",
                     it.contains("Workflow not found.")
                 )
             }
@@ -5142,7 +5142,7 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
         } catch (e: Exception) {
             e.message?.let {
                 assertTrue(
-                    "Exception not returning searchMonitorMetadata error ",
+                    "Expected 0 hits for searchMonitorMetadata, got non-0 results.",
                     it.contains("List is empty")
                 )
             }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/MonitorDataSourcesIT.kt
@@ -5079,7 +5079,7 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
         } catch (e: Exception) {
             e.message?.let {
                 assertTrue(
-                    "Exception not returning GetMonitor Action error ",
+                    "Expected 0 hits for searchMonitorMetadata, got non-0 results.",
                     it.contains("List is empty")
                 )
             }
@@ -5119,7 +5119,7 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
         } catch (e: Exception) {
             e.message?.let {
                 assertTrue(
-                    "Exception not returning GetWorkflow Action error ",
+                    "Expected 0 hits for searchMonitorMetadata, got non-0 results.",
                     it.contains("Workflow not found.")
                 )
             }
@@ -5142,7 +5142,7 @@ class MonitorDataSourcesIT : AlertingSingleNodeTestCase() {
         } catch (e: Exception) {
             e.message?.let {
                 assertTrue(
-                    "Exception not returning GetMonitor Action error ",
+                    "Exception not returning searchMonitorMetadata error ",
                     it.contains("List is empty")
                 )
             }


### PR DESCRIPTION
### Description
Metadata is not fully cleaned up in the alerting config index when a detector is deleted

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
