### PR TITLE
Pinned the commons-beanutils dependency to 1.11.0 version

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -105,6 +105,8 @@ configurations.all {
         force "commons-logging:commons-logging:${versions.commonslogging}"
         // force the version until OpenSearch upgrade to an invulnerable one, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
         force "commons-codec:commons-codec:1.13"
+        // force commons-beanutils to a non-vulnerable version
+        force "commons-beanutils:commons-beanutils:1.11.0"
 
         force "org.slf4j:slf4j-api:${versions.slf4j}" //Needed for http5
         


### PR DESCRIPTION
### Description
Pinned the commons-beanutils dependency to 1.11.0 version. 

### Related Issues
Fixes the CVE listed at https://advisories.opensearch.org/advisories/CVE-2025-48734

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
