### PR TITLE
Timebox doc level monitor execution

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -386,6 +386,8 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             AlertingSettings.DOC_LEVEL_MONITOR_FAN_OUT_NODES,
             DOC_LEVEL_MONITOR_SHARD_FETCH_SIZE,
             AlertingSettings.PERCOLATE_QUERY_MAX_NUM_DOCS_IN_MEMORY,
+            AlertingSettings.DOC_LEVEL_MONITOR_FANOUT_MAX_DURATION,
+            AlertingSettings.DOC_LEVEL_MONITOR_EXECUTION_MAX_DURATION,
             AlertingSettings.REQUEST_TIMEOUT,
             AlertingSettings.MAX_ACTION_THROTTLE_VALUE,
             AlertingSettings.FILTER_BY_BACKEND_ROLES,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunnerExecutionContext.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunnerExecutionContext.kt
@@ -59,10 +59,16 @@ data class MonitorRunnerExecutionContext(
     @Volatile var findingsIndexBatchSize: Int = AlertingSettings.DEFAULT_FINDINGS_INDEXING_BATCH_SIZE,
     @Volatile var fetchOnlyQueryFieldNames: Boolean = true,
     @Volatile var percQueryMaxNumDocsInMemory: Int = AlertingSettings.DEFAULT_PERCOLATE_QUERY_NUM_DOCS_IN_MEMORY,
+    @Volatile var docLevelMonitorFanoutMaxDuration: TimeValue = TimeValue.timeValueMinutes(
+        AlertingSettings.DEFAULT_MAX_DOC_LEVEL_MONITOR_FANOUT_MAX_DURATION_MINUTES
+    ),
+    @Volatile var docLevelMonitorExecutionMaxDuration: TimeValue = TimeValue.timeValueMinutes(
+        AlertingSettings.DEFAULT_MAX_DOC_LEVEL_MONITOR_EXECUTION_MAX_DURATION_MINUTES
+    ),
     @Volatile var percQueryDocsSizeMemoryPercentageLimit: Int =
         AlertingSettings.DEFAULT_PERCOLATE_QUERY_DOCS_SIZE_MEMORY_PERCENTAGE_LIMIT,
     @Volatile var docLevelMonitorShardFetchSize: Int =
         AlertingSettings.DEFAULT_DOC_LEVEL_MONITOR_SHARD_FETCH_SIZE,
     @Volatile var totalNodesFanOut: Int = AlertingSettings.DEFAULT_FAN_OUT_NODES,
-    @Volatile var lockService: LockService? = null
+    @Volatile var lockService: LockService? = null,
 )

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunnerService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunnerService.kt
@@ -36,6 +36,8 @@ import org.opensearch.alerting.script.TriggerExecutionContext
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.settings.AlertingSettings.Companion.ALERT_BACKOFF_COUNT
 import org.opensearch.alerting.settings.AlertingSettings.Companion.ALERT_BACKOFF_MILLIS
+import org.opensearch.alerting.settings.AlertingSettings.Companion.DOC_LEVEL_MONITOR_EXECUTION_MAX_DURATION
+import org.opensearch.alerting.settings.AlertingSettings.Companion.DOC_LEVEL_MONITOR_FANOUT_MAX_DURATION
 import org.opensearch.alerting.settings.AlertingSettings.Companion.DOC_LEVEL_MONITOR_FETCH_ONLY_QUERY_FIELDS_ENABLED
 import org.opensearch.alerting.settings.AlertingSettings.Companion.DOC_LEVEL_MONITOR_SHARD_FETCH_SIZE
 import org.opensearch.alerting.settings.AlertingSettings.Companion.FINDINGS_INDEXING_BATCH_SIZE
@@ -223,6 +225,16 @@ object MonitorRunnerService : JobRunner, CoroutineScope, AbstractLifecycleCompon
         monitorCtx.percQueryMaxNumDocsInMemory = PERCOLATE_QUERY_MAX_NUM_DOCS_IN_MEMORY.get(monitorCtx.settings)
         monitorCtx.clusterService!!.clusterSettings.addSettingsUpdateConsumer(PERCOLATE_QUERY_MAX_NUM_DOCS_IN_MEMORY) {
             monitorCtx.percQueryMaxNumDocsInMemory = it
+        }
+
+        monitorCtx.docLevelMonitorFanoutMaxDuration = DOC_LEVEL_MONITOR_FANOUT_MAX_DURATION.get(monitorCtx.settings)
+        monitorCtx.clusterService!!.clusterSettings.addSettingsUpdateConsumer(DOC_LEVEL_MONITOR_FANOUT_MAX_DURATION) {
+            monitorCtx.docLevelMonitorFanoutMaxDuration = it
+        }
+
+        monitorCtx.docLevelMonitorExecutionMaxDuration = DOC_LEVEL_MONITOR_EXECUTION_MAX_DURATION.get(monitorCtx.settings)
+        monitorCtx.clusterService!!.clusterSettings.addSettingsUpdateConsumer(DOC_LEVEL_MONITOR_EXECUTION_MAX_DURATION) {
+            monitorCtx.docLevelMonitorExecutionMaxDuration = it
         }
 
         monitorCtx.percQueryDocsSizeMemoryPercentageLimit =

