### PR TITLE
Fix CI check with security failing due to empty string in payload body

### DIFF
--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
@@ -1910,7 +1910,6 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         createTestIndex(index)
         createCustomIndexRole(role, index, clusterPermissions)
         createUserRolesMapping(role, arrayOf(user))
-        Thread.sleep(1000) // Allow security changes to propagate
     }
 
     fun createUserWithRoles(
@@ -1927,7 +1926,6 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
                 createUserRolesMapping(role, arrayOf(user))
             }
         }
-        Thread.sleep(1000) // Allow security changes to propagate
     }
 
     fun createUserWithDocLevelSecurityTestData(


### PR DESCRIPTION
### Description

This PR fixes the CI Check running integ tests with security that started failing due to new API validation logic in the security plugin to ensure that there are no empty strings in the body of a payload.

ref: https://github.com/opensearch-project/alerting/actions/runs/19771668916/job/56656855257?pr=1993

```
Suite: Test class org.opensearch.alerting.resthandler.SecureEmailAccountRestApiIT
  1> [2025-11-29T04:29:40,593][INFO ][o.o.a.r.SecureEmailAccountRestApiIT] [test search email accounts with an user without search email account role] There are still tasks running after this test that might break subsequent tests [indices:data/write/bulk[s], indices:data/write/bulk[s][p], indices:data/write/index].
  1> [2025-11-29T04:29:40,595][INFO ][o.o.a.r.SecureEmailAccountRestApiIT] [test search email accounts with an user without search email account role] after test
  2> REPRODUCE WITH: ./gradlew ':alerting:integTest' --tests 'org.opensearch.alerting.resthandler.SecureEmailAccountRestApiIT.test search email accounts with an user without search email account role' -Dtests.seed=AE8E123011533314 -Dtests.security.manager=false -Dtests.locale=yrl-CO -Dtests.timezone=Asia/Pyongyang -Druntime.java=21
  2> org.opensearch.client.ResponseException: method [PUT], host [https://127.0.0.1:37027/], URI [/_plugins/_security/api/roles/hr_role], status line [HTTP/2.0 400 Bad Request]
    {"status":"error","reason":"`null` or blank values are not allowed as json array elements"}
        at __randomizedtesting.SeedInfo.seed([AE8E123011533314:59F6D5E4EDA38E4F]:0)
        at app//org.opensearch.client.RestClient.convertResponse(RestClient.java:501)
        at app//org.opensearch.client.RestClient.performRequest(RestClient.java:384)
        at app//org.opensearch.client.RestClient.performRequest(RestClient.java:359)
        at app//org.opensearch.alerting.AlertingRestTestCase.createCustomIndexRole(AlertingRestTestCase.kt:1768)
        at app//org.opensearch.alerting.AlertingRestTestCase.createUserWithTestDataAndCustomRole(AlertingRestTestCase.kt:1918)
        at app//org.opensearch.alerting.resthandler.SecureEmailAccountRestApiIT.test search email accounts with an user without search email account role(SecureEmailAccountRestApiIT.kt:162)
```

### Related Issues

Resolves https://github.com/opensearch-project/alerting/issues/1956

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
