### PR TITLE
now publishes a list of findings instead of an individual one

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
@@ -614,9 +614,7 @@ class TransportDocLevelMonitorFanOutAction
 
         if (monitor.shouldCreateSingleAlertForFindings == null || monitor.shouldCreateSingleAlertForFindings == false) {
             try {
-                findings.forEach { finding ->
-                    publishFinding(monitor, finding)
-                }
+                publishFindings(monitor, findings)
             } catch (e: Exception) {
                 // suppress exception
                 log.error("Optional finding callback failed", e)
@@ -648,9 +646,9 @@ class TransportDocLevelMonitorFanOutAction
         client.execute(RefreshAction.INSTANCE, RefreshRequest(monitor.dataSources.findingsIndex))
     }
 
-    private fun publishFinding(
+    private fun publishFindings(
         monitor: Monitor,
-        finding: Finding
+        finding: List<Finding>
     ) {
         val publishFindingsRequest = PublishFindingsRequest(monitor.id, finding)
         AlertingPluginInterface.publishFinding(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
@@ -672,9 +672,13 @@ class TransportDocLevelMonitorFanOutAction
             client as NodeClient,
             publishBatchFindingsRequest,
             object : ActionListener<SubscribeFindingsResponse> {
-                override fun onResponse(response: SubscribeFindingsResponse) {}
+                override fun onResponse(response: SubscribeFindingsResponse) {
+                    log.info("findings published successfully")
+                }
 
-                override fun onFailure(e: Exception) {}
+                override fun onFailure(e: Exception) {
+                    log.error("findings published failed due to {}", e.message)
+                }
             }
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
@@ -668,6 +668,7 @@ class TransportDocLevelMonitorFanOutAction
         findings: List<Finding>
     ) {
         val publishBatchFindingsRequest = PublishBatchFindingsRequest(monitor.id, findings)
+        log.debug("publishing {} findings from node {}", findings.size, clusterService.localNode().id)
         AlertingPluginInterface.publishBatchFindings(
             client as NodeClient,
             publishBatchFindingsRequest,
@@ -677,7 +678,7 @@ class TransportDocLevelMonitorFanOutAction
                 }
 
                 override fun onFailure(e: Exception) {
-                    log.error("findings published failed due to {}", e.message)
+                    log.error("publishing findings failed", e)
                 }
             }
         )

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
@@ -647,7 +647,7 @@ class TransportDocLevelMonitorFanOutAction
         client.execute(RefreshAction.INSTANCE, RefreshRequest(monitor.dataSources.findingsIndex))
     }
 
-    private fun publishFindings(
+    private fun publishFinding(
         monitor: Monitor,
         finding: Finding
     ) {
@@ -673,7 +673,7 @@ class TransportDocLevelMonitorFanOutAction
             publishBatchFindingsRequest,
             object : ActionListener<SubscribeFindingsResponse> {
                 override fun onResponse(response: SubscribeFindingsResponse) {
-                    log.info("findings published successfully")
+                    log.debug("findings published successfully")
                 }
 
                 override fun onFailure(e: Exception) {


### PR DESCRIPTION
### Description
Updating DocLevelFanout action to publish batches of findings instead of individual ones.

### Related Issues
https://github.com/opensearch-project/alerting/issues/1859

### Check List
- [N/A] New functionality includes testing.
- [N/A] New functionality has been documented.
- [N/A] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