--- a/alerting/src/main/kotlin/org/opensearch/alerting/listener/PrioritizedActionListener.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/listener/PrioritizedActionListener.kt
@@ -1,0 +1,7 @@
+package org.opensearch.alerting.listener
+
+import org.opensearch.core.action.ActionListener
+
+interface PrioritizedActionListener<Response> : ActionListener<Response> {
+    fun executeImmediately()
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/listener/TimeOutWrappedListener.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/listener/TimeOutWrappedListener.kt
@@ -1,0 +1,93 @@
+// TimeOutableListener.kt
+package org.opensearch.alerting.listener
+
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import org.opensearch.common.unit.TimeValue
+import org.opensearch.core.action.ActionListener
+import org.opensearch.threadpool.Scheduler
+import org.opensearch.threadpool.ThreadPool
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.function.Consumer
+
+/**
+ * The wrapper that schedules a timeout and wraps it in an actual [ActionListener]. The [TimeOutWrappedListener]
+ * guarantees that only one of timeout/response/failure gets executed so that responses are not sent over a closed channel
+ * The wrap and actual scheduling has been split to avoid races in listeners as they get attached.
+ */
+class TimeOutWrappedListener {
+    companion object {
+        private val logger: Logger = LogManager.getLogger(TimeOutWrappedListener::class.java)
+
+        /**
+         * Wraps the listener and schedules the timeout
+         */
+        fun <Response> wrapScheduledTimeout(
+            threadPool: ThreadPool,
+            timeout: TimeValue,
+            executor: String,
+            actionListener: ActionListener<Response>,
+            timeoutConsumer: Consumer<ActionListener<Response>>,
+        ): PrioritizedActionListener<Response> {
+            return scheduleTimeout(threadPool, timeout, executor, initListener(actionListener, timeoutConsumer))
+        }
+
+        fun <Response> initListener(
+            actionListener: ActionListener<Response>,
+            timeoutConsumer: Consumer<ActionListener<Response>>,
+        ): PrioritizedActionListener<Response> {
+            return CompletionPrioritizedActionListener(actionListener, timeoutConsumer)
+        }
+
+        fun <Response> scheduleTimeout(
+            threadPool: ThreadPool,
+            timeout: TimeValue,
+            executor: String,
+            completionTimeoutListener: PrioritizedActionListener<Response>,
+        ): PrioritizedActionListener<Response> {
+            (completionTimeoutListener as CompletionPrioritizedActionListener<Response>).cancellable =
+                threadPool.schedule(completionTimeoutListener as Runnable, timeout, executor)
+            return completionTimeoutListener
+        }
+
+        private class CompletionPrioritizedActionListener<Response>(
+            private val actionListener: ActionListener<Response>,
+            private val timeoutConsumer: Consumer<ActionListener<Response>>,
+        ) : PrioritizedActionListener<Response>, Runnable {
+            @Volatile
+            var cancellable: Scheduler.ScheduledCancellable? = null
+            private val complete = AtomicBoolean(false)
+
+            private fun cancel() {
+                if (cancellable != null && cancellable!!.isCancelled == false) {
+                    cancellable!!.cancel()
+                }
+            }
+
+            override fun run() {
+                executeImmediately()
+            }
+
+            override fun executeImmediately() {
+                if (complete.compareAndSet(false, true)) {
+                    cancel()
+                    timeoutConsumer.accept(this)
+                }
+            }
+
+            override fun onResponse(response: Response) {
+                if (complete.compareAndSet(false, true)) {
+                    cancel()
+                    actionListener.onResponse(response)
+                }
+            }
+
+            override fun onFailure(e: Exception) {
+                if (complete.compareAndSet(false, true)) {
+                    cancel()
+                    actionListener.onFailure(e)
+                }
+            }
+        }
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
@@ -21,6 +21,8 @@ class AlertingSettings {
         const val DEFAULT_PERCOLATE_QUERY_NUM_DOCS_IN_MEMORY = 50000
         const val DEFAULT_PERCOLATE_QUERY_DOCS_SIZE_MEMORY_PERCENTAGE_LIMIT = 10
         const val DEFAULT_DOC_LEVEL_MONITOR_SHARD_FETCH_SIZE = 10000
+        const val DEFAULT_MAX_DOC_LEVEL_MONITOR_FANOUT_MAX_DURATION_MINUTES = 3L
+        const val DEFAULT_MAX_DOC_LEVEL_MONITOR_EXECUTION_MAX_DURATION_MINUTES = 4L
         const val DEFAULT_FAN_OUT_NODES = 1000
 
         val ALERTING_MAX_MONITORS = Setting.intSetting(
@@ -47,6 +49,22 @@ class AlertingSettings {
             DEFAULT_DOC_LEVEL_MONITOR_SHARD_FETCH_SIZE,
             1,
             10000,
+            Setting.Property.NodeScope, Setting.Property.Dynamic
+        )
+
+        /** Setting to help timebox doc level monitor fanout
+         */
+        val DOC_LEVEL_MONITOR_FANOUT_MAX_DURATION = Setting.positiveTimeSetting(
+            "plugins.alerting.monitor.doc_level_monitor_fanout_max_duration",
+            TimeValue.timeValueMinutes(DEFAULT_MAX_DOC_LEVEL_MONITOR_FANOUT_MAX_DURATION_MINUTES),
+            Setting.Property.NodeScope, Setting.Property.Dynamic
+        )
+
+        /** Setting to help timebox doc level monitor execution
+         */
+        val DOC_LEVEL_MONITOR_EXECUTION_MAX_DURATION = Setting.positiveTimeSetting(
+            "plugins.alerting.monitor.doc_level_monitor_execution_max_duration",
+            TimeValue.timeValueMinutes(DEFAULT_MAX_DOC_LEVEL_MONITOR_EXECUTION_MAX_DURATION_MINUTES),
             Setting.Property.NodeScope, Setting.Property.Dynamic
         )
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/DocumentMonitorRunnerIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/DocumentMonitorRunnerIT.kt
@@ -473,8 +473,10 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
 
         val findings = searchFindings(monitor)
         assertEquals("Findings saved for test monitor", 2, findings.size)
-        assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("5"))
-        assertTrue("Findings saved for test monitor", findings[1].relatedDocIds.contains("1"))
+        val findings0 = findings[0].relatedDocIds.contains("1") || findings[0].relatedDocIds.contains("5")
+        val findings1 = findings[1].relatedDocIds.contains("5") || findings[1].relatedDocIds.contains("1")
+        assertTrue("Findings saved for test monitor", findings0)
+        assertTrue("Findings saved for test monitor", findings1)
     }
 
     fun `test monitor run generates no error alerts with versionconflictengineexception with locks`() {
@@ -593,8 +595,10 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
 
         val findings = searchFindings(monitor)
         assertEquals("Findings saved for test monitor", 2, findings.size)
-        assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("5"))
-        assertTrue("Findings saved for test monitor", findings[1].relatedDocIds.contains("1"))
+        val findings0 = findings[0].relatedDocIds.contains("1") || findings[0].relatedDocIds.contains("5")
+        val findings1 = findings[1].relatedDocIds.contains("5") || findings[1].relatedDocIds.contains("1")
+        assertTrue("Findings saved for test monitor", findings0)
+        assertTrue("Findings saved for test monitor", findings1)
     }
 
     fun `test execute monitor input error`() {
@@ -692,8 +696,8 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
 
         val findings = searchFindings(monitor)
         assertEquals("Findings saved for test monitor", 2, findings.size)
-        assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("5"))
-        assertTrue("Findings saved for test monitor", findings[1].relatedDocIds.contains("1"))
+        assertTrue("Findings saved for test monitor", findings[1].relatedDocIds.contains("5"))
+        assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("1"))
     }
 
     fun `test execute monitor generates alerts and findings with per trigger execution for actions`() {
@@ -755,8 +759,10 @@ class DocumentMonitorRunnerIT : AlertingRestTestCase() {
 
         val findings = searchFindings(monitor)
         assertEquals("Findings saved for test monitor", 2, findings.size)
-        assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("5"))
-        assertTrue("Findings saved for test monitor", findings[1].relatedDocIds.contains("1"))
+        val findings0 = findings[0].relatedDocIds.contains("1") || findings[0].relatedDocIds.contains("5")
+        val findings1 = findings[1].relatedDocIds.contains("5") || findings[1].relatedDocIds.contains("1")
+        assertTrue("Findings saved for test monitor", findings[1].relatedDocIds.contains("5"))
+        assertTrue("Findings saved for test monitor", findings[0].relatedDocIds.contains("1"))
     }
 
     fun `test execute monitor with wildcard index that generates alerts and findings for EQUALS query operator`() {


### PR DESCRIPTION
### Description
1. Time box doc level monitor execution to 4m
2. Time box doc level monitor execution to 3m

### Related Issues
#1853 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
