### PR TITLE
Updated commons-validator to fix CVE with commons-beansutils

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -8,15 +8,6 @@ apply plugin: 'opensearch.java-rest-test'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'jacoco'
 
-configurations{
-    all {
-        resolutionStrategy {
-            // force commons-beanutils to a non-vulnerable version
-            force "commons-beanutils:commons-beanutils:1.11.0"
-        }
-    }
-}
-
 dependencies {
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
@@ -25,7 +16,7 @@ dependencies {
     implementation "com.cronutils:cron-utils:9.1.7"
     api "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
     api "org.opensearch:common-utils:${common_utils_version}@jar"
-    implementation 'commons-validator:commons-validator:1.7'
+    implementation 'commons-validator:commons-validator:1.10.0'
 
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"


### PR DESCRIPTION
### Description
Proper fix for CVE 2025-48734 as seen from PR #1893 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
