### PR TITLE
Add filter by backend roles setting

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -432,7 +432,8 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             AlertingSettings.COMMENTS_MAX_CONTENT_SIZE,
             AlertingSettings.MAX_COMMENTS_PER_ALERT,
             AlertingSettings.MAX_COMMENTS_PER_NOTIFICATION,
-            AlertingSettings.NOTIFICATION_CONTEXT_RESULTS_ALLOWED_ROLES
+            AlertingSettings.NOTIFICATION_CONTEXT_RESULTS_ALLOWED_ROLES,
+            AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -527,7 +527,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             AlertingSettings.JOB_QUEUE_ACCOUNT_PROVIDER_TYPE,
             AlertingSettings.TARGET_TYPE_TO_SERVICE_NAME,
             AlertingSettings.TENANT_ACCOUNT_ID_HEADER,
-            AlertingSettings.TENANT_RESOURCE_ID_HEADER
+            AlertingSettings.TENANT_RESOURCE_ID_HEADER,
             AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -528,6 +528,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             AlertingSettings.TARGET_TYPE_TO_SERVICE_NAME,
             AlertingSettings.TENANT_ACCOUNT_ID_HEADER,
             AlertingSettings.TENANT_RESOURCE_ID_HEADER
+            AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -462,6 +462,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             AlertingSettings.REQUEST_TIMEOUT,
             AlertingSettings.MAX_ACTION_THROTTLE_VALUE,
             AlertingSettings.FILTER_BY_BACKEND_ROLES,
+            AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY,
             AlertingSettings.MAX_ACTIONABLE_ALERT_COUNT,
             LegacyOpenDistroAlertingSettings.INPUT_TIMEOUT,
             LegacyOpenDistroAlertingSettings.INDEX_TIMEOUT,
@@ -527,8 +528,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             AlertingSettings.JOB_QUEUE_ACCOUNT_PROVIDER_TYPE,
             AlertingSettings.TARGET_TYPE_TO_SERVICE_NAME,
             AlertingSettings.TENANT_ACCOUNT_ID_HEADER,
