### PR TITLE
Introduce PluginSubject and replace usages of stashContext in TransportGetAlertsAction

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -84,6 +84,7 @@ import org.opensearch.alerting.transport.TransportSearchEmailAccountAction
 import org.opensearch.alerting.transport.TransportSearchEmailGroupAction
 import org.opensearch.alerting.transport.TransportSearchMonitorAction
 import org.opensearch.alerting.util.DocLevelMonitorQueries
+import org.opensearch.alerting.util.PluginClient
 import org.opensearch.alerting.util.destinationmigration.DestinationMigrationCoordinator
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver
 import org.opensearch.cluster.node.DiscoveryNodes
@@ -116,6 +117,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.core.xcontent.XContentParser
 import org.opensearch.env.Environment
 import org.opensearch.env.NodeEnvironment
+import org.opensearch.identity.PluginSubject
 import org.opensearch.index.IndexModule
 import org.opensearch.indices.SystemIndexDescriptor
 import org.opensearch.monitor.jvm.JvmStats
@@ -125,6 +127,7 @@ import org.opensearch.painless.spi.PainlessExtension
 import org.opensearch.percolator.PercolatorPluginExt
 import org.opensearch.plugins.ActionPlugin
 import org.opensearch.plugins.ExtensiblePlugin
+import org.opensearch.plugins.IdentityAwarePlugin
 import org.opensearch.plugins.ReloadablePlugin
 import org.opensearch.plugins.ScriptPlugin
 import org.opensearch.plugins.SearchPlugin
@@ -146,7 +149,7 @@ import java.util.function.Supplier
  * [BucketLevelTrigger.XCONTENT_REGISTRY], [ClusterMetricsInput.XCONTENT_REGISTRY] to the [NamedXContentRegistry] so that we are able to deserialize the custom named objects.
  */
 internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, ReloadablePlugin,
-    SearchPlugin, SystemIndexPlugin, PercolatorPluginExt() {
+    SearchPlugin, SystemIndexPlugin, IdentityAwarePlugin, PercolatorPluginExt() {
 
     override fun getContextAllowlists(): Map<ScriptContext<*>, List<Allowlist>> {
         val whitelist = AllowlistLoader.loadFromResourceFiles(javaClass, "org.opensearch.alerting.txt")
@@ -182,6 +185,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
     lateinit var alertIndices: AlertIndices
     lateinit var clusterService: ClusterService
     lateinit var destinationMigrationCoordinator: DestinationMigrationCoordinator
+    lateinit var pluginClient: PluginClient
     var monitorTypeToMonitorRunners: MutableMap<String, RemoteMonitorRegistry> = mutableMapOf()
 
     override fun getRestHandlers(
@@ -283,6 +287,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
     ): Collection<Any> {
         // Need to figure out how to use the OpenSearch DI classes rather than handwiring things here.
         val settings = environment.settings()
+        pluginClient = PluginClient(client)
         val lockService = LockService(client, clusterService)
         alertIndices = AlertIndices(settings, client, threadPool, clusterService)
         val alertService = AlertService(client, xContentRegistry, alertIndices)
@@ -320,7 +325,10 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
         commentsIndices = CommentsIndices(environment.settings(), client, threadPool, clusterService)
         docLevelMonitorQueries = DocLevelMonitorQueries(client, clusterService)
         scheduler = JobScheduler(threadPool, runner)
-        sweeper = JobSweeper(environment.settings(), client, clusterService, threadPool, xContentRegistry, scheduler, ALERTING_JOB_TYPES)
+        sweeper = JobSweeper(
+            environment.settings(), client, clusterService, threadPool, xContentRegistry,
+            scheduler, ALERTING_JOB_TYPES
+        )
         destinationMigrationCoordinator = DestinationMigrationCoordinator(client, clusterService, threadPool, scheduledJobIndices)
         this.threadPool = threadPool
         this.clusterService = clusterService
@@ -351,8 +359,15 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             destinationMigrationCoordinator,
             lockService,
             alertService,
-            triggerService
+            triggerService,
+            pluginClient
         )
+    }
+
+    override fun assignSubject(pluginSubject: PluginSubject) {
+        // When security is not installed, the pluginSubject will still be assigned.
+        requireNotNull(pluginSubject)
+        pluginClient.setSubject(pluginSubject)
     }
 
     override fun getSettings(): List<Setting<*>> {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/PluginClient.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/PluginClient.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.alerting.util
+
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import org.opensearch.action.ActionRequest
+import org.opensearch.action.ActionType
+import org.opensearch.common.CheckedRunnable
+import org.opensearch.core.action.ActionListener
+import org.opensearch.core.action.ActionResponse
+import org.opensearch.identity.Subject
+import org.opensearch.transport.client.Client
+import org.opensearch.transport.client.FilterClient
+
+/**
+ * A special client for executing transport actions as this plugin's system subject.
+ */
+class PluginClient : FilterClient {
+    private var subject: Subject? = null
+
+    constructor(delegate: Client) : super(delegate)
+
+    constructor(delegate: Client, subject: Subject) : super(delegate) {
+        this.subject = subject
+    }
+
+    fun setSubject(subject: Subject) {
+        this.subject = subject
+    }
+
+    override fun <Request : ActionRequest?, Response : ActionResponse?> doExecute(
+        action: ActionType<Response?>?,
+        request: Request?,
+        listener: ActionListener<Response?>?
+    ) {
+        checkNotNull(subject) { "PluginClient is not initialized." }
+        threadPool().getThreadContext().newStoredContext(false).use { ctx ->
+            subject!!.runAs<RuntimeException?>(
+                CheckedRunnable {
+                    Companion.logger.info(
+                        "Running transport action with subject: {}",
+                        subject!!.getPrincipal().getName()
+                    )
+                    super.doExecute<Request?, Response?>(
+                        action,
+                        request,
+                        ActionListener.runBefore<Response?>(listener, CheckedRunnable<RuntimeException> { ctx.restore() })
+                    )
+                }
+            )
+        }
+    }
+
+    companion object {
+        private val logger: Logger = LogManager.getLogger(PluginClient::class.java)
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,10 @@ task ktlint(type: JavaExec, group: "verification") {
     description = "Check Kotlin code style."
     main = "com.pinterest.ktlint.Main"
     classpath = configurations.ktlint
+    jvmArgs = [
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+        "--add-opens=java.base/java.util=ALL-UNNAMED"
+    ]
     args "alerting/**/*.kt", "elastic-api/**/*.kt", "core/**/*.kt"
 }
 
@@ -78,6 +82,10 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
     description = "Fix Kotlin code style deviations."
     main = "com.pinterest.ktlint.Main"
     classpath = configurations.ktlint
+    jvmArgs = [
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+        "--add-opens=java.base/java.util=ALL-UNNAMED"
+    ]
     args "-F", "alerting/**/*.kt", "elastic-api/**/*.kt", "core/**/*.kt"
 }
 


### PR DESCRIPTION
### Description

This PR replaces usages of ThreadContext.stashContext with a replacement that enforces strong ownership over system indices. The reporting plugin can access the system indices it declares with SystemIndexPlugin.getSystemIndexDescriptors, but otherwise needs to declare additional perms like this: https://github.com/opensearch-project/geospatial/blob/main/src/main/resources/plugin-additional-permissions.yml

The replacement restricts what plugins can do inside a privileged context, but permits access to their own system indices.

This PR also attempts to replace usages of `scope.launch` and `client.suspendUntil` with async code prevent blocking operations.

### Related Issues
Resolves https://github.com/opensearch-project/opensearch-plugins/issues/238

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
