### PR TITLE
change  monitor fan out logic to handle empty request and checking node attributes before fanning out

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
@@ -7,7 +7,6 @@ package org.opensearch.alerting
 
 import org.apache.logging.log4j.LogManager
 import org.opensearch.ExceptionsHelper
-import org.opensearch.Version
 import org.opensearch.action.ActionListenerResponseHandler
 import org.opensearch.action.support.GroupedActionListener
 import org.opensearch.alerting.util.IndexUtils
@@ -580,10 +579,6 @@ class DocumentLevelMonitorRunner : MonitorRunner() {
     private fun getShardsCount(clusterService: ClusterService, index: String): Int {
         val allShards: List<ShardRouting> = clusterService!!.state().routingTable().allShards(index)
         return allShards.filter { it.primary() }.size
-    }
-
-    private fun getNodes(monitorCtx: MonitorRunnerExecutionContext): Map<String, DiscoveryNode> {
-        return monitorCtx.clusterService!!.state().nodes.dataNodes.filter { it.value.version >= Version.CURRENT }
     }
 
     private fun distributeShards(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorFanOutUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorFanOutUtils.kt
@@ -1,0 +1,35 @@
+package org.opensearch.alerting
+
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import org.opensearch.Version
+import org.opensearch.cluster.node.DiscoveryNode
+
+private val logger: Logger = LogManager.getLogger("FanOutEligibility")
+
+fun isNodeEligibleForFanOut(
+    candidateNode: DiscoveryNode,
+    coordinatorNode: DiscoveryNode,
+): Boolean {
+    try {
+        val candidateNodeAttributes: Map<String, Any> = candidateNode.attributes
+        val coordinatorNodeAttributes: Map<String, Any> = coordinatorNode.attributes
+        if (candidateNodeAttributes.containsKey("di_number") && candidateNodeAttributes["di_number"] != null &&
+            coordinatorNodeAttributes.containsKey("di_number") && candidateNodeAttributes["di_number"] != null
+        ) {
+            return candidateNodeAttributes["di_number"] as Int >= coordinatorNodeAttributes["di_number"] as Int
+        }
+    } catch (e: Exception) {
+        logger.error("Error in isNodeEligibleForFanOut criteria evaluation", e)
+        return true
+    }
+    return true
+}
+
+fun getNodes(monitorCtx: MonitorRunnerExecutionContext): Map<String, DiscoveryNode> {
+    val clusterService = monitorCtx.clusterService!!
+    return clusterService.state().nodes.dataNodes.filter {
+        it.value.version >= Version.CURRENT &&
+            isNodeEligibleForFanOut(it.value, clusterService.localNode())
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/remote/monitors/RemoteDocumentLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/remote/monitors/RemoteDocumentLevelMonitorRunner.kt
@@ -7,13 +7,12 @@ package org.opensearch.alerting.remote.monitors
 
 import org.apache.logging.log4j.LogManager
 import org.opensearch.ExceptionsHelper
-import org.opensearch.Version
 import org.opensearch.alerting.MonitorMetadataService
 import org.opensearch.alerting.MonitorRunner
 import org.opensearch.alerting.MonitorRunnerExecutionContext
+import org.opensearch.alerting.getNodes
 import org.opensearch.alerting.util.IndexUtils
 import org.opensearch.cluster.metadata.IndexMetadata
-import org.opensearch.cluster.node.DiscoveryNode
 import org.opensearch.cluster.routing.ShardRouting
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.commons.alerting.action.DocLevelMonitorFanOutResponse
@@ -205,10 +204,6 @@ class RemoteDocumentLevelMonitorRunner : MonitorRunner() {
         if ((monitor.inputs[0] as RemoteDocLevelMonitorInput).docLevelMonitorInput.indices.isEmpty()) {
             throw IllegalArgumentException("DocLevelMonitorInput has no indices")
         }
-    }
-
-    private fun getNodes(monitorCtx: MonitorRunnerExecutionContext): Map<String, DiscoveryNode> {
-        return monitorCtx.clusterService!!.state().nodes.dataNodes.filter { it.value.version >= Version.CURRENT }
     }
 
     private fun distributeShards(


### PR DESCRIPTION
change  monitor fan out logic to handle empty request and checking node attributes before fanning out

this handles upgrade situation where old version is fanning out to new version and encounters failure in request serialization to silently ignore processing the set of shards assigned