### PR TITLE
Update the maven snapshot publish endpoint and credential

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -28,15 +28,16 @@ jobs:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: ${{ matrix.jdk }}
       - uses: actions/checkout@v4
-      - uses: aws-actions/configure-aws-credentials@v1
+      - name: Load secret
+        uses: 1password/load-secrets-action@v2
         with:
-          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
-          aws-region: us-east-1
+          # Export loaded secrets as environment variables
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SONATYPE_USERNAME: op://opensearch-infra-secrets/maven-central-portal-credentials/username
+          SONATYPE_PASSWORD: op://opensearch-infra-secrets/maven-central-portal-credentials/password
       - name: publish snapshots to maven
         run: |
-          export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
-          export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
-          echo "::add-mask::$SONATYPE_USERNAME"
-          echo "::add-mask::$SONATYPE_PASSWORD"
           ./gradlew publishShadowPublicationToSnapshotsRepository
           ./gradlew publishPluginZipPublicationToSnapshotsRepository

--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -83,7 +83,7 @@ publishing {
     repositories {
         maven {
             name = "Snapshots"
-            url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+            url = "https://central.sonatype.com/repository/maven-snapshots/"
             credentials {
                 username "$System.env.SONATYPE_USERNAME"
                 password "$System.env.SONATYPE_PASSWORD"

--- a/build-tools/repositories.gradle
+++ b/build-tools/repositories.gradle
@@ -5,6 +5,7 @@
 
 repositories {
     mavenLocal()
+    maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     mavenCentral()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ buildscript {
 
     repositories {
         mavenLocal()
+        maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
         maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }

--- a/sample-remote-monitor-plugin/build.gradle
+++ b/sample-remote-monitor-plugin/build.gradle
@@ -30,6 +30,7 @@ ext {
 repositories {
     mavenLocal()
     mavenCentral()
+    maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
 }
 

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -44,7 +44,7 @@ publishing {
         }
         maven {
             name = "Snapshots"
-            url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+            url = "https://central.sonatype.com/repository/maven-snapshots/"
             credentials {
                 username "$System.env.SONATYPE_USERNAME"
                 password "$System.env.SONATYPE_PASSWORD"


### PR DESCRIPTION
### Description
Update the Maven Snapshots publish URL in accordance with the recent Sonatype migration. 
https://central.sonatype.org/publish/publish-portal-snapshots/

We have stored the `onepassword` token in this repo secrets and new credentials for Sonatypes username & password have been stored in `onepassword`.  These credentials will be exported as env variables which used by maven publish.

### Related Issues
Part of a campaign issue https://github.com/opensearch-project/opensearch-build/issues/5551

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