-            AlertingSettings.TENANT_RESOURCE_ID_HEADER,
-            AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY
+            AlertingSettings.TENANT_RESOURCE_ID_HEADER
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
@@ -302,5 +302,11 @@ class AlertingSettings {
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         )
+
+        val FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY = Setting.simpleString(
+            "plugins.alerting.filter_by_backend_roles_access_strategy",
+            "intersect",
+            Setting.Property.NodeScope, Setting.Property.Dynamic
+        )
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
@@ -305,8 +305,10 @@ class AlertingSettings {
 
         val FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY = Setting.simpleString(
             "plugins.alerting.filter_by_backend_roles_access_strategy",
-            "intersect",
-            Setting.Property.NodeScope, Setting.Property.Dynamic
+            FilterByBackendRolesAccessStrategy.INTERSECT.strategy,
+            FilterByBackendRolesAccessStrategyValidator(),
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
         )
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
@@ -483,5 +483,11 @@ class AlertingSettings {
             "plugins.alerting.tenant.resource_id_header.",
             Setting.Property.NodeScope, Setting.Property.Dynamic
         )
+
+        val FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY = Setting.simpleString(
+            "plugins.alerting.filter_by_backend_roles_access_strategy",
+            "intersect",
+            Setting.Property.NodeScope, Setting.Property.Dynamic
+        )
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
@@ -486,8 +486,10 @@ class AlertingSettings {
 
         val FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY = Setting.simpleString(
             "plugins.alerting.filter_by_backend_roles_access_strategy",
-            "intersect",
-            Setting.Property.NodeScope, Setting.Property.Dynamic
+            FilterByBackendRolesAccessStrategy.INTERSECT.strategy,
+            FilterByBackendRolesAccessStrategyValidator(),
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
         )
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
@@ -489,7 +489,8 @@ class AlertingSettings {
             FilterByBackendRolesAccessStrategy.INTERSECT.strategy,
             FilterByBackendRolesAccessStrategyValidator(),
             Setting.Property.NodeScope,
-            Setting.Property.Dynamic
+            Setting.Property.Dynamic,
+            Setting.Property.Sensitive
         )
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/FilterByBackendRolesAccessStrategy.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/FilterByBackendRolesAccessStrategy.kt
@@ -10,6 +10,11 @@ package org.opensearch.alerting.settings
  */
 enum class FilterByBackendRolesAccessStrategy(val strategy: String) {
     /**
+     * User backend roles must contain all resource backend roles to have access
+     */
+    ALL("all"),
+
+    /**
      * Backend roles must be exactly equal to have access
      */
     EXACT("exact"),
@@ -18,9 +23,4 @@ enum class FilterByBackendRolesAccessStrategy(val strategy: String) {
      * Backend roles must intersect to have access
      */
     INTERSECT("intersect"),
-
-    /**
-     * User backend roles must contain all resource backend roles to have access
-     */
-    ALL("all"),
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/FilterByBackendRolesAccessStrategy.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/FilterByBackendRolesAccessStrategy.kt
@@ -10,12 +10,17 @@ package org.opensearch.alerting.settings
  */
 enum class FilterByBackendRolesAccessStrategy(val strategy: String) {
     /**
+     * Backend roles must be exactly equal to have access
+     */
+    EXACT("exact"),
+
+    /**
      * Backend roles must intersect to have access
      */
     INTERSECT("intersect"),
 
     /**
-     * Backend roles must be exactly equal to have access
+     * User backend roles must contain all resource backend roles to have access
      */
     ALL("all"),
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/FilterByBackendRolesAccessStrategy.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/FilterByBackendRolesAccessStrategy.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.settings
+
+/**
+ * Defines the FilterByBackendRolesAccessStrategy
+ */
+enum class FilterByBackendRolesAccessStrategy(val strategy: String) {
+    /**
+     * Backend roles must intersect to have access
+     */
+    INTERSECT("intersect"),
+
+    /**
+     * Backend roles must be exactly equal to have access
+     */
+    ALL("all"),
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/FilterByBackendRolesAccessStrategyValidator.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/FilterByBackendRolesAccessStrategyValidator.kt
@@ -12,7 +12,7 @@ class FilterByBackendRolesAccessStrategyValidator : Setting.Validator<String> {
         val allStrategies: List<String> = FilterByBackendRolesAccessStrategy.entries.map { it.strategy }
 
         when (strategy) {
-            FilterByBackendRolesAccessStrategy.ALL.strategy
+            FilterByBackendRolesAccessStrategy.ALL.strategy,
             FilterByBackendRolesAccessStrategy.EXACT.strategy,
             FilterByBackendRolesAccessStrategy.INTERSECT.strategy -> {}
             else -> throw IllegalArgumentException(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/FilterByBackendRolesAccessStrategyValidator.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/FilterByBackendRolesAccessStrategyValidator.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.settings
+
+import org.opensearch.common.settings.Setting
+
+class FilterByBackendRolesAccessStrategyValidator : Setting.Validator<String> {
+    override fun validate(strategy: String) {
+        val allStrategies: List<String> = FilterByBackendRolesAccessStrategy.entries.map { it.strategy }
+
+        when (strategy) {
+            FilterByBackendRolesAccessStrategy.INTERSECT.strategy,
+            FilterByBackendRolesAccessStrategy.ALL.strategy -> {}
+            else -> throw IllegalArgumentException(
+                "Setting value must be one of [$allStrategies]"
+            )
+        }
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/FilterByBackendRolesAccessStrategyValidator.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/FilterByBackendRolesAccessStrategyValidator.kt
@@ -12,8 +12,9 @@ class FilterByBackendRolesAccessStrategyValidator : Setting.Validator<String> {
         val allStrategies: List<String> = FilterByBackendRolesAccessStrategy.entries.map { it.strategy }
 
         when (strategy) {
-            FilterByBackendRolesAccessStrategy.INTERSECT.strategy,
-            FilterByBackendRolesAccessStrategy.ALL.strategy -> {}
+            FilterByBackendRolesAccessStrategy.ALL.strategy
+            FilterByBackendRolesAccessStrategy.EXACT.strategy,
+            FilterByBackendRolesAccessStrategy.INTERSECT.strategy -> {}
             else -> throw IllegalArgumentException(
                 "Setting value must be one of [$allStrategies]"
             )

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/FilterByBackendRolesAccessStrategyValidator.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/FilterByBackendRolesAccessStrategyValidator.kt
@@ -11,13 +11,8 @@ class FilterByBackendRolesAccessStrategyValidator : Setting.Validator<String> {
     override fun validate(strategy: String) {
         val allStrategies: List<String> = FilterByBackendRolesAccessStrategy.entries.map { it.strategy }
 
-        when (strategy) {
-            FilterByBackendRolesAccessStrategy.ALL.strategy,
-            FilterByBackendRolesAccessStrategy.EXACT.strategy,
-            FilterByBackendRolesAccessStrategy.INTERSECT.strategy -> {}
-            else -> throw IllegalArgumentException(
-                "Setting value must be one of [$allStrategies]"
-            )
+        if (strategy.lowercase() !in allStrategies) {
+            throw IllegalArgumentException("Setting value must be one of [$allStrategies]")
         }
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
@@ -38,13 +38,13 @@ private val log = LogManager.getLogger(SecureTransportAction::class.java)
 interface SecureTransportAction {
 
     var filterByEnabled: Boolean
-    // var filterByAccessStrategy: String
+    var filterByAccessStrategy: String
 
     fun listenFilterBySettingChange(clusterService: ClusterService) {
         clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.FILTER_BY_BACKEND_ROLES) { filterByEnabled = it }
-        // clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY) {
-        //     filterByAccessStrategy = it
-        // }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY) {
+            filterByAccessStrategy = it
+        }
     }
 
     fun readUserFromThreadContext(client: Client): User? {
@@ -105,14 +105,13 @@ interface SecureTransportAction {
     }
 
     fun checkUserBackendRolesAccess(userBackendRoles: List<String>, resourceBackendRoles: List<String>): Boolean {
-        return !resourceBackendRoles.sorted().equals(userBackendRoles.sorted())
-        // if (filterByAccessStrategy == "intersect") {
-        //     return resourceBackendRoles.intersect(userBackendRoles).isEmpty()
-        // } else if (filterByAccessStrategy == "all") {
-        //     return !resourceBackendRoles.equals(userBackendRoles)
-        // }
-        // // TODO: this should never be reached
-        // return false
+        if (filterByAccessStrategy == "intersect") {
+            return resourceBackendRoles.intersect(userBackendRoles).isEmpty()
+        } else if (filterByAccessStrategy == "all") {
+            return !resourceBackendRoles.sorted().equals(userBackendRoles.sorted())
+        }
+        // TODO: this should never be reached
+        return false
     }
 
     /**

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
@@ -105,11 +105,11 @@ interface SecureTransportAction {
         return true
     }
 
-    fun checkUserBackendRolesAccess(userBackendRoles: List<String>, resourceBackendRoles: List<String>): Boolean {
+    fun doUserBackendRolesMatchResource(userBackendRoles: List<String>, resourceBackendRoles: List<String>): Boolean {
         if (filterByAccessStrategy == FilterByBackendRolesAccessStrategy.INTERSECT.strategy) {
-            return resourceBackendRoles.intersect(userBackendRoles).isEmpty()
+            return resourceBackendRoles.any { it in resourceBackendRoles }
         } else if (filterByAccessStrategy == FilterByBackendRolesAccessStrategy.ALL.strategy) {
-            return !resourceBackendRoles.sorted().equals(userBackendRoles.sorted())
+            return resourceBackendRoles.sorted().equals(userBackendRoles.sorted())
         }
         // Not sure if this is necessary, since there is a validator
         // on the setting itself
@@ -141,7 +141,7 @@ interface SecureTransportAction {
         if (
             resourceBackendRoles == null ||
             requesterBackendRoles == null ||
-            checkUserBackendRolesAccess(requesterBackendRoles, resourceBackendRoles)
+            !doUserBackendRolesMatchResource(requesterBackendRoles, resourceBackendRoles)
         ) {
             actionListener.onFailure(
                 AlertingException.wrap(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
@@ -107,7 +107,7 @@ interface SecureTransportAction {
 
     fun doUserBackendRolesMatchResource(userBackendRoles: List<String>, resourceBackendRoles: List<String>): Boolean {
         if (filterByAccessStrategy == FilterByBackendRolesAccessStrategy.INTERSECT.strategy) {
-            return resourceBackendRoles.any { it in resourceBackendRoles }
+            return resourceBackendRoles.any { it in userBackendRoles }
         } else if (filterByAccessStrategy == FilterByBackendRolesAccessStrategy.ALL.strategy) {
             return resourceBackendRoles.sorted().equals(userBackendRoles.sorted())
         }
@@ -116,7 +116,6 @@ interface SecureTransportAction {
         throw IllegalArgumentException(
             "Invalid filter by access strategy: $filterByAccessStrategy"
         )
-        return false
     }
 
     /**

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
@@ -38,13 +38,13 @@ private val log = LogManager.getLogger(SecureTransportAction::class.java)
 interface SecureTransportAction {
 
     var filterByEnabled: Boolean
-    val filterByAccessStrategy: String
+    // var filterByAccessStrategy: String
 
     fun listenFilterBySettingChange(clusterService: ClusterService) {
         clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.FILTER_BY_BACKEND_ROLES) { filterByEnabled = it }
-        clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY) {
-            filterByAccessStrategy = it
-        }
+        // clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY) {
+        //     filterByAccessStrategy = it
+        // }
     }
 
     fun readUserFromThreadContext(client: Client): User? {
@@ -105,13 +105,14 @@ interface SecureTransportAction {
     }
 
     fun checkUserBackendRolesAccess(userBackendRoles: List<String>, resourceBackendRoles: List<String>): Boolean {
-        if (filter_by_backend_roles_access_strategy == "intersect") {
-            return resourceBackendRoles.intersect(userBackendRoles).isEmpty()
-        } else if (filter_by_backend_roles_access_strategy == "all") {
-            return !resourceBackendRoles.equals(userBackendRoles)
-        }
-        // TODO: this should never be reached
-        return false
+        return !resourceBackendRoles.equals(userBackendRoles)
+        // if (filterByAccessStrategy == "intersect") {
+        //     return resourceBackendRoles.intersect(userBackendRoles).isEmpty()
+        // } else if (filterByAccessStrategy == "all") {
+        //     return !resourceBackendRoles.equals(userBackendRoles)
+        // }
+        // // TODO: this should never be reached
+        // return false
     }
 
     /**

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
@@ -8,6 +8,7 @@ package org.opensearch.alerting.transport
 import org.apache.logging.log4j.LogManager
 import org.opensearch.OpenSearchStatusException
 import org.opensearch.alerting.settings.AlertingSettings
+import org.opensearch.alerting.settings.FilterByBackendRolesAccessStrategy
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.commons.ConfigConstants
 import org.opensearch.commons.alerting.util.AlertingException
@@ -105,12 +106,16 @@ interface SecureTransportAction {
     }
 
     fun checkUserBackendRolesAccess(userBackendRoles: List<String>, resourceBackendRoles: List<String>): Boolean {
-        if (filterByAccessStrategy == "intersect") {
+        if (filterByAccessStrategy == FilterByBackendRolesAccessStrategy.INTERSECT.strategy) {
             return resourceBackendRoles.intersect(userBackendRoles).isEmpty()
-        } else if (filterByAccessStrategy == "all") {
+        } else if (filterByAccessStrategy == FilterByBackendRolesAccessStrategy.ALL.strategy) {
             return !resourceBackendRoles.sorted().equals(userBackendRoles.sorted())
         }
-        // TODO: this should never be reached
+        // Not sure if this is necessary, since there is a validator
+        // on the setting itself
+        throw IllegalArgumentException(
+            "Invalid filter by access strategy: $filterByAccessStrategy"
+        )
         return false
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
@@ -105,7 +105,7 @@ interface SecureTransportAction {
     }
 
     fun checkUserBackendRolesAccess(userBackendRoles: List<String>, resourceBackendRoles: List<String>): Boolean {
-        return !resourceBackendRoles.equals(userBackendRoles)
+        return !resourceBackendRoles.sorted().equals(userBackendRoles.sorted())
         // if (filterByAccessStrategy == "intersect") {
         //     return resourceBackendRoles.intersect(userBackendRoles).isEmpty()
         // } else if (filterByAccessStrategy == "all") {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
@@ -106,9 +106,11 @@ interface SecureTransportAction {
     }
 
     fun doUserBackendRolesMatchResource(userBackendRoles: List<String>, resourceBackendRoles: List<String>): Boolean {
-        if (filterByAccessStrategy == FilterByBackendRolesAccessStrategy.INTERSECT.strategy) {
+        if (filterByAccessStrategy == FilterByBackendRolesAccessStrategy.ALL.strategy) {
+            return userBackendRoles.containsAll(resourceBackendRoles)
+        } else if (filterByAccessStrategy == FilterByBackendRolesAccessStrategy.INTERSECT.strategy) {
             return resourceBackendRoles.any { it in userBackendRoles }
-        } else if (filterByAccessStrategy == FilterByBackendRolesAccessStrategy.ALL.strategy) {
+        } else if (filterByAccessStrategy == FilterByBackendRolesAccessStrategy.EXACT.strategy) {
             return resourceBackendRoles.sorted().equals(userBackendRoles.sorted())
         }
         // Not sure if this is necessary, since there is a validator

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
@@ -38,9 +38,13 @@ private val log = LogManager.getLogger(SecureTransportAction::class.java)
 interface SecureTransportAction {
 
     var filterByEnabled: Boolean
+    val filterByAccessStrategy: String
 
     fun listenFilterBySettingChange(clusterService: ClusterService) {
         clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.FILTER_BY_BACKEND_ROLES) { filterByEnabled = it }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY) {
+            filterByAccessStrategy = it
+        }
     }
 
     fun readUserFromThreadContext(client: Client): User? {
@@ -100,6 +104,16 @@ interface SecureTransportAction {
         return true
     }
 
+    fun checkUserBackendRolesAccess(userBackendRoles: List<String>, resourceBackendRoles: List<String>): Boolean {
+        if (filter_by_backend_roles_access_strategy == "intersect") {
+            return resourceBackendRoles.intersect(userBackendRoles).isEmpty()
+        } else if (filter_by_backend_roles_access_strategy == "all") {
+            return !resourceBackendRoles.equals(userBackendRoles)
+        }
+        // TODO: this should never be reached
+        return false
+    }
+
     /**
      * If FilterBy is enabled, this function verifies that the requester user has FilterBy permissions to access
      * the resource. If FilterBy is disabled, we will assume the user has permissions and return true.
@@ -122,7 +136,7 @@ interface SecureTransportAction {
         if (
             resourceBackendRoles == null ||
             requesterBackendRoles == null ||
-            resourceBackendRoles.intersect(requesterBackendRoles).isEmpty()
+            checkUserBackendRolesAccess(requesterBackendRoles, resourceBackendRoles)
         ) {
             actionListener.onFailure(
                 AlertingException.wrap(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/SecureTransportAction.kt
@@ -111,7 +111,7 @@ interface SecureTransportAction {
         } else if (filterByAccessStrategy == FilterByBackendRolesAccessStrategy.INTERSECT.strategy) {
             return resourceBackendRoles.any { it in userBackendRoles }
         } else if (filterByAccessStrategy == FilterByBackendRolesAccessStrategy.EXACT.strategy) {
-            return resourceBackendRoles.sorted().equals(userBackendRoles.sorted())
+            return resourceBackendRoles.toSet().equals(userBackendRoles.toSet())
         }
         // Not sure if this is necessary, since there is a validator
         // on the setting itself

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
@@ -124,7 +124,11 @@ class TransportAcknowledgeAlertAction @Inject constructor(
                         AcknowledgeHandler(client, actionListener, request).start(monitor)
                     } else {
                         actionListener.onFailure(
-                            AlertingException("Not allowed to acknowledge alerts for this monitor", RestStatus.FORBIDDEN, IllegalStateException())
+                            AlertingException(
+                                "Not allowed to acknowledge alerts for this monitor",
+                                RestStatus.FORBIDDEN,
+                                IllegalStateException()
+                            )
                         )
                     }
                 } catch (e: Exception) {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
@@ -8,6 +8,8 @@ package org.opensearch.alerting.transport
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.withContext
 import org.apache.logging.log4j.LogManager
 import org.opensearch.ResourceNotFoundException
 import org.opensearch.action.ActionRequest
@@ -25,7 +27,6 @@ import org.opensearch.common.settings.Settings
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
-import org.opensearch.commons.ConfigConstants
 import org.opensearch.commons.alerting.action.AcknowledgeAlertRequest
 import org.opensearch.commons.alerting.action.AcknowledgeAlertResponse
 import org.opensearch.commons.alerting.action.AlertingActions
@@ -90,48 +91,43 @@ class TransportAcknowledgeAlertAction @Inject constructor(
         val request = acknowledgeAlertRequest as? AcknowledgeAlertRequest
             ?: recreateObject(acknowledgeAlertRequest) { AcknowledgeAlertRequest(it) }
         val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
-        log.info("TransportAcknowledgeAlertAction client: $client")
-
-        val userStr = client.threadPool().threadContext.getTransient<String>(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT)
 
         client.threadPool().threadContext.stashContext().use {
-            log.info("TransportAcknowledgeAlertAction user: $userStr")
-
             scope.launch(TenantContext(tenantId)) {
-                // Pass the user from the acknowledge alert action client to the
-                // client for getting a monitor so that checks by backend role
-                // can be performed, if enabled.
-                if (userStr.isNotBlank()) {
-                    log.info("passing on user $userStr from acknowledge alert client to client for getting monitor")
-                    transportGetMonitorAction.client.threadPool().threadContext
-                        .putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, userStr)
-                }
+                val singleThreadContext = newSingleThreadContext("TransportAcknowledgeAlertAction")
+                withContext(singleThreadContext) {
+                    it.restore()
+                    try {
+                        var getMonitorResponse: GetMonitorResponse =
+                            transportGetMonitorAction.client.suspendUntil {
+                                val getMonitorRequest = GetMonitorRequest(
+                                    monitorId = request.monitorId,
+                                    -3L,
+                                    RestRequest.Method.GET,
+                                    FetchSourceContext.FETCH_SOURCE
+                                )
+                                execute(AlertingActions.GET_MONITOR_ACTION_TYPE, getMonitorRequest, it)
+                            }
 
-                val getMonitorResponse: GetMonitorResponse =
-                    transportGetMonitorAction.client.suspendUntil {
-                        val getMonitorRequest = GetMonitorRequest(
-                            monitorId = request.monitorId,
-                            -3L,
-                            RestRequest.Method.GET,
-                            FetchSourceContext.FETCH_SOURCE
-                        )
-                        execute(AlertingActions.GET_MONITOR_ACTION_TYPE, getMonitorRequest, it)
-                    }
-                log.info("get monitor response: $getMonitorResponse")
-                if (getMonitorResponse.monitor == null) {
-                    actionListener.onFailure(
-                        AlertingException.wrap(
-                            ResourceNotFoundException(
-                                String.format(
-                                    Locale.ROOT,
-                                    "No monitor found with id [%s]",
-                                    request.monitorId
+                        if (getMonitorResponse.monitor == null) {
+                            actionListener.onFailure(
+                                AlertingException.wrap(
+                                    ResourceNotFoundException(
+                                        String.format(
+                                            Locale.ROOT,
+                                            "No monitor found with id [%s]",
+                                            request.monitorId
+                                        )
+                                    )
                                 )
                             )
-                        )
-                    )
-                } else {
-                    AcknowledgeHandler(client, actionListener, request).start(getMonitorResponse.monitor!!)
+                        } else {
+                            AcknowledgeHandler(client, actionListener, request).start(getMonitorResponse.monitor!!)
+                        }
+                    } catch (e: Exception) {
+                        log.error("Failed to launch acknowledge handler", e)
+                        actionListener.onFailure(e)
+                    }
                 }
             }
         }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
@@ -122,6 +122,10 @@ class TransportAcknowledgeAlertAction @Inject constructor(
 
                     if (canAccess) {
                         AcknowledgeHandler(client, actionListener, request).start(monitor)
+                    } else {
+                        actionListener.onFailure(
+                            AlertingException("Not allowed to acknowledge alerts for this monitor", RestStatus.FORBIDDEN, IllegalStateException())
+                        )
                     }
                 } catch (e: Exception) {
                     log.error("Failed to launch acknowledge handler", e)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
@@ -94,14 +94,15 @@ class TransportAcknowledgeAlertAction @Inject constructor(
 
         client.threadPool().threadContext.stashContext().use {
             scope.launch(TenantContext(tenantId)) {
-                val singleThreadContext = newSingleThreadContext("TransportAcknowledgeAlertAction")
-                withContext(singleThreadContext) {
-                    // in the case where filter by backend role is enabled, we need the user context
-                    // which is stashed via `stashContext()` above  to be restored here so that it will be
-                    // used in the get monitor request.
-                    it.restore()
-                    try {
-                        var getMonitorResponse: GetMonitorResponse =
+                try {
+                    val singleThreadContext = newSingleThreadContext("TransportAcknowledgeAlertAction")
+                    var getMonitorResponse: GetMonitorResponse? = null
+                    withContext(singleThreadContext) {
+                        // in the case where filter by backend role is enabled, we need the user context
+                        // which is stashed via `stashContext()` above  to be restored here so that it will be
+                        // used in the get monitor request.
+                        it.restore()
+                        getMonitorResponse =
                             transportGetMonitorAction.client.suspendUntil {
                                 val getMonitorRequest = GetMonitorRequest(
                                     monitorId = request.monitorId,
@@ -111,29 +112,27 @@ class TransportAcknowledgeAlertAction @Inject constructor(
                                 )
                                 execute(AlertingActions.GET_MONITOR_ACTION_TYPE, getMonitorRequest, it)
                             }
-                        if (getMonitorResponse.monitor == null) {
-                            actionListener.onFailure(
-                                AlertingException.wrap(
-                                    ResourceNotFoundException(
-                                        String.format(
-                                            Locale.ROOT,
-                                            "No monitor found with id [%s]",
-                                            request.monitorId
-                                        )
+                    }
+                    if (getMonitorResponse == null || getMonitorResponse?.monitor == null) {
+                        actionListener.onFailure(
+                            AlertingException.wrap(
+                                ResourceNotFoundException(
+                                    String.format(
+                                        Locale.ROOT,
+                                        "No monitor found with id [%s]",
+                                        request.monitorId
                                     )
                                 )
                             )
-                        } else {
-                            // explicitly stash the context, including user information, since AcknowledgeHandler
-                            // should NOT act as the authenticated user, if any
-                            client.threadPool().threadContext.stashContext().use {
-                                AcknowledgeHandler(client, actionListener, request).start(getMonitorResponse.monitor!!)
-                            }
+                        )
+                    } else {
+                        getMonitorResponse?.let { getMonitorResponseSafe ->
+                            AcknowledgeHandler(client, actionListener, request).start(getMonitorResponseSafe.monitor!!)
                         }
-                    } catch (e: Exception) {
-                        log.error("Failed to launch acknowledge handler", e)
-                        actionListener.onFailure(e)
                     }
+                } catch (e: Exception) {
+                    log.error("Failed to launch acknowledge handler", e)
+                    actionListener.onFailure(e)
                 }
             }
         }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
@@ -117,6 +117,7 @@ class TransportAcknowledgeAlertAction @Inject constructor(
                         )
                         execute(AlertingActions.GET_MONITOR_ACTION_TYPE, getMonitorRequest, it)
                     }
+                log.info("get monitor response: $getMonitorResponse")
                 if (getMonitorResponse.monitor == null) {
                     actionListener.onFailure(
                         AlertingException.wrap(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
@@ -25,6 +25,7 @@ import org.opensearch.common.settings.Settings
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
+import org.opensearch.commons.ConfigConstants
 import org.opensearch.commons.alerting.action.AcknowledgeAlertRequest
 import org.opensearch.commons.alerting.action.AcknowledgeAlertResponse
 import org.opensearch.commons.alerting.action.AlertingActions
@@ -89,8 +90,23 @@ class TransportAcknowledgeAlertAction @Inject constructor(
         val request = acknowledgeAlertRequest as? AcknowledgeAlertRequest
             ?: recreateObject(acknowledgeAlertRequest) { AcknowledgeAlertRequest(it) }
         val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+        log.info("TransportAcknowledgeAlertAction client: $client")
+
+        val userStr = client.threadPool().threadContext.getTransient<String>(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT)
+
         client.threadPool().threadContext.stashContext().use {
+            log.info("TransportAcknowledgeAlertAction user: $userStr")
+
             scope.launch(TenantContext(tenantId)) {
+                // Pass the user from the acknowledge alert action client to the
+                // client for getting a monitor so that checks by backend role
+                // can be performed, if enabled.
+                if (userStr.isNotBlank()) {
+                    log.info("passing on user $userStr from acknowledge alert client to client for getting monitor")
+                    transportGetMonitorAction.client.threadPool().threadContext
+                        .putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, userStr)
+                }
+
                 val getMonitorResponse: GetMonitorResponse =
                     transportGetMonitorAction.client.suspendUntil {
                         val getMonitorRequest = GetMonitorRequest(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
@@ -8,8 +8,6 @@ package org.opensearch.alerting.transport
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.newSingleThreadContext
-import kotlinx.coroutines.withContext
 import org.apache.logging.log4j.LogManager
 import org.opensearch.ResourceNotFoundException
 import org.opensearch.action.ActionRequest
@@ -17,7 +15,6 @@ import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.alerting.AlertingPlugin
-import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.util.await
 import org.opensearch.alerting.util.use
@@ -30,13 +27,13 @@ import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.alerting.action.AcknowledgeAlertRequest
 import org.opensearch.commons.alerting.action.AcknowledgeAlertResponse
 import org.opensearch.commons.alerting.action.AlertingActions
-import org.opensearch.commons.alerting.action.GetMonitorRequest
-import org.opensearch.commons.alerting.action.GetMonitorResponse
 import org.opensearch.commons.alerting.model.Alert
 import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.commons.alerting.util.optionalTimeField
 import org.opensearch.commons.utils.TenantContext
+import org.opensearch.commons.utils.currentTenantId
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.xcontent.NamedXContentRegistry
@@ -47,13 +44,12 @@ import org.opensearch.index.query.QueryBuilders
 import org.opensearch.remote.metadata.client.BulkDataObjectRequest
 import org.opensearch.remote.metadata.client.BulkDataObjectResponse
 import org.opensearch.remote.metadata.client.DeleteDataObjectRequest
+import org.opensearch.remote.metadata.client.GetDataObjectRequest
 import org.opensearch.remote.metadata.client.PutDataObjectRequest
 import org.opensearch.remote.metadata.client.SdkClient
 import org.opensearch.remote.metadata.client.SearchDataObjectRequest
 import org.opensearch.remote.metadata.client.UpdateDataObjectRequest
-import org.opensearch.rest.RestRequest
 import org.opensearch.search.builder.SearchSourceBuilder
-import org.opensearch.search.fetch.subphase.FetchSourceContext
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService
 import org.opensearch.transport.client.Client
@@ -74,13 +70,18 @@ class TransportAcknowledgeAlertAction @Inject constructor(
     val sdkClient: SdkClient
 ) : HandledTransportAction<ActionRequest, AcknowledgeAlertResponse>(
     AlertingActions.ACKNOWLEDGE_ALERTS_ACTION_NAME, transportService, actionFilters, ::AcknowledgeAlertRequest
-) {
+),
+    SecureTransportAction {
+
+    @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     @Volatile
     private var isAlertHistoryEnabled = AlertingSettings.ALERT_HISTORY_ENABLED.get(settings)
 
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.ALERT_HISTORY_ENABLED) { isAlertHistoryEnabled = it }
+        listenFilterBySettingChange(clusterService)
     }
 
     override fun doExecute(
@@ -90,30 +91,18 @@ class TransportAcknowledgeAlertAction @Inject constructor(
     ) {
         val request = acknowledgeAlertRequest as? AcknowledgeAlertRequest
             ?: recreateObject(acknowledgeAlertRequest) { AcknowledgeAlertRequest(it) }
-        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+        val user = readUserFromThreadContext(client)
 
+        if (!validateUserBackendRoles(user, actionListener)) {
+            return
+        }
+
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
         client.threadPool().threadContext.stashContext().use {
             scope.launch(TenantContext(tenantId)) {
                 try {
-                    val singleThreadContext = newSingleThreadContext("TransportAcknowledgeAlertAction")
-                    var getMonitorResponse: GetMonitorResponse? = null
-                    withContext(singleThreadContext) {
-                        // in the case where filter by backend role is enabled, we need the user context
-                        // which is stashed via `stashContext()` above  to be restored here so that it will be
-                        // used in the get monitor request.
-                        it.restore()
-                        getMonitorResponse =
-                            transportGetMonitorAction.client.suspendUntil {
-                                val getMonitorRequest = GetMonitorRequest(
-                                    monitorId = request.monitorId,
-                                    -3L,
-                                    RestRequest.Method.GET,
-                                    FetchSourceContext.FETCH_SOURCE
-                                )
-                                execute(AlertingActions.GET_MONITOR_ACTION_TYPE, getMonitorRequest, it)
-                            }
-                    }
-                    if (getMonitorResponse == null || getMonitorResponse?.monitor == null) {
+                    val monitor = getMonitor(request.monitorId)
+                    if (monitor == null) {
                         actionListener.onFailure(
                             AlertingException.wrap(
                                 ResourceNotFoundException(
@@ -125,10 +114,14 @@ class TransportAcknowledgeAlertAction @Inject constructor(
                                 )
                             )
                         )
-                    } else {
-                        getMonitorResponse?.let { getMonitorResponseSafe ->
-                            AcknowledgeHandler(client, actionListener, request).start(getMonitorResponseSafe.monitor!!)
-                        }
+                        return@launch
+                    }
+
+                    val canAccess = user == null || !doFilterForUser(user) ||
+                        checkUserPermissionsWithResource(user, monitor.user, actionListener, "monitor", request.monitorId)
+
+                    if (canAccess) {
+                        AcknowledgeHandler(client, actionListener, request).start(monitor)
                     }
                 } catch (e: Exception) {
                     log.error("Failed to launch acknowledge handler", e)
@@ -136,6 +129,25 @@ class TransportAcknowledgeAlertAction @Inject constructor(
                 }
             }
         }
+    }
+
+    private suspend fun getMonitor(monitorId: String): Monitor? {
+        val tenantId = currentTenantId()
+        val getRequest = GetDataObjectRequest.builder()
+            .index(ScheduledJob.SCHEDULED_JOBS_INDEX)
+            .id(monitorId)
+            .tenantId(tenantId)
+            .build()
+        val response = sdkClient.getDataObject(getRequest)
+        val getResponse = response.getResponse()
+        if (getResponse == null || !getResponse.isExists) {
+            return null
+        }
+        val xcp = XContentHelper.createParser(
+            xContentRegistry, LoggingDeprecationHandler.INSTANCE,
+            getResponse.sourceAsBytesRef, XContentType.JSON
+        )
+        return ScheduledJob.parse(xcp, getResponse.id, getResponse.version) as Monitor
     }
 
     inner class AcknowledgeHandler(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
@@ -96,6 +96,9 @@ class TransportAcknowledgeAlertAction @Inject constructor(
             scope.launch(TenantContext(tenantId)) {
                 val singleThreadContext = newSingleThreadContext("TransportAcknowledgeAlertAction")
                 withContext(singleThreadContext) {
+                    // in the case where filter by backend role is enabled, we need the user context
+                    // which is stashed via `stashContext()` above  to be restored here so that it will be
+                    // used in the get monitor request.
                     it.restore()
                     try {
                         var getMonitorResponse: GetMonitorResponse =
@@ -108,7 +111,6 @@ class TransportAcknowledgeAlertAction @Inject constructor(
                                 )
                                 execute(AlertingActions.GET_MONITOR_ACTION_TYPE, getMonitorRequest, it)
                             }
-
                         if (getMonitorResponse.monitor == null) {
                             actionListener.onFailure(
                                 AlertingException.wrap(
@@ -122,7 +124,11 @@ class TransportAcknowledgeAlertAction @Inject constructor(
                                 )
                             )
                         } else {
-                            AcknowledgeHandler(client, actionListener, request).start(getMonitorResponse.monitor!!)
+                            // explicitly stash the context, including user information, since AcknowledgeHandler
+                            // should NOT act as the authenticated user, if any
+                            client.threadPool().threadContext.stashContext().use {
+                                AcknowledgeHandler(client, actionListener, request).start(getMonitorResponse.monitor!!)
+                            }
                         }
                     } catch (e: Exception) {
                         log.error("Failed to launch acknowledge handler", e)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
@@ -36,6 +36,7 @@ import org.opensearch.commons.utils.TenantContext
 import org.opensearch.commons.utils.currentTenantId
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.action.ActionListener
+import org.opensearch.core.rest.RestStatus
 import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.core.xcontent.ToXContentObject
 import org.opensearch.core.xcontent.XContentParser

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteAlertingCommentAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteAlertingCommentAction.kt
@@ -60,6 +60,7 @@ class TransportDeleteAlertingCommentAction @Inject constructor(
 
     @Volatile private var alertingCommentsEnabled = AlertingSettings.ALERTING_COMMENTS_ENABLED.get(settings)
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.ALERTING_COMMENTS_ENABLED) {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteAlertingCommentAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteAlertingCommentAction.kt
@@ -63,6 +63,7 @@ class TransportDeleteAlertingCommentAction @Inject constructor(
 
     @Volatile private var alertingCommentsEnabled = AlertingSettings.ALERTING_COMMENTS_ENABLED.get(settings)
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.ALERTING_COMMENTS_ENABLED) {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
@@ -56,6 +56,7 @@ class TransportDeleteMonitorAction @Inject constructor(
     SecureTransportAction {
 
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     init {
         listenFilterBySettingChange(clusterService)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
@@ -65,6 +65,7 @@ class TransportDeleteMonitorAction @Inject constructor(
     @Volatile private var externalSchedulerEnabled = AlertingSettings.EXTERNAL_SCHEDULER_ENABLED.get(settings)
     @Volatile private var externalSchedulerAccountId = AlertingSettings.EXTERNAL_SCHEDULER_ACCOUNT_ID.get(settings)
     @Volatile private var externalSchedulerRoleName = AlertingSettings.EXTERNAL_SCHEDULER_ROLE_NAME.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.EXTERNAL_SCHEDULER_ENABLED) {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt
@@ -83,6 +83,7 @@ class TransportDeleteWorkflowAction @Inject constructor(
     private val log = LogManager.getLogger(javaClass)
 
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     init {
         listenFilterBySettingChange(clusterService)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt
@@ -85,6 +85,7 @@ class TransportDeleteWorkflowAction @Inject constructor(
     private val log = LogManager.getLogger(javaClass)
 
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
@@ -196,6 +196,7 @@ class TransportDocLevelMonitorFanOutAction
 
     @Volatile
     override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     override fun doExecute(
         task: Task,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
@@ -201,6 +201,7 @@ class TransportDocLevelMonitorFanOutAction
 
     @Volatile
     override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     override fun doExecute(
         task: Task,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
@@ -73,6 +73,9 @@ class TransportExecuteMonitorAction @Inject constructor(
 
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
 
+    @Volatile
+    override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
+
     private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
 
     init {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
@@ -73,6 +73,7 @@ class TransportGetAlertsAction @Inject constructor(
 
     @Volatile
     override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     init {
         listenFilterBySettingChange(clusterService)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
@@ -78,6 +78,7 @@ class TransportGetAlertsAction @Inject constructor(
 
     @Volatile
     override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     init {
         listenFilterBySettingChange(clusterService)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetDestinationsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetDestinationsAction.kt
@@ -57,6 +57,7 @@ class TransportGetDestinationsAction @Inject constructor(
     SecureTransportAction {
 
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     init {
         listenFilterBySettingChange(clusterService)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetDestinationsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetDestinationsAction.kt
@@ -60,6 +60,7 @@ class TransportGetDestinationsAction @Inject constructor(
     SecureTransportAction {
 
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetFindingsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetFindingsAction.kt
@@ -71,6 +71,7 @@ class TransportGetFindingsSearchAction @Inject constructor(
     SecureTransportAction {
 
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     init {
         listenFilterBySettingChange(clusterService)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetFindingsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetFindingsAction.kt
@@ -75,6 +75,7 @@ class TransportGetFindingsSearchAction @Inject constructor(
     SecureTransportAction {
 
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetMonitorAction.kt
@@ -90,6 +90,9 @@ class TransportGetMonitorAction @Inject constructor(
             return
         }
 
+        log.info("FOOBAR")
+        println("FOOBAR2")
+
         /*
          * Remove security context before you call elasticsearch api's. By this time, permissions required
          * to call this api are validated.

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetMonitorAction.kt
@@ -90,9 +90,6 @@ class TransportGetMonitorAction @Inject constructor(
             return
         }
 
-        log.info("FOOBAR")
-        println("FOOBAR2")
-
         /*
          * Remove security context before you call elasticsearch api's. By this time, permissions required
          * to call this api are validated.

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetMonitorAction.kt
@@ -69,6 +69,7 @@ class TransportGetMonitorAction @Inject constructor(
 
     @Volatile
     override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     init {
         listenFilterBySettingChange(clusterService)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetMonitorAction.kt
@@ -72,6 +72,7 @@ class TransportGetMonitorAction @Inject constructor(
 
     @Volatile
     override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetRemoteIndexesAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetRemoteIndexesAction.kt
@@ -61,6 +61,7 @@ class TransportGetRemoteIndexesAction @Inject constructor(
     SecureTransportAction {
 
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     @Volatile private var remoteMonitoringEnabled = CROSS_CLUSTER_MONITORING_ENABLED.get(settings)
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetRemoteIndexesAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetRemoteIndexesAction.kt
@@ -63,6 +63,7 @@ class TransportGetRemoteIndexesAction @Inject constructor(
     SecureTransportAction {
 
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     @Volatile private var remoteMonitoringEnabled = CROSS_CLUSTER_MONITORING_ENABLED.get(settings)
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAction.kt
@@ -48,6 +48,7 @@ class TransportGetWorkflowAction @Inject constructor(
     private val log = LogManager.getLogger(javaClass)
 
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     init {
         listenFilterBySettingChange(clusterService)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAction.kt
@@ -48,6 +48,7 @@ class TransportGetWorkflowAction @Inject constructor(
     private val log = LogManager.getLogger(javaClass)
 
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAlertsAction.kt
@@ -70,6 +70,9 @@ class TransportGetWorkflowAlertsAction @Inject constructor(
     override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
 
     @Volatile
+    override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
+
+    @Volatile
     private var isAlertHistoryEnabled = AlertingSettings.ALERT_HISTORY_ENABLED.get(settings)
 
     init {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAlertsAction.kt
@@ -76,6 +76,9 @@ class TransportGetWorkflowAlertsAction @Inject constructor(
     override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
 
     @Volatile
+    override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
+
+    @Volatile
     private var isAlertHistoryEnabled = AlertingSettings.ALERT_HISTORY_ENABLED.get(settings)
 
     private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexAlertingCommentAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexAlertingCommentAction.kt
@@ -86,6 +86,7 @@ constructor(
     @Volatile private var indexTimeout = INDEX_TIMEOUT.get(settings)
 
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(ALERTING_COMMENTS_ENABLED) { alertingCommentsEnabled = it }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexAlertingCommentAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexAlertingCommentAction.kt
@@ -88,6 +88,7 @@ constructor(
     @Volatile private var indexTimeout = INDEX_TIMEOUT.get(settings)
 
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(ALERTING_COMMENTS_ENABLED) { alertingCommentsEnabled = it }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -111,6 +111,7 @@ class TransportIndexMonitorAction @Inject constructor(
     @Volatile private var maxActionThrottle = MAX_ACTION_THROTTLE_VALUE.get(settings)
     @Volatile private var allowList = ALLOW_LIST.get(settings)
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(ALERTING_MAX_MONITORS) { maxMonitors = it }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -156,6 +156,7 @@ class TransportIndexMonitorAction @Inject constructor(
     @Volatile private var jobQueueName = AlertingSettings.JOB_QUEUE_NAME.get(settings)
     @Volatile private var externalSchedulerRoleName = AlertingSettings.EXTERNAL_SCHEDULER_ROLE_NAME.get(settings)
     @Volatile private var externalSchedulerExecutionRoleName = AlertingSettings.EXTERNAL_SCHEDULER_EXECUTION_ROLE_NAME.get(settings)
+    @Volatile override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
 
     private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
@@ -119,6 +119,9 @@ class TransportIndexWorkflowAction @Inject constructor(
     @Volatile
     override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
 
+    @Volatile
+    override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
+
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(ALERTING_MAX_MONITORS) { maxMonitors = it }
         clusterService.clusterSettings.addSettingsUpdateConsumer(REQUEST_TIMEOUT) { requestTimeout = it }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
@@ -126,6 +126,9 @@ class TransportIndexWorkflowAction @Inject constructor(
     @Volatile
     override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
 
+    @Volatile
+    override var filterByAccessStrategy = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
+
     private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
 
     init {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchAlertingCommentAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchAlertingCommentAction.kt
@@ -63,6 +63,8 @@ class TransportSearchAlertingCommentAction @Inject constructor(
 
     @Volatile private var alertingCommentsEnabled = AlertingSettings.ALERTING_COMMENTS_ENABLED.get(settings)
     @Volatile override var filterByEnabled: Boolean = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy: String = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
+
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.ALERTING_COMMENTS_ENABLED) {
             alertingCommentsEnabled = it

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchAlertingCommentAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchAlertingCommentAction.kt
@@ -69,6 +69,8 @@ class TransportSearchAlertingCommentAction @Inject constructor(
 
     @Volatile private var alertingCommentsEnabled = AlertingSettings.ALERTING_COMMENTS_ENABLED.get(settings)
     @Volatile override var filterByEnabled: Boolean = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile override var filterByAccessStrategy: String = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
+
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.ALERTING_COMMENTS_ENABLED) {
             alertingCommentsEnabled = it

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
@@ -62,6 +62,9 @@ class TransportSearchMonitorAction @Inject constructor(
     SecureTransportAction {
     @Volatile
     override var filterByEnabled: Boolean = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile
+    override var filterByAccessStrategy: String = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
+
     init {
         listenFilterBySettingChange(clusterService)
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
@@ -64,6 +64,9 @@ class TransportSearchMonitorAction @Inject constructor(
     SecureTransportAction {
     @Volatile
     override var filterByEnabled: Boolean = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile
+    override var filterByAccessStrategy: String = AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.get(settings)
+
     init {
         listenFilterBySettingChange(clusterService)
     }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
@@ -1482,7 +1482,7 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         assertEquals(updateResponse.statusLine.toString(), 200, updateResponse.statusLine.statusCode)
     }
 
-    fun setFilterByBackendRolesStrategy(strategy String) {
+    fun setFilterByBackendRolesStrategy(strategy: String) {
         val updateResponse = client().makeRequest(
             "PUT", "_cluster/settings",
             emptyMap(),

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
@@ -1482,6 +1482,20 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         assertEquals(updateResponse.statusLine.toString(), 200, updateResponse.statusLine.statusCode)
     }
 
+    fun setFilterByBackendRolesStrategy(strategy String) {
+        val updateResponse = client().makeRequest(
+            "PUT", "_cluster/settings",
+            emptyMap(),
+            StringEntity(
+                XContentFactory.jsonBuilder().startObject().field("persistent")
+                    .startObject().field(AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.key, strategy).endObject()
+                    .endObject().string(),
+                ContentType.APPLICATION_JSON
+            )
+        )
+        assertEquals(updateResponse.statusLine.toString(), 200, updateResponse.statusLine.statusCode)
+    }
+
     fun disableFilterBy() {
         val updateResponse = client().makeRequest(
             "PUT", "_cluster/settings",

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
@@ -1500,6 +1500,20 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         assertEquals(updateResponse.statusLine.toString(), 200, updateResponse.statusLine.statusCode)
     }
 
+    fun setFilterByBackendRolesStrategy(strategy String) {
+        val updateResponse = client().makeRequest(
+            "PUT", "_cluster/settings",
+            emptyMap(),
+            StringEntity(
+                XContentFactory.jsonBuilder().startObject().field("persistent")
+                    .startObject().field(AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY.key, strategy).endObject()
+                    .endObject().string(),
+                ContentType.APPLICATION_JSON
+            )
+        )
+        assertEquals(updateResponse.statusLine.toString(), 200, updateResponse.statusLine.statusCode)
+    }
+
     fun disableFilterBy() {
         val updateResponse = client().makeRequest(
             "PUT", "_cluster/settings",

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
@@ -1500,7 +1500,7 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         assertEquals(updateResponse.statusLine.toString(), 200, updateResponse.statusLine.statusCode)
     }
 
-    fun setFilterByBackendRolesStrategy(strategy String) {
+    fun setFilterByBackendRolesStrategy(strategy: String) {
         val updateResponse = client().makeRequest(
             "PUT", "_cluster/settings",
             emptyMap(),

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
@@ -774,6 +774,21 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         return response
     }
 
+    protected fun acknowledgeAlertsWithClient(client: RestClient, monitor: Monitor, vararg alerts: Alert): Response {
+        val request = XContentFactory.jsonBuilder().startObject()
+            .array("alerts", *alerts.map { it.id }.toTypedArray())
+            .endObject()
+            .string()
+            .let { StringEntity(it, APPLICATION_JSON) }
+
+        val response = client.makeRequest(
+            "POST", "${monitor.relativeUrl()}/_acknowledge/alerts?refresh=true",
+            emptyMap(), request
+        )
+        assertEquals("Acknowledge call failed.", RestStatus.OK, response.restStatus())
+        return response
+    }
+
     protected fun acknowledgeChainedAlerts(workflowId: String, vararg alertId: String): Response {
         val request = jsonBuilder().startObject()
             .array("alerts", *alertId.map { it }.toTypedArray())

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
@@ -170,6 +170,16 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         return response
     }
 
+    protected fun deleteMonitorWithClient(client: RestClient, monitor: Monitor, refresh: Boolean = true): Response {
+        val response = client.makeRequest(
+            "DELETE", "$ALERTING_BASE_URI/${monitor.id}?refresh=$refresh", emptyMap(),
+            monitor.toHttpEntity()
+        )
+        assertEquals("Unable to delete a monitor", RestStatus.OK, response.restStatus())
+
+        return response
+    }
+
     protected fun deleteWorkflow(workflow: Workflow, deleteDelegates: Boolean = false, refresh: Boolean = true): Response {
         val response = client().makeRequest(
             "DELETE",

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -516,7 +516,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             getUser,
             TEST_HR_INDEX,
             TEST_HR_ROLE,
-            listOf("role1", "role2", "role3"),
+            listOf("role3", "role2", "role1"),
             getClusterPermissionsFromCustomRole(ALERTING_GET_MONITOR_ACCESS)
         )
         val getUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), getUser, password)

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -43,7 +43,6 @@ import org.opensearch.alerting.randomDocumentLevelMonitor
 import org.opensearch.alerting.randomQueryLevelMonitor
 import org.opensearch.alerting.randomQueryLevelTrigger
 import org.opensearch.alerting.randomTemplateScript
-import org.opensearch.alerting.randomUser
 import org.opensearch.client.Response
 import org.opensearch.client.ResponseException
 import org.opensearch.client.RestClient
@@ -324,36 +323,109 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
-    fun `test get monitor with enable filterBy for a user with multiple backend roles`() {
+    fun `test get monitor for backend roles in same order where filterByAccessStrategy is all`() {
         enableFilterBy()
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
         // setFilterByBackendRolesStrategy("all")
 
-        createUserWithTestDataAndCustomRole(
+        val monitor = randomQueryLevelMonitor(enabled = true)
+
+        createUserWithRoles(
             user,
-            TEST_HR_INDEX,
-            TEST_HR_ROLE,
-            listOf(TEST_HR_BACKEND_ROLE, "foobar"),
-            getClusterPermissionsFromCustomRole(ALERTING_GET_MONITOR_ACCESS)
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf(TEST_HR_BACKEND_ROLE, "role2"),
+            false
         )
 
-        val user2 = randomUser(roles = listOf(TEST_HR_ROLE))
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf(TEST_HR_BACKEND_ROLE, "role2"))
+        assertNotNull("The monitor was not created", createdMonitor)
 
-        println("user name: ${user2.name}")
+        createUserRolesMapping(ALERTING_FULL_ACCESS_ROLE, arrayOf())
+        createUserRolesMapping(READALL_AND_MONITOR_ROLE, arrayOf())
 
-        val monitor = randomQueryLevelMonitor(user = user2)
-
-        println("monitor ID: ${monitor.id}")
+        // getUser should have access to the monitor
+        val getUser = "getUser"
+        createUserWithTestDataAndCustomRole(
+            getUser,
+            TEST_HR_INDEX,
+            TEST_HR_ROLE,
+            listOf(TEST_HR_BACKEND_ROLE, "role2"),
+            getClusterPermissionsFromCustomRole(ALERTING_GET_MONITOR_ACCESS)
+        )
+        val getUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), getUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
 
         try {
-            val getMonitorResponse = userClient?.makeRequest(
+            val getMonitorResponse = getUserClient?.makeRequest(
                 "GET",
-                "$ALERTING_BASE_URI/${monitor.id}",
+                "$ALERTING_BASE_URI/${createdMonitor.id}",
                 null,
                 BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json")
             )
             assertEquals("Get monitor failed", RestStatus.OK, getMonitorResponse?.restStatus())
         } finally {
             deleteRoleAndRoleMapping(TEST_HR_ROLE)
+            deleteUser(getUser)
+            getUserClient?.close()
+        }
+    }
+
+    fun `test get monitor for backend roles in different order where filterByAccessStrategy is all`() {
+        enableFilterBy()
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        // setFilterByBackendRolesStrategy("all")
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf(TEST_HR_BACKEND_ROLE, "role2"),
+            false
+        )
+
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf(TEST_HR_BACKEND_ROLE, "role2"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        createUserRolesMapping(ALERTING_FULL_ACCESS_ROLE, arrayOf())
+        createUserRolesMapping(READALL_AND_MONITOR_ROLE, arrayOf())
+
+        // getUser should have access to the monitor
+        val getUser = "getUser"
+        createUserWithTestDataAndCustomRole(
+            getUser,
+            TEST_HR_INDEX,
+            TEST_HR_ROLE,
+            listOf("role2", TEST_HR_BACKEND_ROLE),
+            getClusterPermissionsFromCustomRole(ALERTING_GET_MONITOR_ACCESS)
+        )
+        val getUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), getUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            val getMonitorResponse = getUserClient?.makeRequest(
+                "GET",
+                "$ALERTING_BASE_URI/${createdMonitor.id}",
+                null,
+                BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+            )
+            assertEquals("Get monitor failed", RestStatus.OK, getMonitorResponse?.restStatus())
+        } finally {
+            deleteRoleAndRoleMapping(TEST_HR_ROLE)
+            deleteUser(getUser)
+            getUserClient?.close()
         }
     }
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -330,7 +330,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             // refer: `test create monitor with enable filter by`
             return
         }
-        // setFilterByBackendRolesStrategy("all")
+        setFilterByBackendRolesStrategy("all")
 
         val monitor = randomQueryLevelMonitor(enabled = true)
 
@@ -406,6 +406,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             getUser,
             TEST_HR_INDEX,
             TEST_HR_ROLE,
+            // intentionally change order of backend roles from order on monitor to ensure order doesn't matter
             listOf("role2", TEST_HR_BACKEND_ROLE),
             getClusterPermissionsFromCustomRole(ALERTING_GET_MONITOR_ACCESS)
         )

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -323,14 +323,14 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
-    fun `test get monitor succeeds for same backend roles in same order when filterByAccessStrategy is all`() {
+    fun `test get monitor succeeds for same backend roles in same order when filterByAccessStrategy is exact`() {
         enableFilterBy()
         if (!isHttps()) {
             // if security is disabled and filter by is enabled, we can't create monitor
             // refer: `test create monitor with enable filter by`
             return
         }
-        setFilterByBackendRolesStrategy("all")
+        setFilterByBackendRolesStrategy("exact")
 
         val monitor = randomQueryLevelMonitor(enabled = true)
 
@@ -376,14 +376,14 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
-    fun `test get monitor succeeds for same backend roles in different order when filterByAccessStrategy is all`() {
+    fun `test get monitor succeeds for same backend roles in different order when filterByAccessStrategy is exact`() {
         enableFilterBy()
         if (!isHttps()) {
             // if security is disabled and filter by is enabled, we can't create monitor
             // refer: `test create monitor with enable filter by`
             return
         }
-        setFilterByBackendRolesStrategy("all")
+        setFilterByBackendRolesStrategy("exact")
 
         val monitor = randomQueryLevelMonitor(enabled = true)
 
@@ -430,14 +430,14 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
-    fun `test get monitor fails for different backend roles when filterByAccessStrategy is all`() {
+    fun `test get monitor fails for different backend roles when filterByAccessStrategy is exact`() {
         enableFilterBy()
         if (!isHttps()) {
             // if security is disabled and filter by is enabled, we can't create monitor
             // refer: `test create monitor with enable filter by`
             return
         }
-        setFilterByBackendRolesStrategy("all")
+        setFilterByBackendRolesStrategy("exact")
 
         val monitor = randomQueryLevelMonitor(enabled = true)
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -383,7 +383,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             // refer: `test create monitor with enable filter by`
             return
         }
-        // setFilterByBackendRolesStrategy("all")
+        setFilterByBackendRolesStrategy("all")
 
         val monitor = randomQueryLevelMonitor(enabled = true)
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -323,7 +323,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
-    fun `test get monitor for backend roles in same order where filterByAccessStrategy is all`() {
+    fun `test get monitor succeeds for same backend roles in same order when filterByAccessStrategy is all`() {
         enableFilterBy()
         if (!isHttps()) {
             // if security is disabled and filter by is enabled, we can't create monitor
@@ -376,7 +376,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
-    fun `test get monitor for backend roles in different order where filterByAccessStrategy is all`() {
+    fun `test get monitor succeeds for same backend roles in different order when filterByAccessStrategy is all`() {
         enableFilterBy()
         if (!isHttps()) {
             // if security is disabled and filter by is enabled, we can't create monitor

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -430,6 +430,62 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
+    fun `test get monitor fails for different backend roles when filterByAccessStrategy is all`() {
+        enableFilterBy()
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        setFilterByBackendRolesStrategy("all")
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf(TEST_HR_BACKEND_ROLE, "role2"),
+            false
+        )
+
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf(TEST_HR_BACKEND_ROLE, "role2"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        createUserRolesMapping(ALERTING_FULL_ACCESS_ROLE, arrayOf())
+        createUserRolesMapping(READALL_AND_MONITOR_ROLE, arrayOf())
+
+        // getUser should NOT have access to the monitor
+        val getUser = "getUser"
+        createUserWithTestDataAndCustomRole(
+            getUser,
+            TEST_HR_INDEX,
+            TEST_HR_ROLE,
+            // roles are different from monitor backend roles specified above
+            listOf(TEST_HR_BACKEND_ROLE, "role1"),
+            getClusterPermissionsFromCustomRole(ALERTING_GET_MONITOR_ACCESS)
+        )
+        val getUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), getUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            val getMonitorResponse = getUserClient?.makeRequest(
+                "GET",
+                "$ALERTING_BASE_URI/${createdMonitor.id}",
+                null,
+                BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+            )
+            fail("Expected Forbidden exception")
+        } catch (e: ResponseException) {
+            assertEquals("Get monitor failed", RestStatus.FORBIDDEN.status, e.response.statusLine.statusCode)
+        } finally {
+            deleteRoleAndRoleMapping(TEST_HR_ROLE)
+            deleteUser(getUser)
+            getUserClient?.close()
+        }
+    }
+
     fun getDocs(response: Response?): Any? {
         val hits = createParser(
             XContentType.JSON.xContent(),

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -43,6 +43,7 @@ import org.opensearch.alerting.randomDocumentLevelMonitor
 import org.opensearch.alerting.randomQueryLevelMonitor
 import org.opensearch.alerting.randomQueryLevelTrigger
 import org.opensearch.alerting.randomTemplateScript
+import org.opensearch.alerting.randomUser
 import org.opensearch.client.Response
 import org.opensearch.client.ResponseException
 import org.opensearch.client.RestClient
@@ -318,6 +319,39 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             fail("Expected 403 Method FORBIDDEN response")
         } catch (e: ResponseException) {
             assertEquals("Unexpected status", RestStatus.FORBIDDEN, e.response.restStatus())
+        } finally {
+            deleteRoleAndRoleMapping(TEST_HR_ROLE)
+        }
+    }
+
+    fun `test get monitor with enable filterBy for a user with multiple backend roles`() {
+        enableFilterBy()
+        setFilterByBackendRolesStrategy("all")
+
+        createUserWithTestDataAndCustomRole(
+            user,
+            TEST_HR_INDEX,
+            TEST_HR_ROLE,
+            listOf(TEST_HR_BACKEND_ROLE, "foobar"),
+            getClusterPermissionsFromCustomRole(ALERTING_GET_MONITOR_ACCESS)
+        )
+
+        val user2 = randomUser(roles = listOf(TEST_HR_ROLE))
+
+        println("user name: ${user2.name}")
+
+        val monitor = randomQueryLevelMonitor(user = user2)
+
+        println("monitor ID: ${monitor.id}")
+
+        try {
+            val getMonitorResponse = userClient?.makeRequest(
+                "GET",
+                "$ALERTING_BASE_URI/${monitor.id}",
+                null,
+                BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+            )
+            assertEquals("Get monitor failed", RestStatus.OK, getMonitorResponse?.restStatus())
         } finally {
             deleteRoleAndRoleMapping(TEST_HR_ROLE)
         }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -326,7 +326,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
 
     fun `test get monitor with enable filterBy for a user with multiple backend roles`() {
         enableFilterBy()
-        setFilterByBackendRolesStrategy("all")
+        // setFilterByBackendRolesStrategy("all")
 
         createUserWithTestDataAndCustomRole(
             user,

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -486,6 +486,114 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
+    fun `test get monitor succeeds when filterByAccessStrategy is all and user backend roles contain all resource roles`() {
+        enableFilterBy()
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        setFilterByBackendRolesStrategy("all")
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1", "role2"),
+            false
+        )
+
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf("role1", "role2"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        createUserRolesMapping(ALERTING_FULL_ACCESS_ROLE, arrayOf())
+        createUserRolesMapping(READALL_AND_MONITOR_ROLE, arrayOf())
+
+        // getUser should have access to the monitor
+        val getUser = "getUser"
+        createUserWithTestDataAndCustomRole(
+            getUser,
+            TEST_HR_INDEX,
+            TEST_HR_ROLE,
+            listOf("role1", "role2", "role3"),
+            getClusterPermissionsFromCustomRole(ALERTING_GET_MONITOR_ACCESS)
+        )
+        val getUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), getUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            val getMonitorResponse = getUserClient?.makeRequest(
+                "GET",
+                "$ALERTING_BASE_URI/${createdMonitor.id}",
+                null,
+                BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+            )
+            assertEquals("Get monitor failed", RestStatus.OK, getMonitorResponse?.restStatus())
+        } finally {
+            deleteRoleAndRoleMapping(TEST_HR_ROLE)
+            deleteUser(getUser)
+            getUserClient?.close()
+        }
+    }
+
+    fun `test get monitor fails when filterByAccessStrategy is all and user backend roles do not contain all resource roles`() {
+        enableFilterBy()
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        setFilterByBackendRolesStrategy("all")
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1", "role2"),
+            false
+        )
+
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf("role1", "role2"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        createUserRolesMapping(ALERTING_FULL_ACCESS_ROLE, arrayOf())
+        createUserRolesMapping(READALL_AND_MONITOR_ROLE, arrayOf())
+
+        // getUser should have access to the monitor
+        val getUser = "getUser"
+        createUserWithTestDataAndCustomRole(
+            getUser,
+            TEST_HR_INDEX,
+            TEST_HR_ROLE,
+            listOf("role2", "role3"),
+            getClusterPermissionsFromCustomRole(ALERTING_GET_MONITOR_ACCESS)
+        )
+        val getUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), getUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            val getMonitorResponse = getUserClient?.makeRequest(
+                "GET",
+                "$ALERTING_BASE_URI/${createdMonitor.id}",
+                null,
+                BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+            )
+            fail("Expected Forbidden exception")
+        } catch (e: ResponseException) {
+            assertEquals("Get monitor failed", RestStatus.FORBIDDEN.status, e.response.statusLine.statusCode)
+        } finally {
+            deleteRoleAndRoleMapping(TEST_HR_ROLE)
+            deleteUser(getUser)
+            getUserClient?.close()
+        }
+    }
+
     fun getDocs(response: Response?): Any? {
         val hits = createParser(
             XContentType.JSON.xContent(),

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -2188,6 +2188,51 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
+    fun `test acknowledge alerts succeeds when filterByAccessStrategy is all`() {
+        enableFilterBy()
+        putAlertMappings()
+
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        setFilterByBackendRolesStrategy("all")
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1"),
+            false
+        )
+
+        var monitor = createRandomMonitor(refresh = true)
+        val activeAlert = createAlert(randomAlert(monitor).copy(state = Alert.State.ACTIVE))
+
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf("role1"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        val acknowledgeUser = "acknowledgeUser"
+        createUserWithRoles(
+            acknowledgeUser,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            // contains all roles of monitor
+            listOf("role1"),
+            false
+        )
+        val acknowledgeUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), acknowledgeUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            val response = acknowledgeAlertsWithClient(acknowledgeUserClient, createdMonitor, activeAlert)
+            assertEquals("Acknowledge alert failed", RestStatus.OK, response?.restStatus())
+        } finally {
+            acknowledgeUserClient?.close()
+        }
+    }
+
     // Execute Monitor related security tests
 
     fun `test execute monitor with elevate permissions`() {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -1638,7 +1638,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             .build()
 
         try {
-            deleteMonitor(monitor = createdMonitor)
+            deleteMonitorWithClient(deleteUserClient, monitor = createdMonitor)
             fail("Expected Forbidden exception")
         } catch (e: ResponseException) {
             assertEquals("Get monitor failed", RestStatus.FORBIDDEN.status, e.response.statusLine.statusCode)

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -1089,6 +1089,212 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
+    fun `test update monitor succeeds when filterByAccessStrategy is all`() {
+        enableFilterBy()
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        setFilterByBackendRolesStrategy("all")
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1"),
+            false
+        )
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf("role1"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        val getMonitorResponse = userClient?.makeRequest(
+            "GET",
+            "$ALERTING_BASE_URI/${createdMonitor.id}",
+            null,
+            BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+        )
+        assertEquals("Get monitor failed", RestStatus.OK, getMonitorResponse?.restStatus())
+
+        val updateUser = "updateUser"
+        createUserWithRoles(
+            updateUser,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1"),
+            false
+        )
+        val updateUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), updateUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            val updatedMonitor = updateMonitorWithClient(updateUserClient, createdMonitor, listOf("role1"))
+        } finally {
+            deleteUser(updateUser)
+            updateUserClient?.close()
+            createUserRolesMapping(ALERTING_FULL_ACCESS_ROLE, arrayOf())
+            createUserRolesMapping(READALL_AND_MONITOR_ROLE, arrayOf())
+        }
+    }
+
+    fun `test update monitor fails when filterByAccessStrategy is all`() {
+        enableFilterBy()
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        setFilterByBackendRolesStrategy("all")
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1", "role2"),
+            false
+        )
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf("role1", "role2"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        val getMonitorResponse = userClient?.makeRequest(
+            "GET",
+            "$ALERTING_BASE_URI/${createdMonitor.id}",
+            null,
+            BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+        )
+        assertEquals("Get monitor failed", RestStatus.OK, getMonitorResponse?.restStatus())
+
+        val updateUser = "updateUser"
+        createUserWithRoles(
+            updateUser,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1"),
+            false
+        )
+        val updateUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), updateUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            val updatedMonitor = updateMonitorWithClient(updateUserClient, createdMonitor, listOf("role1"))
+            fail("Expected Forbidden exception")
+        } catch (e: ResponseException) {
+            assertEquals("Get monitor failed", RestStatus.FORBIDDEN.status, e.response.statusLine.statusCode)
+        } finally {
+            deleteUser(updateUser)
+            updateUserClient?.close()
+            createUserRolesMapping(ALERTING_FULL_ACCESS_ROLE, arrayOf())
+            createUserRolesMapping(READALL_AND_MONITOR_ROLE, arrayOf())
+        }
+    }
+
+    fun `test update monitor succeeds when filterByAccessStrategy is exact`() {
+        enableFilterBy()
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        setFilterByBackendRolesStrategy("exact")
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1", "role2"),
+            false
+        )
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf("role1", "role2"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        val getMonitorResponse = userClient?.makeRequest(
+            "GET",
+            "$ALERTING_BASE_URI/${createdMonitor.id}",
+            null,
+            BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+        )
+        assertEquals("Get monitor failed", RestStatus.OK, getMonitorResponse?.restStatus())
+
+        val updateUser = "updateUser"
+        createUserWithRoles(
+            updateUser,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1", "role2"),
+            false
+        )
+        val updateUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), updateUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            val updatedMonitor = updateMonitorWithClient(updateUserClient, createdMonitor, listOf("role1", "role2"))
+        } finally {
+            deleteUser(updateUser)
+            updateUserClient?.close()
+            createUserRolesMapping(ALERTING_FULL_ACCESS_ROLE, arrayOf())
+            createUserRolesMapping(READALL_AND_MONITOR_ROLE, arrayOf())
+        }
+    }
+
+    fun `test update monitor fails when filterByAccessStrategy is exact`() {
+        enableFilterBy()
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        setFilterByBackendRolesStrategy("exact")
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1", "role2"),
+            false
+        )
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf("role1", "role2"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        val getMonitorResponse = userClient?.makeRequest(
+            "GET",
+            "$ALERTING_BASE_URI/${createdMonitor.id}",
+            null,
+            BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+        )
+        assertEquals("Get monitor failed", RestStatus.OK, getMonitorResponse?.restStatus())
+
+        val updateUser = "updateUser"
+        createUserWithRoles(
+            updateUser,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1", "role2", "role3"),
+            false
+        )
+        val updateUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), updateUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            val updatedMonitor = updateMonitorWithClient(updateUserClient, createdMonitor, listOf("role1"))
+            fail("Expected Forbidden exception")
+        } catch (e: ResponseException) {
+            assertEquals("Get monitor failed", RestStatus.FORBIDDEN.status, e.response.statusLine.statusCode)
+        } finally {
+            deleteUser(updateUser)
+            updateUserClient?.close()
+            createUserRolesMapping(ALERTING_FULL_ACCESS_ROLE, arrayOf())
+            createUserRolesMapping(READALL_AND_MONITOR_ROLE, arrayOf())
+        }
+    }
+
     fun `test update monitor as admin with enable filter by with removing a permission`() {
         enableFilterBy()
         if (!isHttps()) {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -45,7 +45,6 @@ import org.opensearch.alerting.randomPPLTrigger
 import org.opensearch.alerting.randomQueryLevelMonitor
 import org.opensearch.alerting.randomQueryLevelTrigger
 import org.opensearch.alerting.randomTemplateScript
-import org.opensearch.alerting.randomUser
 import org.opensearch.client.Response
 import org.opensearch.client.ResponseException
 import org.opensearch.client.RestClient
@@ -331,36 +330,109 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
-    fun `test get monitor with enable filterBy for a user with multiple backend roles`() {
+    fun `test get monitor for backend roles in same order where filterByAccessStrategy is all`() {
         enableFilterBy()
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
         // setFilterByBackendRolesStrategy("all")
 
-        createUserWithTestDataAndCustomRole(
+        val monitor = randomQueryLevelMonitor(enabled = true)
+
+        createUserWithRoles(
             user,
-            TEST_HR_INDEX,
-            TEST_HR_ROLE,
-            listOf(TEST_HR_BACKEND_ROLE, "foobar"),
-            getClusterPermissionsFromCustomRole(ALERTING_GET_MONITOR_ACCESS)
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf(TEST_HR_BACKEND_ROLE, "role2"),
+            false
         )
 
-        val user2 = randomUser(roles = listOf(TEST_HR_ROLE))
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf(TEST_HR_BACKEND_ROLE, "role2"))
+        assertNotNull("The monitor was not created", createdMonitor)
 
-        println("user name: ${user2.name}")
+        createUserRolesMapping(ALERTING_FULL_ACCESS_ROLE, arrayOf())
+        createUserRolesMapping(READALL_AND_MONITOR_ROLE, arrayOf())
 
-        val monitor = randomQueryLevelMonitor(user = user2)
-
-        println("monitor ID: ${monitor.id}")
+        // getUser should have access to the monitor
+        val getUser = "getUser"
+        createUserWithTestDataAndCustomRole(
+            getUser,
+            TEST_HR_INDEX,
+            TEST_HR_ROLE,
+            listOf(TEST_HR_BACKEND_ROLE, "role2"),
+            getClusterPermissionsFromCustomRole(ALERTING_GET_MONITOR_ACCESS)
+        )
+        val getUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), getUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
 
         try {
-            val getMonitorResponse = userClient?.makeRequest(
+            val getMonitorResponse = getUserClient?.makeRequest(
                 "GET",
-                "$ALERTING_BASE_URI/${monitor.id}",
+                "$ALERTING_BASE_URI/${createdMonitor.id}",
                 null,
                 BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json")
             )
             assertEquals("Get monitor failed", RestStatus.OK, getMonitorResponse?.restStatus())
         } finally {
             deleteRoleAndRoleMapping(TEST_HR_ROLE)
+            deleteUser(getUser)
+            getUserClient?.close()
+        }
+    }
+
+    fun `test get monitor for backend roles in different order where filterByAccessStrategy is all`() {
+        enableFilterBy()
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        // setFilterByBackendRolesStrategy("all")
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf(TEST_HR_BACKEND_ROLE, "role2"),
+            false
+        )
+
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf(TEST_HR_BACKEND_ROLE, "role2"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        createUserRolesMapping(ALERTING_FULL_ACCESS_ROLE, arrayOf())
+        createUserRolesMapping(READALL_AND_MONITOR_ROLE, arrayOf())
+
+        // getUser should have access to the monitor
+        val getUser = "getUser"
+        createUserWithTestDataAndCustomRole(
+            getUser,
+            TEST_HR_INDEX,
+            TEST_HR_ROLE,
+            listOf("role2", TEST_HR_BACKEND_ROLE),
+            getClusterPermissionsFromCustomRole(ALERTING_GET_MONITOR_ACCESS)
+        )
+        val getUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), getUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            val getMonitorResponse = getUserClient?.makeRequest(
+                "GET",
+                "$ALERTING_BASE_URI/${createdMonitor.id}",
+                null,
+                BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+            )
+            assertEquals("Get monitor failed", RestStatus.OK, getMonitorResponse?.restStatus())
+        } finally {
+            deleteRoleAndRoleMapping(TEST_HR_ROLE)
+            deleteUser(getUser)
+            getUserClient?.close()
         }
     }
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -2212,7 +2212,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
 
         val activeAlert = createAlert(randomAlert(createdMonitor).copy(state = Alert.State.ACTIVE))
 
-        val acknowledgeUser = "acknowledgeUser"
+        val acknowledgeUser = "acknowledgeUser1"
         createUserWithRoles(
             acknowledgeUser,
             listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
@@ -2229,6 +2229,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             val response = acknowledgeAlertsWithClient(acknowledgeUserClient, createdMonitor, activeAlert)
             assertEquals("Acknowledge alert failed", RestStatus.OK, response?.restStatus())
         } finally {
+            deleteUser(acknowledgeUser)
             acknowledgeUserClient?.close()
         }
     }
@@ -2257,7 +2258,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
 
         val activeAlert = createAlert(randomAlert(createdMonitor).copy(state = Alert.State.ACTIVE))
 
-        val acknowledgeUser = "acknowledgeUser"
+        val acknowledgeUser = "acknowledgeUser2"
         createUserWithRoles(
             acknowledgeUser,
             listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
@@ -2276,6 +2277,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         } catch (e: ResponseException) {
             assertEquals("Get monitor failed", RestStatus.FORBIDDEN.status, e.response.statusLine.statusCode)
         } finally {
+            deleteUser(acknowledgeUser)
             acknowledgeUserClient?.close()
         }
     }
@@ -2304,7 +2306,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
 
         val activeAlert = createAlert(randomAlert(createdMonitor).copy(state = Alert.State.ACTIVE))
 
-        val acknowledgeUser = "acknowledgeUser"
+        val acknowledgeUser = "acknowledgeUser3"
         createUserWithRoles(
             acknowledgeUser,
             listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
@@ -2321,6 +2323,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             val response = acknowledgeAlertsWithClient(acknowledgeUserClient, createdMonitor, activeAlert)
             assertEquals("Acknowledge alert failed", RestStatus.OK, response?.restStatus())
         } finally {
+            deleteUser(acknowledgeUser)
             acknowledgeUserClient?.close()
         }
     }
@@ -2349,7 +2352,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
 
         val activeAlert = createAlert(randomAlert(createdMonitor).copy(state = Alert.State.ACTIVE))
 
-        val acknowledgeUser = "acknowledgeUser"
+        val acknowledgeUser = "acknowledgeUser4"
         createUserWithRoles(
             acknowledgeUser,
             listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
@@ -2368,6 +2371,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         } catch (e: ResponseException) {
             assertEquals("Get monitor failed", RestStatus.FORBIDDEN.status, e.response.statusLine.statusCode)
         } finally {
+            deleteUser(acknowledgeUser)
             acknowledgeUserClient?.close()
         }
     }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -330,14 +330,14 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
-    fun `test get monitor succeeds for same backend roles in same order when filterByAccessStrategy is all`() {
+    fun `test get monitor succeeds for same backend roles in same order when filterByAccessStrategy is exact`() {
         enableFilterBy()
         if (!isHttps()) {
             // if security is disabled and filter by is enabled, we can't create monitor
             // refer: `test create monitor with enable filter by`
             return
         }
-        setFilterByBackendRolesStrategy("all")
+        setFilterByBackendRolesStrategy("exact")
 
         val monitor = randomQueryLevelMonitor(enabled = true)
 
@@ -383,14 +383,14 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
-    fun `test get monitor succeeds for same backend roles in different order when filterByAccessStrategy is all`() {
+    fun `test get monitor succeeds for same backend roles in different order when filterByAccessStrategy is exact`() {
         enableFilterBy()
         if (!isHttps()) {
             // if security is disabled and filter by is enabled, we can't create monitor
             // refer: `test create monitor with enable filter by`
             return
         }
-        setFilterByBackendRolesStrategy("all")
+        setFilterByBackendRolesStrategy("exact")
 
         val monitor = randomQueryLevelMonitor(enabled = true)
 
@@ -437,14 +437,14 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
-    fun `test get monitor fails for different backend roles when filterByAccessStrategy is all`() {
+    fun `test get monitor fails for different backend roles when filterByAccessStrategy is exact`() {
         enableFilterBy()
         if (!isHttps()) {
             // if security is disabled and filter by is enabled, we can't create monitor
             // refer: `test create monitor with enable filter by`
             return
         }
-        setFilterByBackendRolesStrategy("all")
+        setFilterByBackendRolesStrategy("exact")
 
         val monitor = randomQueryLevelMonitor(enabled = true)
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -1638,7 +1638,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             .build()
 
         try {
-            deleteMonitorWithClient(deleteUserClient, monitor = createdMonitor)
+            deleteMonitor(monitor = createdMonitor)
             fail("Expected Forbidden exception")
         } catch (e: ResponseException) {
             assertEquals("Get monitor failed", RestStatus.FORBIDDEN.status, e.response.statusLine.statusCode)
@@ -1798,6 +1798,188 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             assertEquals("Get monitor failed", RestStatus.FORBIDDEN, e.response.restStatus())
         } finally {
             deleteRoleAndRoleMapping(TEST_HR_ROLE)
+        }
+    }
+
+    fun `test execute monitor succeeds when filterByAccessStrategy is all`() {
+        enableFilterBy()
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        setFilterByBackendRolesStrategy("all")
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1"),
+            false
+        )
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf("role1"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        val executeUser = "executeUser"
+        createUserWithRoles(
+            executeUser,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            // contains all roles of monitor
+            listOf("role1"),
+            false
+        )
+        val executeUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), executeUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            executeUserClient?.makeRequest(
+                "POST",
+                "$ALERTING_BASE_URI/${createdMonitor.id}/_execute",
+                mutableMapOf()
+            )
+        } finally {
+            executeUserClient?.close()
+        }
+    }
+
+    fun `test execute monitor fails when filterByAccessStrategy is all`() {
+        enableFilterBy()
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        setFilterByBackendRolesStrategy("all")
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1", "role2"),
+            false
+        )
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf("role1", "role2"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        val executeUser = "executeUser"
+        createUserWithRoles(
+            executeUser,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            // does not contain all roles of monitor
+            listOf("role1"),
+            false
+        )
+        val executeUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), executeUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            executeUserClient?.makeRequest(
+                "POST",
+                "$ALERTING_BASE_URI/${createdMonitor.id}/_execute",
+                mutableMapOf()
+            )
+            fail("Expected Forbidden exception")
+        } catch (e: ResponseException) {
+            assertEquals("Get monitor failed", RestStatus.FORBIDDEN.status, e.response.statusLine.statusCode)
+        } finally {
+            executeUserClient?.close()
+        }
+    }
+
+    fun `test execute monitor succeeds when filterByAccessStrategy is exact`() {
+        enableFilterBy()
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        setFilterByBackendRolesStrategy("exact")
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1", "role2"),
+            false
+        )
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf("role1", "role2"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        val executeUser = "executeUser"
+        createUserWithRoles(
+            executeUser,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            // matches roles of monitor exactly
+            listOf("role1", "role2"),
+            false
+        )
+        val executeUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), executeUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            executeUserClient?.makeRequest(
+                "POST",
+                "$ALERTING_BASE_URI/${createdMonitor.id}/_execute",
+                mutableMapOf()
+            )
+        } finally {
+            executeUserClient?.close()
+        }
+    }
+
+    fun `test execute monitor fails when filterByAccessStrategy is exact`() {
+        enableFilterBy()
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        setFilterByBackendRolesStrategy("exact")
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1", "role2"),
+            false
+        )
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf("role1", "role2"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        val executeUser = "executeUser"
+        createUserWithRoles(
+            executeUser,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            // contains all roles of monitor but does not match them exactly
+            listOf("role1", "role2", "role3"),
+            false
+        )
+        val executeUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), executeUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            executeUserClient?.makeRequest(
+                "POST",
+                "$ALERTING_BASE_URI/${createdMonitor.id}/_execute",
+                mutableMapOf()
+            )
+            fail("Expected Forbidden exception")
+        } catch (e: ResponseException) {
+            assertEquals("Get monitor failed", RestStatus.FORBIDDEN.status, e.response.statusLine.statusCode)
+        } finally {
+            executeUserClient?.close()
         }
     }
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -330,7 +330,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
-    fun `test get monitor for backend roles in same order where filterByAccessStrategy is all`() {
+    fun `test get monitor succeeds for same backend roles in same order when filterByAccessStrategy is all`() {
         enableFilterBy()
         if (!isHttps()) {
             // if security is disabled and filter by is enabled, we can't create monitor
@@ -383,7 +383,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
-    fun `test get monitor for backend roles in different order where filterByAccessStrategy is all`() {
+    fun `test get monitor succeeds for same backend roles in different order when filterByAccessStrategy is all`() {
         enableFilterBy()
         if (!isHttps()) {
             // if security is disabled and filter by is enabled, we can't create monitor

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -493,6 +493,114 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
+    fun `test get monitor succeeds when filterByAccessStrategy is all and user backend roles contain all resource roles`() {
+        enableFilterBy()
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        setFilterByBackendRolesStrategy("all")
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1", "role2"),
+            false
+        )
+
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf("role1", "role2"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        createUserRolesMapping(ALERTING_FULL_ACCESS_ROLE, arrayOf())
+        createUserRolesMapping(READALL_AND_MONITOR_ROLE, arrayOf())
+
+        // getUser should have access to the monitor
+        val getUser = "getUser"
+        createUserWithTestDataAndCustomRole(
+            getUser,
+            TEST_HR_INDEX,
+            TEST_HR_ROLE,
+            listOf("role1", "role2", "role3"),
+            getClusterPermissionsFromCustomRole(ALERTING_GET_MONITOR_ACCESS)
+        )
+        val getUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), getUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            val getMonitorResponse = getUserClient?.makeRequest(
+                "GET",
+                "$ALERTING_BASE_URI/${createdMonitor.id}",
+                null,
+                BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+            )
+            assertEquals("Get monitor failed", RestStatus.OK, getMonitorResponse?.restStatus())
+        } finally {
+            deleteRoleAndRoleMapping(TEST_HR_ROLE)
+            deleteUser(getUser)
+            getUserClient?.close()
+        }
+    }
+
+    fun `test get monitor fails when filterByAccessStrategy is all and user backend roles do not contain all resource roles`() {
+        enableFilterBy()
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        setFilterByBackendRolesStrategy("all")
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1", "role2"),
+            false
+        )
+
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf("role1", "role2"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        createUserRolesMapping(ALERTING_FULL_ACCESS_ROLE, arrayOf())
+        createUserRolesMapping(READALL_AND_MONITOR_ROLE, arrayOf())
+
+        // getUser should have access to the monitor
+        val getUser = "getUser"
+        createUserWithTestDataAndCustomRole(
+            getUser,
+            TEST_HR_INDEX,
+            TEST_HR_ROLE,
+            listOf("role2", "role3"),
+            getClusterPermissionsFromCustomRole(ALERTING_GET_MONITOR_ACCESS)
+        )
+        val getUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), getUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            val getMonitorResponse = getUserClient?.makeRequest(
+                "GET",
+                "$ALERTING_BASE_URI/${createdMonitor.id}",
+                null,
+                BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+            )
+            fail("Expected Forbidden exception")
+        } catch (e: ResponseException) {
+            assertEquals("Get monitor failed", RestStatus.FORBIDDEN.status, e.response.statusLine.statusCode)
+        } finally {
+            deleteRoleAndRoleMapping(TEST_HR_ROLE)
+            deleteUser(getUser)
+            getUserClient?.close()
+        }
+    }
+
     fun getDocs(response: Response?): Any? {
         val hits = createParser(
             XContentType.JSON.xContent(),

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -1482,7 +1482,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             .build()
 
         try {
-            deleteMonitor(monitor = createdMonitor)
+            deleteMonitorWithClient(deleteUserClient, monitor = createdMonitor)
         } finally {
             deleteUser(deleteUser)
             deleteUserClient?.close()
@@ -1587,7 +1587,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             .build()
 
         try {
-            deleteMonitor(monitor = createdMonitor)
+            deleteMonitorWithClient(deleteUserClient, monitor = createdMonitor)
         } finally {
             deleteUser(deleteUser)
             deleteUserClient?.close()
@@ -1835,11 +1835,12 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             .build()
 
         try {
-            executeUserClient?.makeRequest(
+            val executeMonitorResponse = executeUserClient?.makeRequest(
                 "POST",
                 "$ALERTING_BASE_URI/${createdMonitor.id}/_execute",
                 mutableMapOf()
             )
+            assertEquals("Execute monitor failed", RestStatus.OK, executeMonitorResponse?.restStatus())
         } finally {
             executeUserClient?.close()
         }
@@ -1926,11 +1927,12 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             .build()
 
         try {
-            executeUserClient?.makeRequest(
+            val executeMonitorResponse = executeUserClient?.makeRequest(
                 "POST",
                 "$ALERTING_BASE_URI/${createdMonitor.id}/_execute",
                 mutableMapOf()
             )
+            assertEquals("Execute monitor failed", RestStatus.OK, executeMonitorResponse?.restStatus())
         } finally {
             executeUserClient?.close()
         }
@@ -2356,8 +2358,8 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         createUserWithRoles(
             acknowledgeUser,
             listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
-            // does not contain all roles of monitor
-            listOf("role1"),
+            // does not match roles of monitor exactly
+            listOf("role1", "role2", "role3"),
             false
         )
         val acknowledgeUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), acknowledgeUser, password)

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -523,7 +523,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             getUser,
             TEST_HR_INDEX,
             TEST_HR_ROLE,
-            listOf("role1", "role2", "role3"),
+            listOf("role3", "role2", "role1"),
             getClusterPermissionsFromCustomRole(ALERTING_GET_MONITOR_ACCESS)
         )
         val getUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), getUser, password)

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -45,6 +45,7 @@ import org.opensearch.alerting.randomPPLTrigger
 import org.opensearch.alerting.randomQueryLevelMonitor
 import org.opensearch.alerting.randomQueryLevelTrigger
 import org.opensearch.alerting.randomTemplateScript
+import org.opensearch.alerting.randomUser
 import org.opensearch.client.Response
 import org.opensearch.client.ResponseException
 import org.opensearch.client.RestClient
@@ -325,6 +326,39 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             fail("Expected 403 Method FORBIDDEN response")
         } catch (e: ResponseException) {
             assertEquals("Unexpected status", RestStatus.FORBIDDEN, e.response.restStatus())
+        } finally {
+            deleteRoleAndRoleMapping(TEST_HR_ROLE)
+        }
+    }
+
+    fun `test get monitor with enable filterBy for a user with multiple backend roles`() {
+        enableFilterBy()
+        setFilterByBackendRolesStrategy("all")
+
+        createUserWithTestDataAndCustomRole(
+            user,
+            TEST_HR_INDEX,
+            TEST_HR_ROLE,
+            listOf(TEST_HR_BACKEND_ROLE, "foobar"),
+            getClusterPermissionsFromCustomRole(ALERTING_GET_MONITOR_ACCESS)
+        )
+
+        val user2 = randomUser(roles = listOf(TEST_HR_ROLE))
+
+        println("user name: ${user2.name}")
+
+        val monitor = randomQueryLevelMonitor(user = user2)
+
+        println("monitor ID: ${monitor.id}")
+
+        try {
+            val getMonitorResponse = userClient?.makeRequest(
+                "GET",
+                "$ALERTING_BASE_URI/${monitor.id}",
+                null,
+                BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+            )
+            assertEquals("Get monitor failed", RestStatus.OK, getMonitorResponse?.restStatus())
         } finally {
             deleteRoleAndRoleMapping(TEST_HR_ROLE)
         }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -1121,6 +1121,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         createUserWithRoles(
             updateUser,
             listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            // contains all roles of monitor
             listOf("role1"),
             false
         )
@@ -1171,6 +1172,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         createUserWithRoles(
             updateUser,
             listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            // does not contain all roles of monitor
             listOf("role1"),
             false
         )
@@ -1224,6 +1226,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         createUserWithRoles(
             updateUser,
             listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            // exactly matches roles of monitor
             listOf("role1", "role2"),
             false
         )
@@ -1274,6 +1277,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         createUserWithRoles(
             updateUser,
             listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            // contains all roles of monitor but does not exactly match them
             listOf("role1", "role2", "role3"),
             false
         )
@@ -1434,6 +1438,216 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         ).map()["hits"]!! as Map<String, Map<String, Any>>
         val adminDocsFound = adminHits["total"]?.get("value")
         assertEquals("Monitor found during search", 0, adminDocsFound)
+    }
+
+    fun `test delete monitor succeeds when filterByAccessStrategy is all`() {
+        enableFilterBy()
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        setFilterByBackendRolesStrategy("all")
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1"),
+            false
+        )
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf("role1"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        val getMonitorResponse = userClient?.makeRequest(
+            "GET",
+            "$ALERTING_BASE_URI/${createdMonitor.id}",
+            null,
+            BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+        )
+        assertEquals("Get monitor failed", RestStatus.OK, getMonitorResponse?.restStatus())
+
+        val deleteUser = "deleteUser"
+        createUserWithRoles(
+            deleteUser,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            // contains all roles of monitor
+            listOf("role1"),
+            false
+        )
+        val deleteUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), deleteUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            deleteMonitor(monitor = createdMonitor)
+        } finally {
+            deleteUser(deleteUser)
+            deleteUserClient?.close()
+            createUserRolesMapping(ALERTING_FULL_ACCESS_ROLE, arrayOf())
+            createUserRolesMapping(READALL_AND_MONITOR_ROLE, arrayOf())
+        }
+    }
+
+    fun `test delete monitor fails when filterByAccessStrategy is all`() {
+        enableFilterBy()
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        setFilterByBackendRolesStrategy("all")
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1", "role2"),
+            false
+        )
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf("role1", "role2"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        val getMonitorResponse = userClient?.makeRequest(
+            "GET",
+            "$ALERTING_BASE_URI/${createdMonitor.id}",
+            null,
+            BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+        )
+        assertEquals("Get monitor failed", RestStatus.OK, getMonitorResponse?.restStatus())
+
+        val deleteUser = "deleteUser"
+        createUserWithRoles(
+            deleteUser,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            // does not contain all roles of monitor
+            listOf("role1"),
+            false
+        )
+        val deleteUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), deleteUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            deleteMonitorWithClient(deleteUserClient, monitor = createdMonitor)
+            fail("Expected Forbidden exception")
+        } catch (e: ResponseException) {
+            assertEquals("Get monitor failed", RestStatus.FORBIDDEN.status, e.response.statusLine.statusCode)
+        } finally {
+            deleteUser(deleteUser)
+            deleteUserClient?.close()
+            createUserRolesMapping(ALERTING_FULL_ACCESS_ROLE, arrayOf())
+            createUserRolesMapping(READALL_AND_MONITOR_ROLE, arrayOf())
+        }
+    }
+
+    fun `test delete monitor succeeds when filterByAccessStrategy is exact`() {
+        enableFilterBy()
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        setFilterByBackendRolesStrategy("exact")
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1"),
+            false
+        )
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf("role1"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        val getMonitorResponse = userClient?.makeRequest(
+            "GET",
+            "$ALERTING_BASE_URI/${createdMonitor.id}",
+            null,
+            BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+        )
+        assertEquals("Get monitor failed", RestStatus.OK, getMonitorResponse?.restStatus())
+
+        val deleteUser = "deleteUser"
+        createUserWithRoles(
+            deleteUser,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            // exactly matches roles of monitor
+            listOf("role1"),
+            false
+        )
+        val deleteUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), deleteUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            deleteMonitor(monitor = createdMonitor)
+        } finally {
+            deleteUser(deleteUser)
+            deleteUserClient?.close()
+            createUserRolesMapping(ALERTING_FULL_ACCESS_ROLE, arrayOf())
+            createUserRolesMapping(READALL_AND_MONITOR_ROLE, arrayOf())
+        }
+    }
+
+    fun `test delete monitor fails when filterByAccessStrategy is exact`() {
+        enableFilterBy()
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        setFilterByBackendRolesStrategy("exact")
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1", "role2"),
+            false
+        )
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf("role1", "role2"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        val getMonitorResponse = userClient?.makeRequest(
+            "GET",
+            "$ALERTING_BASE_URI/${createdMonitor.id}",
+            null,
+            BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+        )
+        assertEquals("Get monitor failed", RestStatus.OK, getMonitorResponse?.restStatus())
+
+        val deleteUser = "deleteUser"
+        createUserWithRoles(
+            deleteUser,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            // contains roles of monitor, but does not exactly match them
+            listOf("role1", "role2", "role3"),
+            false
+        )
+        val deleteUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), deleteUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            deleteMonitorWithClient(deleteUserClient, monitor = createdMonitor)
+            fail("Expected Forbidden exception")
+        } catch (e: ResponseException) {
+            assertEquals("Get monitor failed", RestStatus.FORBIDDEN.status, e.response.statusLine.statusCode)
+        } finally {
+            deleteUser(deleteUser)
+            deleteUserClient?.close()
+            createUserRolesMapping(ALERTING_FULL_ACCESS_ROLE, arrayOf())
+            createUserRolesMapping(READALL_AND_MONITOR_ROLE, arrayOf())
+        }
     }
 
     /*

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -437,6 +437,62 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
+    fun `test get monitor fails for different backend roles when filterByAccessStrategy is all`() {
+        enableFilterBy()
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        setFilterByBackendRolesStrategy("all")
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf(TEST_HR_BACKEND_ROLE, "role2"),
+            false
+        )
+
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf(TEST_HR_BACKEND_ROLE, "role2"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        createUserRolesMapping(ALERTING_FULL_ACCESS_ROLE, arrayOf())
+        createUserRolesMapping(READALL_AND_MONITOR_ROLE, arrayOf())
+
+        // getUser should NOT have access to the monitor
+        val getUser = "getUser"
+        createUserWithTestDataAndCustomRole(
+            getUser,
+            TEST_HR_INDEX,
+            TEST_HR_ROLE,
+            // roles are different from monitor backend roles specified above
+            listOf(TEST_HR_BACKEND_ROLE, "role1"),
+            getClusterPermissionsFromCustomRole(ALERTING_GET_MONITOR_ACCESS)
+        )
+        val getUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), getUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            val getMonitorResponse = getUserClient?.makeRequest(
+                "GET",
+                "$ALERTING_BASE_URI/${createdMonitor.id}",
+                null,
+                BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+            )
+            fail("Expected Forbidden exception")
+        } catch (e: ResponseException) {
+            assertEquals("Get monitor failed", RestStatus.FORBIDDEN.status, e.response.statusLine.statusCode)
+        } finally {
+            deleteRoleAndRoleMapping(TEST_HR_ROLE)
+            deleteUser(getUser)
+            getUserClient?.close()
+        }
+    }
+
     fun getDocs(response: Response?): Any? {
         val hits = createParser(
             XContentType.JSON.xContent(),

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -337,7 +337,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             // refer: `test create monitor with enable filter by`
             return
         }
-        // setFilterByBackendRolesStrategy("all")
+        setFilterByBackendRolesStrategy("all")
 
         val monitor = randomQueryLevelMonitor(enabled = true)
 
@@ -413,6 +413,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             getUser,
             TEST_HR_INDEX,
             TEST_HR_ROLE,
+            // intentionally change order of backend roles from order on monitor to ensure order doesn't matter
             listOf("role2", TEST_HR_BACKEND_ROLE),
             getClusterPermissionsFromCustomRole(ALERTING_GET_MONITOR_ACCESS)
         )

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -2206,11 +2206,11 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             false
         )
 
-        var monitor = createRandomMonitor(refresh = true)
-        val activeAlert = createAlert(randomAlert(monitor).copy(state = Alert.State.ACTIVE))
-
+        val monitor = randomQueryLevelMonitor(enabled = true)
         val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf("role1"))
         assertNotNull("The monitor was not created", createdMonitor)
+
+        val activeAlert = createAlert(randomAlert(createdMonitor).copy(state = Alert.State.ACTIVE))
 
         val acknowledgeUser = "acknowledgeUser"
         createUserWithRoles(

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -2233,6 +2233,145 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
+    fun `test acknowledge alerts fails when filterByAccessStrategy is all`() {
+        enableFilterBy()
+        putAlertMappings()
+
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        setFilterByBackendRolesStrategy("all")
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1", "role2"),
+            false
+        )
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf("role1", "role2"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        val activeAlert = createAlert(randomAlert(createdMonitor).copy(state = Alert.State.ACTIVE))
+
+        val acknowledgeUser = "acknowledgeUser"
+        createUserWithRoles(
+            acknowledgeUser,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            // does not contain all roles of monitor
+            listOf("role1"),
+            false
+        )
+        val acknowledgeUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), acknowledgeUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            val response = acknowledgeAlertsWithClient(acknowledgeUserClient, createdMonitor, activeAlert)
+            fail("Expected Forbidden exception")
+        } catch (e: ResponseException) {
+            assertEquals("Get monitor failed", RestStatus.FORBIDDEN.status, e.response.statusLine.statusCode)
+        } finally {
+            acknowledgeUserClient?.close()
+        }
+    }
+
+    fun `test acknowledge alerts succeeds when filterByAccessStrategy is exact`() {
+        enableFilterBy()
+        putAlertMappings()
+
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        setFilterByBackendRolesStrategy("exact")
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1", "role2"),
+            false
+        )
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf("role1", "role2"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        val activeAlert = createAlert(randomAlert(createdMonitor).copy(state = Alert.State.ACTIVE))
+
+        val acknowledgeUser = "acknowledgeUser"
+        createUserWithRoles(
+            acknowledgeUser,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            // matches all roles of monitor exactly
+            listOf("role1", "role2"),
+            false
+        )
+        val acknowledgeUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), acknowledgeUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            val response = acknowledgeAlertsWithClient(acknowledgeUserClient, createdMonitor, activeAlert)
+            assertEquals("Acknowledge alert failed", RestStatus.OK, response?.restStatus())
+        } finally {
+            acknowledgeUserClient?.close()
+        }
+    }
+
+    fun `test acknowledge alerts fails when filterByAccessStrategy is exact`() {
+        enableFilterBy()
+        putAlertMappings()
+
+        if (!isHttps()) {
+            // if security is disabled and filter by is enabled, we can't create monitor
+            // refer: `test create monitor with enable filter by`
+            return
+        }
+        setFilterByBackendRolesStrategy("exact")
+
+        createUserWithRoles(
+            user,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            listOf("role1", "role2"),
+            false
+        )
+
+        val monitor = randomQueryLevelMonitor(enabled = true)
+        val createdMonitor = createMonitorWithClient(userClient!!, monitor = monitor, listOf("role1", "role2"))
+        assertNotNull("The monitor was not created", createdMonitor)
+
+        val activeAlert = createAlert(randomAlert(createdMonitor).copy(state = Alert.State.ACTIVE))
+
+        val acknowledgeUser = "acknowledgeUser"
+        createUserWithRoles(
+            acknowledgeUser,
+            listOf(ALERTING_FULL_ACCESS_ROLE, READALL_AND_MONITOR_ROLE),
+            // does not contain all roles of monitor
+            listOf("role1"),
+            false
+        )
+        val acknowledgeUserClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), acknowledgeUser, password)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
+
+        try {
+            val response = acknowledgeAlertsWithClient(acknowledgeUserClient, createdMonitor, activeAlert)
+            fail("Expected Forbidden exception")
+        } catch (e: ResponseException) {
+            assertEquals("Get monitor failed", RestStatus.FORBIDDEN.status, e.response.statusLine.statusCode)
+        } finally {
+            acknowledgeUserClient?.close()
+        }
+    }
+
     // Execute Monitor related security tests
 
     fun `test execute monitor with elevate permissions`() {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -333,7 +333,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
 
     fun `test get monitor with enable filterBy for a user with multiple backend roles`() {
         enableFilterBy()
-        setFilterByBackendRolesStrategy("all")
+        // setFilterByBackendRolesStrategy("all")
 
         createUserWithTestDataAndCustomRole(
             user,

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -390,7 +390,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             // refer: `test create monitor with enable filter by`
             return
         }
-        // setFilterByBackendRolesStrategy("all")
+        setFilterByBackendRolesStrategy("all")
 
         val monitor = randomQueryLevelMonitor(enabled = true)
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/settings/AlertingSettingsTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/settings/AlertingSettingsTests.kt
@@ -80,6 +80,7 @@ class AlertingSettingsTests : OpenSearchTestCase() {
                     AlertingSettings.REQUEST_TIMEOUT,
                     AlertingSettings.MAX_ACTION_THROTTLE_VALUE,
                     AlertingSettings.FILTER_BY_BACKEND_ROLES,
+                    AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY,
                     ScheduledJobSettings.SWEEP_PERIOD,
                     ScheduledJobSettings.SWEEP_PAGE_SIZE,
                     ScheduledJobSettings.SWEEP_BACKOFF_RETRY_COUNT,

--- a/alerting/src/test/kotlin/org/opensearch/alerting/settings/AlertingSettingsTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/settings/AlertingSettingsTests.kt
@@ -93,6 +93,7 @@ class AlertingSettingsTests : OpenSearchTestCase() {
                     AlertingSettings.REQUEST_TIMEOUT,
                     AlertingSettings.MAX_ACTION_THROTTLE_VALUE,
                     AlertingSettings.FILTER_BY_BACKEND_ROLES,
+                    AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY,
                     ScheduledJobSettings.SWEEP_PERIOD,
                     ScheduledJobSettings.SWEEP_PAGE_SIZE,
                     ScheduledJobSettings.SWEEP_BACKOFF_RETRY_COUNT,

--- a/alerting/src/test/kotlin/org/opensearch/alerting/settings/FilterByBackendRolesAccessStrategyValidatorTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/settings/FilterByBackendRolesAccessStrategyValidatorTests.kt
@@ -10,31 +10,11 @@ import kotlin.test.assertFailsWith
 
 class FilterByBackendRolesAccessStrategyValidatorTests : OpenSearchTestCase() {
 
-    fun `test accepts strategy of all`() {
+    fun `test accepts valid strategies`() {
         val validator = FilterByBackendRolesAccessStrategyValidator()
-        try {
-            validator.validate("all")
-        } catch (e: Exception) {
-            fail("Unexpected exception")
-        }
-    }
-
-    fun `test accepts strategy of exact`() {
-        val validator = FilterByBackendRolesAccessStrategyValidator()
-        try {
-            validator.validate("exact")
-        } catch (e: Exception) {
-            fail("Unexpected exception")
-        }
-    }
-
-    fun `test accepts strategy of intersect`() {
-        val validator = FilterByBackendRolesAccessStrategyValidator()
-        try {
-            validator.validate("intersect")
-        } catch (e: Exception) {
-            fail("Unexpected exception")
-        }
+        validator.validate("all")
+        validator.validate("exact")
+        validator.validate("intersect")
     }
 
     fun `test rejects invalid strategy`() {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/settings/FilterByBackendRolesAccessStrategyValidatorTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/settings/FilterByBackendRolesAccessStrategyValidatorTests.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.settings
+
+import org.opensearch.test.OpenSearchTestCase
+import kotlin.test.assertFailsWith
+
+class FilterByBackendRolesAccessStrategyValidatorTests : OpenSearchTestCase() {
+
+    fun `test accepts strategy of all`() {
+        val validator = FilterByBackendRolesAccessStrategyValidator()
+        try {
+            validator.validate("all")
+        } catch (e: Exception) {
+            fail("Unexpected exception")
+        }
+    }
+
+    fun `test accepts strategy of exact`() {
+        val validator = FilterByBackendRolesAccessStrategyValidator()
+        try {
+            validator.validate("exact")
+        } catch (e: Exception) {
+            fail("Unexpected exception")
+        }
+    }
+
+    fun `test accepts strategy of intersect`() {
+        val validator = FilterByBackendRolesAccessStrategyValidator()
+        try {
+            validator.validate("intersect")
+        } catch (e: Exception) {
+            fail("Unexpected exception")
+        }
+    }
+
+    fun `test rejects invalid strategy`() {
+        val validator = FilterByBackendRolesAccessStrategyValidator()
+        assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException") {
+            validator.validate("invalid")
+        }
+    }
+}

--- a/alerting/src/test/kotlin/org/opensearch/alerting/settings/FilterByBackendRolesAccessStrategyValidatorTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/settings/FilterByBackendRolesAccessStrategyValidatorTests.kt
@@ -13,14 +13,23 @@ class FilterByBackendRolesAccessStrategyValidatorTests : OpenSearchTestCase() {
     fun `test accepts valid strategies`() {
         val validator = FilterByBackendRolesAccessStrategyValidator()
         validator.validate("all")
+        validator.validate("ALL")
         validator.validate("exact")
+        validator.validate("EXACT")
         validator.validate("intersect")
+        validator.validate("INTERSECT")
     }
 
     fun `test rejects invalid strategy`() {
         val validator = FilterByBackendRolesAccessStrategyValidator()
         assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException") {
             validator.validate("invalid")
+        }
+        assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException") {
+            validator.validate("")
+        }
+        assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException") {
+            validator.validate(" ")
         }
     }
 }


### PR DESCRIPTION
### Description

This PR adds a new plugin setting, `plugins.alerting.filter_by_backend_roles_access_strategy`, which allows users to control how filtering by backend roles works to determine access to alerting objects (monitors).  The options for this setting are:

- `exact` - Users have access to alerting objects if they have **exactly the same (with no additional)** backend roles as the user who created the object
- `intersect` - Users have access to alerting objects if they share **at least one** backend role with the user who created the object
- `all` - Users have access to alerting objects if their backend roles **contain all of the backend roles** of the user who created the object

### Related Issues

Resolves #1940 

### Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
