### PR TITLE
Integrated OpenSearch Remote Metadata SDKClient with Alerting

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -111,6 +111,10 @@ configurations.all {
         // This is required because kotlin-coroutines-core 1.1.1 still requires kotlin stdlib 1.3.20 and we're using a higher kotlin version
         force "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
         force "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
+
+        // Remote Metadata SDK
+        force "org.apache.httpcomponents.core5:httpcore5:5.3.2"
+        force "org.apache.httpcomponents.core5:httpcore5-h2:5.3.2"
     }
 }
 
@@ -171,6 +175,7 @@ dependencies {
     implementation "com.github.seancfoley:ipaddress:5.4.1"
     implementation project(path: ":alerting-spi", configuration: 'shadow')
 
+    implementation ("org.opensearch:opensearch-remote-metadata-sdk:${opensearch_build}")
     testImplementation "org.antlr:antlr4-runtime:${versions.antlr4}"
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
     testImplementation "org.mockito:mockito-core:${versions.mockito}"

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
@@ -8,6 +8,10 @@ package org.opensearch.alerting.settings
 import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.common.settings.Setting
 import org.opensearch.common.unit.TimeValue
+import org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_ENDPOINT_KEY
+import org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_REGION_KEY
+import org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_SERVICE_NAME_KEY
+import org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_TYPE_KEY
 import java.util.concurrent.TimeUnit
 
 /**
@@ -275,5 +279,40 @@ class AlertingSettings {
             0,
             Setting.Property.NodeScope, Setting.Property.Dynamic
         )
+
+        /** This setting controls whether multi tenancy is enabled */
+        val MULTI_TENANCY_ENABLED: Setting<Boolean?> = Setting
+            .boolSetting(
+                "plugins.alerting.multi_tenancy_enabled",
+                false, Setting.Property.NodeScope
+            )
+
+        /** This setting sets the remote metadata store type  */
+        val REMOTE_METADATA_STORE_TYPE: Setting<String?> = Setting
+            .simpleString(
+                "plugins.alerting.$REMOTE_METADATA_TYPE_KEY",
+                Setting.Property.NodeScope, Setting.Property.Final
+            )
+
+        /** This setting sets the remote metadata endpoint  */
+        val REMOTE_METADATA_ENDPOINT: Setting<String?> = Setting
+            .simpleString(
+                "plugins.alerting.$REMOTE_METADATA_ENDPOINT_KEY",
+                Setting.Property.NodeScope, Setting.Property.Final
+            )
+
+        /** This setting sets the remote metadata region  */
+        val REMOTE_METADATA_REGION: Setting<String?> = Setting
+            .simpleString(
+                "plugins.alerting.$REMOTE_METADATA_REGION_KEY",
+                Setting.Property.NodeScope, Setting.Property.Final
+            )
+
+        /** This setting sets the remote metadata service name  */
+        val REMOTE_METADATA_SERVICE_NAME: Setting<String?> = Setting
+            .simpleString(
+                "plugins.alerting.$REMOTE_METADATA_SERVICE_NAME_KEY",
+                Setting.Property.NodeScope, Setting.Property.Final
+            )
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -78,6 +78,7 @@ import org.opensearch.index.query.QueryBuilders
 import org.opensearch.index.reindex.BulkByScrollResponse
 import org.opensearch.index.reindex.DeleteByQueryAction
 import org.opensearch.index.reindex.DeleteByQueryRequestBuilder
+import org.opensearch.remote.metadata.client.SdkClient
 import org.opensearch.rest.RestRequest
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.tasks.Task
@@ -93,6 +94,7 @@ private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 class TransportIndexMonitorAction @Inject constructor(
     transportService: TransportService,
     val client: Client,
+    val sdkClient: SdkClient,
     actionFilters: ActionFilters,
     val scheduledJobIndices: ScheduledJobIndices,
     val docLevelMonitorQueries: DocLevelMonitorQueries,


### PR DESCRIPTION
### Description
Integrated [Opensearch Remote Metadata SDKClient](https://github.com/opensearch-project/opensearch-remote-metadata-sdk) with Alerting
- Added Alerting settings for remote metadata client
- Wired up remote metadata client with alerting
- Onboarded the Remote Metadata Client into `TransportIndexMonitorAction`

### Related Issues
Resolves #1821 


### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
