### PR TITLE
Moved the commons-beanutils pinning to the core gradle file

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -105,8 +105,6 @@ configurations.all {
         force "commons-logging:commons-logging:${versions.commonslogging}"
         // force the version until OpenSearch upgrade to an invulnerable one, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
         force "commons-codec:commons-codec:1.13"
-        // force commons-beanutils to a non-vulnerable version
-        force "commons-beanutils:commons-beanutils:1.11.0"
 
         force "org.slf4j:slf4j-api:${versions.slf4j}" //Needed for http5
         

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -8,6 +8,15 @@ apply plugin: 'opensearch.java-rest-test'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'jacoco'
 
+configurations{
+    all {
+        resolutionStrategy {
+            // force commons-beanutils to a non-vulnerable version
+            force "commons-beanutils:commons-beanutils:1.11.0"
+        }
+    }
+}
+
 dependencies {
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"


### PR DESCRIPTION
### Description
Moved the commons-beanutils pinning to the core gradle file where the commons-validator dependency is present

### Related Issues
Fixes CVE 2025-48734. The previous PR #1887 did not work

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
