### PR TITLE
Revert "[Backport 2.19] Enabling alerting comments feature by defualt"

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
@@ -243,7 +243,7 @@ class AlertingSettings {
 
         val ALERTING_COMMENTS_ENABLED = Setting.boolSetting(
             "plugins.alerting.comments_enabled",
-            true,
+            false,
             Setting.Property.NodeScope, Setting.Property.Dynamic
         )
 


### PR DESCRIPTION
Reverts opensearch-project/alerting#1902

Release team explained that this commit shouldn't be backported for a patch release.