### PR TITLE
Add configurable max triggers per monitor setting

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -382,6 +382,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             AlertingSettings.ALERT_HISTORY_MAX_DOCS,
             AlertingSettings.ALERT_HISTORY_RETENTION_PERIOD,
             AlertingSettings.ALERTING_MAX_MONITORS,
+            AlertingSettings.MAX_TRIGGERS_PER_MONITOR,
             AlertingSettings.PERCOLATE_QUERY_DOCS_SIZE_MEMORY_PERCENTAGE_LIMIT,
             AlertingSettings.DOC_LEVEL_MONITOR_FAN_OUT_NODES,
             DOC_LEVEL_MONITOR_SHARD_FETCH_SIZE,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
@@ -25,10 +25,19 @@ class AlertingSettings {
         const val DEFAULT_MAX_DOC_LEVEL_MONITOR_FANOUT_MAX_DURATION_MINUTES = 3L
         const val DEFAULT_MAX_DOC_LEVEL_MONITOR_EXECUTION_MAX_DURATION_MINUTES = 4L
         const val DEFAULT_FAN_OUT_NODES = 1000
+        const val DEFAULT_MAX_TRIGGERS_PER_MONITOR = 10
 
         val ALERTING_MAX_MONITORS = Setting.intSetting(
             "plugins.alerting.monitor.max_monitors",
             LegacyOpenDistroAlertingSettings.ALERTING_MAX_MONITORS,
+            Setting.Property.NodeScope, Setting.Property.Dynamic
+        )
+
+        val MAX_TRIGGERS_PER_MONITOR = Setting.intSetting(
+            "plugins.alerting.monitor.max_triggers",
+            DEFAULT_MAX_TRIGGERS_PER_MONITOR,
+            0,
+            50,
             Setting.Property.NodeScope, Setting.Property.Dynamic
         )
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -37,6 +37,7 @@ import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.settings.AlertingSettings.Companion.ALERTING_MAX_MONITORS
 import org.opensearch.alerting.settings.AlertingSettings.Companion.INDEX_TIMEOUT
 import org.opensearch.alerting.settings.AlertingSettings.Companion.MAX_ACTION_THROTTLE_VALUE
+import org.opensearch.alerting.settings.AlertingSettings.Companion.MAX_TRIGGERS_PER_MONITOR
 import org.opensearch.alerting.settings.AlertingSettings.Companion.REQUEST_TIMEOUT
 import org.opensearch.alerting.settings.DestinationSettings.Companion.ALLOW_LIST
 import org.opensearch.alerting.util.DocLevelMonitorQueries
@@ -106,6 +107,7 @@ class TransportIndexMonitorAction @Inject constructor(
     SecureTransportAction {
 
     @Volatile private var maxMonitors = ALERTING_MAX_MONITORS.get(settings)
+    @Volatile private var maxTriggersPerMonitor = MAX_TRIGGERS_PER_MONITOR.get(settings)
     @Volatile private var requestTimeout = REQUEST_TIMEOUT.get(settings)
     @Volatile private var indexTimeout = INDEX_TIMEOUT.get(settings)
     @Volatile private var maxActionThrottle = MAX_ACTION_THROTTLE_VALUE.get(settings)
@@ -114,6 +116,7 @@ class TransportIndexMonitorAction @Inject constructor(
 
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(ALERTING_MAX_MONITORS) { maxMonitors = it }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(MAX_TRIGGERS_PER_MONITOR) { maxTriggersPerMonitor = it }
         clusterService.clusterSettings.addSettingsUpdateConsumer(REQUEST_TIMEOUT) { requestTimeout = it }
         clusterService.clusterSettings.addSettingsUpdateConsumer(INDEX_TIMEOUT) { indexTimeout = it }
         clusterService.clusterSettings.addSettingsUpdateConsumer(MAX_ACTION_THROTTLE_VALUE) { maxActionThrottle = it }
@@ -378,6 +381,7 @@ class TransportIndexMonitorAction @Inject constructor(
 
             try {
                 validateActionThrottle(request.monitor, maxActionThrottle, TimeValue.timeValueMinutes(1))
+                validateTriggerCount(request.monitor)
             } catch (e: RuntimeException) {
                 actionListener.onFailure(AlertingException.wrap(e))
                 return
@@ -404,6 +408,12 @@ class TransportIndexMonitorAction @Inject constructor(
                         }
                     }
                 )
+            }
+        }
+
+        private fun validateTriggerCount(monitor: Monitor) {
+            require(monitor.triggers.size <= maxTriggersPerMonitor) {
+                "The current cluster settings only allow up to $maxTriggersPerMonitor triggers per monitor."
             }
         }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
@@ -39,6 +39,7 @@ import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.settings.AlertingSettings.Companion.ALERTING_MAX_MONITORS
 import org.opensearch.alerting.settings.AlertingSettings.Companion.INDEX_TIMEOUT
 import org.opensearch.alerting.settings.AlertingSettings.Companion.MAX_ACTION_THROTTLE_VALUE
+import org.opensearch.alerting.settings.AlertingSettings.Companion.MAX_TRIGGERS_PER_MONITOR
 import org.opensearch.alerting.settings.AlertingSettings.Companion.REQUEST_TIMEOUT
 import org.opensearch.alerting.settings.DestinationSettings.Companion.ALLOW_LIST
 import org.opensearch.alerting.util.IndexUtils
@@ -105,6 +106,9 @@ class TransportIndexWorkflowAction @Inject constructor(
     private var maxMonitors = ALERTING_MAX_MONITORS.get(settings)
 
     @Volatile
+    private var maxTriggersPerMonitor = MAX_TRIGGERS_PER_MONITOR.get(settings)
+
+    @Volatile
     private var requestTimeout = REQUEST_TIMEOUT.get(settings)
 
     @Volatile
@@ -121,6 +125,7 @@ class TransportIndexWorkflowAction @Inject constructor(
 
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(ALERTING_MAX_MONITORS) { maxMonitors = it }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(MAX_TRIGGERS_PER_MONITOR) { maxTriggersPerMonitor = it }
         clusterService.clusterSettings.addSettingsUpdateConsumer(REQUEST_TIMEOUT) { requestTimeout = it }
         clusterService.clusterSettings.addSettingsUpdateConsumer(INDEX_TIMEOUT) { indexTimeout = it }
         clusterService.clusterSettings.addSettingsUpdateConsumer(MAX_ACTION_THROTTLE_VALUE) { maxActionThrottle = it }
@@ -178,6 +183,17 @@ class TransportIndexWorkflowAction @Inject constructor(
 
         scope.launch {
             try {
+                val triggerCount = transformedRequest.workflow.triggers.size
+                if (triggerCount > maxTriggersPerMonitor) {
+                    actionListener.onFailure(
+                        AlertingException.wrap(
+                            IllegalArgumentException(
+                                "The current cluster settings only allow up to $maxTriggersPerMonitor triggers per monitor."
+                            )
+                        )
+                    )
+                    return@launch
+                }
                 validateMonitorAccess(
                     transformedRequest,
                     user,

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -1586,4 +1586,44 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         val executeResponse = executeMonitor(monitor2.id)
         assertEquals("Execute monitor failed", RestStatus.OK, executeResponse.restStatus())
     }
+
+    fun `test existing monitor with triggers over new limit still executes`() {
+        // Create monitor with 10 triggers at default limit
+        val triggers = (1..10).map {
+            randomQueryLevelTrigger(name = "trigger-$it", condition = Script("return true"))
+        }
+        val monitor = createMonitor(randomQueryLevelMonitor(triggers = triggers, enabled = true))
+        assertEquals("Monitor should have 10 triggers", 10, monitor.triggers.size)
+
+        // Execute monitor — should succeed
+        val executeResponse = executeMonitor(monitor.id)
+        assertEquals("Execute monitor failed", RestStatus.OK, executeResponse.restStatus())
+
+        // Lower the limit to 5
+        client().updateSettings("plugins.alerting.monitor.max_triggers", 5)
+
+        // Execute the existing monitor again — should still succeed
+        val executeResponse2 = executeMonitor(monitor.id)
+        assertEquals("Existing monitor should still execute after lowering limit", RestStatus.OK, executeResponse2.restStatus())
+
+        // Reset setting
+        client().updateSettings("plugins.alerting.monitor.max_triggers", 10)
+    }
+
+    fun `test new monitor rejected when over trigger limit`() {
+        client().updateSettings("plugins.alerting.monitor.max_triggers", 5)
+        try {
+            val triggers = (1..6).map {
+                randomQueryLevelTrigger(name = "trigger-$it", condition = Script("return true"))
+            }
+            try {
+                createMonitor(randomQueryLevelMonitor(triggers = triggers))
+                fail("Expected monitor creation to fail")
+            } catch (e: ResponseException) {
+                assertEquals("Should be bad request", RestStatus.BAD_REQUEST.status, e.response.statusLine.statusCode)
+            }
+        } finally {
+            client().updateSettings("plugins.alerting.monitor.max_triggers", 10)
+        }
+    }
 }


### PR DESCRIPTION
### Description

Add `plugins.alerting.monitor.max_triggers` cluster setting (default: 10, min: 1, dynamic) to allow configuring the maximum number of triggers per monitor. Validation is performed in `TransportIndexMonitorAction` 
before monitor creation.

Companion common-utils PR: https://github.com/opensearch-project/common-utils/pull/913
Resolves #468


### Related Issues
Resolves #1828 #468 
https://github.com/opensearch-project/alerting/issues/1828
https://github.com/opensearch-project/alerting#468

### Testing

End-to-end tested on a local cluster:
- Default limit (10): 11 triggers rejected — "Monitors can only support up to 10 triggers."
- Limit set to 20: 11 triggers accepted and stored
- Limit set to 5: 6 triggers rejected — "Monitors can only support up to 5 triggers."

Testing info here : https://github.com/opensearch-project/common-utils/pull/913#issue-4054949628 

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
