### PR TITLE
Preserve user when stashing thread context when sending alert notification messages.

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
@@ -23,6 +23,7 @@ import org.opensearch.alerting.util.destinationmigration.sendNotification
 import org.opensearch.alerting.util.isAllowed
 import org.opensearch.alerting.util.isTestAction
 import org.opensearch.alerting.util.use
+import org.opensearch.commons.ConfigConstants
 import org.opensearch.commons.alerting.model.ActionRunResult
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.MonitorRunResult
@@ -69,7 +70,10 @@ abstract class MonitorRunner {
             }
             if (!dryrun) {
                 val client = monitorCtx.client
-                client!!.threadPool().threadContext.stashContext().use {
+                val userStr = client!!.threadPool().threadContext
+                    .getTransient<String>(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT)
+                client.threadPool().threadContext.stashContext().use {
+                    client.threadPool().threadContext.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, userStr)
                     withClosableContext(
                         InjectorContextElement(
                             monitor.id,


### PR DESCRIPTION
### Description
This change fixes an authentication failure when monitors send email alerts via SMTP with STARTTLS encryption.

When a monitor was triggered during its scheduled execution, the notification failed to send with error `Can't send command to SMTP host`. However, the ExecuteMonitor API was not experiencing this same issue; it correctly sent the notification.

This was because the `TransportExecuteMonitorAction` was extracting the user context before `stashContext()` was called. 
https://github.com/opensearch-project/alerting/blob/main/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt#L67

When `stashContext()` is called on the thread context, it clears all transient values including the `OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT`. This caused subsequent SMTP operations to execute without proper authentication credentials, resulting in connection failures.

This PR adds code to preserve the user authentication context when stashing thread context during monitor execution. This ensures SMTP keystore credentials remain accessible when sending notifications.

The changes in this PR also align with the user context preservation strategy used by `NotificationApiUtils`.
https://github.com/opensearch-project/alerting/blob/main/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/NotificationApiUtils.kt#L81

### Related Issues
https://github.com/opensearch-project/alerting-dashboards-plugin/issues/1368

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
