### PR TITLE
Update test CI  artifact naming to include Java version

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: alerting-plugin-${{ matrix.os }}
+          name: alerting-plugin-${{ matrix.os }}-${{ matrix.java }}
           path: alerting-artifacts
           overwrite: true
 
@@ -82,7 +82,7 @@ jobs:
       WORKING_DIR: ${{ matrix.working_directory }}.
     strategy:
       matrix:
-        java: [21, 24]
+        java: [21, 25]
         os: [ windows-latest, macos-latest ]
         include:
           - os: windows-latest
@@ -120,6 +120,6 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: alerting-plugin-${{ matrix.os }}
+          name: alerting-plugin-${{ matrix.os }}-${{ matrix.java }}
           path: alerting-artifacts
           overwrite: true


### PR DESCRIPTION
### Description

Adds Java version to artifact name so that uploads don't fail on conflict.

### Related Issues

Fixes test failures, see https://github.com/opensearch-project/alerting/actions/runs/19906096749/job/57062569909?pr=1996

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
