### PR TITLE
Fix bucket selector aggregation writeable name.

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -97,6 +97,7 @@ import org.opensearch.common.settings.SettingsFilter
 import org.opensearch.commons.alerting.action.AlertingActions
 import org.opensearch.commons.alerting.action.DocLevelMonitorFanOutAction
 import org.opensearch.commons.alerting.aggregation.bucketselectorext.BucketSelectorExtAggregationBuilder
+import org.opensearch.commons.alerting.aggregation.bucketselectorext.BucketSelectorIndices
 import org.opensearch.commons.alerting.model.BucketLevelTrigger
 import org.opensearch.commons.alerting.model.ChainedAlertTrigger
 import org.opensearch.commons.alerting.model.ClusterMetricsInput
@@ -459,10 +460,8 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             SearchPlugin.PipelineAggregationSpec(
                 BucketSelectorExtAggregationBuilder.NAME,
                 { sin: StreamInput -> BucketSelectorExtAggregationBuilder(sin) },
-                { parser: XContentParser, agg_name: String ->
-                    BucketSelectorExtAggregationBuilder.parse(agg_name, parser)
-                }
-            )
+                { parser: XContentParser, agg_name: String -> BucketSelectorExtAggregationBuilder.parse(agg_name, parser) }
+            ).addResultReader({ sin: StreamInput -> BucketSelectorIndices(sin) })
         )
     }
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/aggregation/bucketselectorext/BucketSelectorExtAggregatorTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/aggregation/bucketselectorext/BucketSelectorExtAggregatorTests.kt
@@ -102,10 +102,12 @@ class BucketSelectorExtAggregatorTests : AggregatorTestCase() {
                 iw.addDocument(doc)
             },
             Consumer { f: InternalFilters ->
+                val bucketSelectorIndices = f.buckets[0].aggregations.get<Aggregation>("test_bucket_selector_ext") as BucketSelectorIndices
                 assertThat(
-                    (f.buckets[0].aggregations.get<Aggregation>("test_bucket_selector_ext") as BucketSelectorIndices).bucketIndices[0],
+                    bucketSelectorIndices.bucketIndices[0],
                     CoreMatchers.equalTo(1)
                 )
+                assertEquals(BucketSelectorExtAggregationBuilder.NAME.preferredName, bucketSelectorIndices.writeableName)
             },
             fieldType, fieldType1
         )
@@ -162,10 +164,12 @@ class BucketSelectorExtAggregatorTests : AggregatorTestCase() {
                 iw.addDocument(doc)
             },
             Consumer { f: InternalFilters ->
+                val bucketSelectorIndices = f.buckets[0].aggregations.get<Aggregation>("test_bucket_selector_ext") as BucketSelectorIndices
                 assertThat(
-                    (f.buckets[0].aggregations.get<Aggregation>("test_bucket_selector_ext") as BucketSelectorIndices).bucketIndices.size,
+                    bucketSelectorIndices.bucketIndices.size,
                     CoreMatchers.equalTo(0)
                 )
+                assertEquals(BucketSelectorExtAggregationBuilder.NAME.preferredName, bucketSelectorIndices.writeableName)
             },
             fieldType, fieldType1
         )
@@ -183,10 +187,12 @@ class BucketSelectorExtAggregatorTests : AggregatorTestCase() {
                 iw.addDocument(doc)
             },
             Consumer { f: InternalFilters ->
+                val bucketSelectorIndices = f.buckets[0].aggregations.get<Aggregation>("test_bucket_selector_ext") as BucketSelectorIndices
                 assertThat(
-                    (f.buckets[0].aggregations.get<Aggregation>("test_bucket_selector_ext") as BucketSelectorIndices).bucketIndices[0],
+                    bucketSelectorIndices.bucketIndices[0],
                     CoreMatchers.equalTo(1)
                 )
+                assertEquals(BucketSelectorExtAggregationBuilder.NAME.preferredName, bucketSelectorIndices.writeableName)
             },
             fieldType, fieldType1
         )
@@ -226,10 +232,12 @@ class BucketSelectorExtAggregatorTests : AggregatorTestCase() {
                 iw.addDocument(doc)
             },
             Consumer { f: InternalFilters ->
+                val bucketSelectorIndices = f.buckets[0].aggregations.get<Aggregation>("test_bucket_selector_ext") as BucketSelectorIndices
                 assertThat(
-                    (f.buckets[0].aggregations.get<Aggregation>("test_bucket_selector_ext") as BucketSelectorIndices).bucketIndices.size,
+                    bucketSelectorIndices.bucketIndices.size,
                     CoreMatchers.equalTo(0)
                 )
+                assertEquals(BucketSelectorExtAggregationBuilder.NAME.preferredName, bucketSelectorIndices.writeableName)
             },
             fieldType, fieldType1
         )
@@ -270,10 +278,12 @@ class BucketSelectorExtAggregatorTests : AggregatorTestCase() {
                 iw.addDocument(doc)
             },
             Consumer { f: InternalFilters ->
+                val bucketSelectorIndices = f.buckets[0].aggregations.get<Aggregation>("test_bucket_selector_ext") as BucketSelectorIndices
                 assertThat(
-                    (f.buckets[0].aggregations.get<Aggregation>("test_bucket_selector_ext") as BucketSelectorIndices).bucketIndices[0],
+                    bucketSelectorIndices.bucketIndices[0],
                     CoreMatchers.equalTo(0)
                 )
+                assertEquals(BucketSelectorExtAggregationBuilder.NAME.preferredName, bucketSelectorIndices.writeableName)
             },
             fieldType, fieldType1
         )
@@ -318,10 +328,12 @@ class BucketSelectorExtAggregatorTests : AggregatorTestCase() {
                 iw.addDocument(doc)
             },
             Consumer { f: InternalFilter ->
+                val bucketSelectorIndices = f.aggregations.get<Aggregation>("test_bucket_selector_ext") as BucketSelectorIndices
                 assertThat(
-                    (f.aggregations.get<Aggregation>("test_bucket_selector_ext") as BucketSelectorIndices).bucketIndices[0],
+                    bucketSelectorIndices.bucketIndices[0],
                     CoreMatchers.equalTo(1)
                 )
+                assertEquals(BucketSelectorExtAggregationBuilder.NAME.preferredName, bucketSelectorIndices.writeableName)
             },
             fieldType, fieldType1
         )


### PR DESCRIPTION
### Description
Fixed pipeline aggregation registration.

This PR depends on the changes in PR https://github.com/opensearch-project/common-utils/pull/773

#### Backporting
This change is needed back to v1.1; however, [bucketselectorext](https://github.com/opensearch-project/common-utils/tree/main/src/main/kotlin/org/opensearch/commons/alerting/aggregation/bucketselectorext) assets were moved to the common utils repo from alerting in v2.4. Will raise separate PRs to backport these changes further.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
