### PR TITLE
Force create last run context in monitor workflow metadata when workflow is re-enabled

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -692,8 +692,21 @@ class TransportIndexMonitorAction @Inject constructor(
                     )
                     return
                 }
+                var isDocLevelMonitorRestarted = false
+                // Force re-creation of last run context if monitor is of type standard doc-level/threat-intel
+                // And monitor is re-enabled
+                if (request.monitor.enabled && !currentMonitor.enabled &&
+                    request.monitor.monitorType.endsWith(Monitor.MonitorType.DOC_LEVEL_MONITOR.value)
+                ) {
+                    isDocLevelMonitorRestarted = true
+                }
+
                 var updatedMetadata: MonitorMetadata
-                val (metadata, created) = MonitorMetadataService.getOrCreateMetadata(request.monitor)
+                val (metadata, created) = MonitorMetadataService.getOrCreateMetadata(
+                    request.monitor,
+                    forceCreateLastRunContext = isDocLevelMonitorRestarted
+                )
+
                 // Recreate runContext if metadata exists
                 // Delete and insert all queries from/to queryIndex
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
@@ -552,10 +552,17 @@ class TransportIndexWorkflowAction @Inject constructor(
                 val monitors = monitorCtx.workflowService!!.getMonitorsById(delegates.map { it.monitorId }, delegates.size)
 
                 for (monitor in monitors) {
+                    var isWorkflowRestarted = false
+
+                    if (request.workflow.enabled && !currentWorkflow.enabled) {
+                        isWorkflowRestarted = true
+                    }
+
                     val (monitorMetadata, created) = MonitorMetadataService.getOrCreateMetadata(
                         monitor = monitor,
                         createWithRunContext = true,
-                        workflowMetadataId = workflowMetadata.id
+                        workflowMetadataId = workflowMetadata.id,
+                        forceCreateLastRunContext = isWorkflowRestarted
                     )
 
                     if (!created &&


### PR DESCRIPTION
### Description
Force create last run context in monitor workflow metadata when workflow is re-enabled. Currently, the metadata isnt updated, when workflow is disabled, leading to old findings also getting generated by the detector, when the detector was disabled.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
