### PR TITLE
Replace _id sort with _seq_no in JobSweeper to fix fielddata error

### DIFF
--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -1559,4 +1559,31 @@ class MonitorRestApiIT : AlertingRestTestCase() {
             alertingStatsResponse[statsResponseOpenSearchSweeperEnabledField]
         )
     }
+
+    fun `test sweeper works with id field data disabled`() {
+        client().updateSettings(ScheduledJobSettings.SWEEPER_ENABLED.key, true)
+        val monitor = createRandomMonitor(refresh = true)
+        // Disable _id fielddata — this previously broke the sweeper
+        client().updateSettings("indices.id_field_data.enabled", false)
+        try {
+            val monitor2 = createRandomMonitor(refresh = true)
+            assertNotNull("Monitor was not created", monitor2.id)
+            val executeResponse = executeMonitor(monitor2.id)
+            assertEquals("Execute monitor failed", RestStatus.OK, executeResponse.restStatus())
+        } finally {
+            client().updateSettings("indices.id_field_data.enabled", true)
+        }
+    }
+
+    fun `test sweeper works after all monitors deleted`() {
+        client().updateSettings(ScheduledJobSettings.SWEEPER_ENABLED.key, true)
+        val monitor = createRandomMonitor(refresh = true)
+        client().makeRequest("DELETE", "$ALERTING_BASE_URI/${monitor.id}")
+        refreshIndex(ScheduledJob.SCHEDULED_JOBS_INDEX)
+        // Create a new monitor after index was emptied — sweeper should handle this
+        val monitor2 = createRandomMonitor(refresh = true)
+        assertNotNull("Monitor was not created", monitor2.id)
+        val executeResponse = executeMonitor(monitor2.id)
+        assertEquals("Execute monitor failed", RestStatus.OK, executeResponse.restStatus())
+    }
 }

--- a/core/src/main/kotlin/org/opensearch/alerting/core/JobSweeper.kt
+++ b/core/src/main/kotlin/org/opensearch/alerting/core/JobSweeper.kt
@@ -295,7 +295,7 @@ class JobSweeper(
         lastFullSweepTimeNano = System.nanoTime()
     }
 
-    private fun sweepShard(shardId: ShardId, shardNodes: ShardNodes, startAfter: String = "") {
+    private fun sweepShard(shardId: ShardId, shardNodes: ShardNodes, startAfter: Long = -1L) {
         val logger = Loggers.getLogger(javaClass, shardId)
         logger.debug("Sweeping shard $shardId")
 
@@ -308,7 +308,7 @@ class JobSweeper(
 
         // sweep the shard for new and updated jobs. Uses a search after query to paginate, assuming that any concurrent
         // updates and deletes are handled by the index operation listener.
-        var searchAfter: String? = startAfter
+        var searchAfter: Long? = startAfter
         while (searchAfter != null) {
             val boolQueryBuilder = BoolQueryBuilder()
             sweepableJobTypes.forEach { boolQueryBuilder.should(QueryBuilders.existsQuery(it)) }
@@ -318,18 +318,23 @@ class JobSweeper(
                 .source(
                     SearchSourceBuilder.searchSource()
                         .version(true)
+                        .seqNoAndPrimaryTerm(true)
                         .sort(
-                            FieldSortBuilder("_id")
-                                .unmappedType("keyword")
-                                .missing("_last")
+                            FieldSortBuilder("_seq_no")
+                                .unmappedType("long")
                         )
                         .searchAfter(arrayOf(searchAfter))
                         .size(sweepPageSize)
                         .query(boolQueryBuilder)
                 )
 
-            val response = sweepSearchBackoff.retry {
-                client.search(jobSearchRequest).actionGet(requestTimeout)
+            val response = try {
+                sweepSearchBackoff.retry {
+                    client.search(jobSearchRequest).actionGet(requestTimeout)
+                }
+            } catch (e: Exception) {
+                logger.error("Aborting sweep of shard $shardId, will retry on next sweep cycle.", e)
+                return
             }
             if (response.status() != RestStatus.OK) {
                 logger.error("Error sweeping shard $shardId.", response.firstFailureOrNull())
@@ -344,7 +349,7 @@ class JobSweeper(
                     parseAndSweepJob(xcp, shardId, hit.id, hit.version, hit.sourceRef)
                 }
             }
-            searchAfter = response.hits.lastOrNull()?.id
+            searchAfter = response.hits.lastOrNull()?.seqNo
         }
     }
 


### PR DESCRIPTION
### Description

 When indices.id_field_data.enabled is set to false, the JobSweeper fails with Fielddata access on the _id field is disallowed because it sorts by _id during search_after pagination.

This replaces FieldSortBuilder("_id") with FieldSortBuilder("_seq_no"). _seq_no has doc_values enabled by default (no fielddata needed) and is unique per shard, which the sweeper already scopes to via _shards preference.

Resolves #2037

### Related Issues
Resolves #2037

### Testing

```
**Before fix (on main):**                                                                                                                                                                                                                                      1. Started local cluster: ./gradlew :alerting:run
 2. Created a monitor — succeeded
3. Disabled _id fielddata: PUT _cluster/settings {"persistent": {"indices.id_field_data.enabled": false}}
4. Waited for sweeper cycle (~60s)
5. Result: sweeper fails repeatedly every cycle:
 

> [ERROR][o.o.a.c.JobSweeper] [integTest-0] [.opendistro-alerting-config][0] Error while sweeping shard [.opendistro-alerting-config][0]
> org.opensearch.action.search.SearchPhaseExecutionException: all shards failed
>   at org.opensearch.index.mapper.IdFieldMapper$IdFieldType.fielddataBuilder(IdFieldMapper.java:184)
> 

 **After fix:**
 1. Built with fix, replaced core jar in test cluster
 2. Disabled _id fielddata before creating any monitors
 3. Created first monitor — succeeded, sweeper scheduled it
 4. Created second monitor — succeeded, sweeper scheduled it
 5. Waited for sweeper cycle (~65s)
 6. Result: no fielddata errors, both monitors scheduled : 
 
> [INFO][o.o.a.c.s.JobScheduler] Scheduling jobId : Yvti45wBWj1CzDFgjaLp, name: test-sweeper-fix
> [INFO][o.o.a.c.s.JobScheduler] Scheduling jobId : cftr45wBWj1CzDFgzKLx, name: test-sweeper-fix-2


```

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
