### PR TITLE
Migrated client calls to sdk client and added SdkClientExtensions

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchEmailAccountAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchEmailAccountAction.kt
@@ -20,6 +20,9 @@ import org.opensearch.common.settings.Settings
 import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.rest.RestStatus
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest
+import org.opensearch.remote.metadata.common.SdkClientUtils
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService
 import org.opensearch.transport.client.Client
@@ -27,6 +30,7 @@ import org.opensearch.transport.client.Client
 class TransportSearchEmailAccountAction @Inject constructor(
     transportService: TransportService,
     val client: Client,
+    val sdkClient: SdkClient,
     actionFilters: ActionFilters,
     val clusterService: ClusterService,
     settings: Settings
@@ -54,19 +58,24 @@ class TransportSearchEmailAccountAction @Inject constructor(
             return
         }
 
-        client.threadPool().threadContext.stashContext().use {
-            client.search(
-                searchRequest,
-                object : ActionListener<SearchResponse> {
-                    override fun onResponse(response: SearchResponse) {
-                        actionListener.onResponse(response)
-                    }
+        val searchDataObjectRequest = SearchDataObjectRequest.builder()
+            .indices(*searchRequest.indices())
+            .searchSourceBuilder(searchRequest.source())
+            .build()
 
-                    override fun onFailure(e: Exception) {
-                        actionListener.onFailure(e)
-                    }
-                }
-            )
+        client.threadPool().threadContext.stashContext().use {
+            sdkClient.searchDataObjectAsync(searchDataObjectRequest)
+                .whenComplete(
+                    SdkClientUtils.wrapSearchCompletion(object : ActionListener<SearchResponse> {
+                        override fun onResponse(response: SearchResponse) {
+                            actionListener.onResponse(response)
+                        }
+
+                        override fun onFailure(e: Exception) {
+                            actionListener.onFailure(e)
+                        }
+                    })
+                )
         }
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/SdkClientExtensions.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/SdkClientExtensions.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.util
+
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.opensearch.OpenSearchStatusException
+import org.opensearch.core.rest.RestStatus
+import org.opensearch.core.xcontent.XContentParser
+import org.opensearch.index.engine.VersionConflictEngineException
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.remote.metadata.common.SdkClientUtils
+import java.util.function.BiConsumer
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * Suspends until an SdkClient async operation completes, with parsing and exception handling.
+ *
+ * @param block A lambda that receives a [BiConsumer] to handle the [CompletionStage]'s result or exception.
+ * @return The parsed result of type [R] (e.g., [IndexResponse], [GetResponse]) after converting the raw response.
+ * @throws IllegalArgumentException If the raw response does not have a `parser()` method or cannot be parsed to [R].
+ */
+suspend inline fun <Raw : Any, reified R : Any> SdkClient.suspendUntil(
+    crossinline block: SdkClient.(BiConsumer<Raw, Throwable?>) -> Unit
+): R {
+    try {
+        val rawResponse: Raw = suspendCancellableCoroutine { cont ->
+            block(
+                BiConsumer<Raw, Throwable?> { result, exception ->
+                    if (exception != null) {
+                        cont.resumeWithException(SdkClientUtils.unwrapAndConvertToException(exception))
+                    } else {
+                        cont.resume(result)
+                    }
+                }
+            )
+        }
+        val parser = rawResponse::class.java.getMethod("parser").invoke(rawResponse) as? XContentParser
+            ?: throw IllegalArgumentException("Missing parser() on ${rawResponse::class.simpleName}")
+        val parsed = R::class.java.getMethod("fromXContent", XContentParser::class.java)
+            .invoke(null, parser) as? R
+            ?: throw IllegalArgumentException("Failed to parse response into ${R::class.simpleName}")
+        return parsed
+    } catch (e: Throwable) {
+        throw handleException(e)
+    }
+}
+
+/**
+ * Centralized Method for Handling different types of exceptions,
+ * transforming them into appropriate OpenSearch exceptions
+ *
+ * @param exception The exception to process
+ * @return The appropriate matching exception found
+ */
+fun handleException(exception: Throwable): Throwable {
+    if (isVersionConflict(exception)) {
+        return OpenSearchStatusException(
+            exception.message ?: "Version conflict occurred",
+            RestStatus.CONFLICT
+        )
+    }
+    return exception
+}
+
+/**
+ * Checks if an exception represents a version conflict.
+ *
+ * @param exception The exception to check.
+ * @return True if the exception or its cause is a [VersionConflictEngineException], false otherwise.
+ */
+private fun isVersionConflict(exception: Throwable): Boolean {
+    val cause = exception.cause ?: exception
+    return cause is VersionConflictEngineException ||
+        (cause is OpenSearchStatusException && cause.cause is VersionConflictEngineException)
+}


### PR DESCRIPTION
### Description
Migrated the following Transport layer operations to sdk client:

- TransportDeleteAlertingCommentAction
- TransportGetWorkflowAction
- TransportSearchEmailAccountAction
- TransportSearchEmailGroupAction
- TransportSearchMonitorAction

Added SdkClientExtensions for supporting `suspendUntil` functionality

### Related Issues
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
