### PR TITLE
Issue 1057: Refactored consistent responses and fixed unrelated exceptions

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetMonitorAction.kt
@@ -149,7 +149,9 @@ class TransportGetMonitorAction @Inject constructor(
                     }
 
                     override fun onFailure(t: Exception) {
-                        actionListener.onFailure(AlertingException.wrap(t))
+                        actionListener.onFailure(
+                            AlertingException.wrap(OpenSearchStatusException("Monitor not found.", RestStatus.NOT_FOUND))
+                        )
                     }
                 }
             )

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
@@ -6,6 +6,7 @@
 package org.opensearch.alerting.transport
 
 import org.apache.logging.log4j.LogManager
+import org.opensearch.OpenSearchStatusException
 import org.opensearch.action.ActionRequest
 import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.search.SearchResponse
@@ -27,6 +28,7 @@ import org.opensearch.commons.authuser.User
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry
+import org.opensearch.core.rest.RestStatus
 import org.opensearch.index.query.BoolQueryBuilder
 import org.opensearch.index.query.ExistsQueryBuilder
 import org.opensearch.index.query.MatchQueryBuilder
@@ -109,7 +111,9 @@ class TransportSearchMonitorAction @Inject constructor(
                 }
 
                 override fun onFailure(t: Exception) {
-                    actionListener.onFailure(AlertingException.wrap(t))
+                    actionListener.onFailure(
+                        AlertingException.wrap(OpenSearchStatusException("Monitor not found.", RestStatus.NOT_FOUND))
+                    )
                 }
             }
         )


### PR DESCRIPTION
### Description
This PR ensures consistent responses by handling cases where the alerting config index does not exist when no monitors are created. Previously, calling the get & search APIs in this scenario would return an exception. It also addresses unrelated exceptions.

### Related Issues
Resolves #1057 

### Issue Summary:
When no monitors are created in OpenSearch, the alerting configuration index (.opendistro-alerting-config) does not exist. In this scenario, calling the GET or SEARCH APIs for monitors results in an exception indicating that the alerting config index is missing.

 ### Example:
#### Before Fix:

GET API Call:
```
GET _plugins/_alerting/monitors/abcd

# Response:
{
  "error": {
    "root_cause": [
      {
        "type": "alerting_exception",
        "reason": "Configured indices are not found: [.opendistro-alerting-config]"
      }
    ],
    "type": "alerting_exception",
    "reason": "Configured indices are not found: [.opendistro-alerting-config]",
    "caused_by": {
      "type": "exception",
      "reason": "org.opensearch.index.IndexNotFoundException: no such index [.opendistro-alerting-config]"
    }
  },
  "status": 404
}
```
- SEARCH API Call:
```
GET _plugins/_alerting/monitors/_search
{
  "query": {
    "match": {
      "monitor.name": "my-monitor-name"
    }
  }
}

# Response:
{
  "error": {
    "root_cause": [
      {
        "type": "alerting_exception",
        "reason": "Configured indices are not found: [.opendistro-alerting-config]"
      }
    ],
    "type": "alerting_exception",
    "reason": "Configured indices are not found: [.opendistro-alerting-config]",
    "caused_by": {
      "type": "exception",
      "reason": "org.opensearch.index.IndexNotFoundException: no such index [.opendistro-alerting-config]"
    }
  },
  "status": 404
}
```
In both cases, the absence of the alerting configuration index causes the API calls to fail with a 404 error indicating that the index does not exist.

#### After: Fix
This fix addresses the issue by providing a more consistent and meaningful error message when the alerting configuration index is not available, and no monitors have been created.

- GET/SEARCH API Call:
```
GET _plugins/_alerting/monitors/jDBVX5MB5hhhn6aR4HhV

# Response:
{
  "error": {
    "root_cause": [
      {
        "type": "alerting_exception",
        "reason": "Monitor not found."
      }
    ],
    "type": "alerting_exception",
    "reason": "Monitor not found.",
    "caused_by": {
      "type": "exception",
      "reason": "org.opensearch.OpenSearchStatusException: Monitor not found."
    }
  },
  "status": 404
}
```

The behavior is similar for search queries, where an appropriate error message (Monitor not found) is returned when no matching monitors are present, instead of indicating the absence of the alerting configuration index.

### Key Changes:
1. Consistent Response: The error response now consistently returns "Monitor not found" when no monitors exist, instead of showing an index-related error.
2. Improved User Experience: This change improves clarity for users by providing more relevant error messages for cases where monitors are missing, instead of pointing to a missing index that may not be immediately relevant to the user.


### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
