### PR TITLE
fix: Set cancelAfterTimeInterval on SearchRequest in InputService and…

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/InputService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/InputService.kt
@@ -19,6 +19,7 @@ import org.opensearch.alerting.util.IndexUtils
 import org.opensearch.alerting.util.addUserBackendRolesFilter
 import org.opensearch.alerting.util.clusterMetricsMonitorHelpers.executeTransportAction
 import org.opensearch.alerting.util.clusterMetricsMonitorHelpers.toMap
+import org.opensearch.alerting.util.getCancelAfterTimeInterval
 import org.opensearch.alerting.util.getRoleFilterEnabled
 import org.opensearch.alerting.util.use
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver
@@ -26,6 +27,7 @@ import org.opensearch.cluster.routing.Preference
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.io.stream.BytesStreamOutput
 import org.opensearch.common.settings.Settings
+import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.alerting.model.ClusterMetricsInput
@@ -186,6 +188,11 @@ class InputService(
                 searchRequest.source(SearchSourceBuilder.fromXContent(it))
             }
 
+            val cancelTimeout = getCancelAfterTimeInterval()
+            if (cancelTimeout != -1L) {
+                searchRequest.cancelAfterTimeInterval = TimeValue.timeValueMinutes(cancelTimeout)
+            }
+
             // Add user role filter for AD result
             client.threadPool().threadContext.stashContext().use {
                 // Possible long term solution:
@@ -267,6 +274,11 @@ class InputService(
 
         XContentType.JSON.xContent().createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, searchSource).use {
             searchRequest.source(SearchSourceBuilder.fromXContent(it))
+        }
+
+        val cancelTimeout = getCancelAfterTimeInterval()
+        if (cancelTimeout != -1L) {
+            searchRequest.cancelAfterTimeInterval = TimeValue.timeValueMinutes(cancelTimeout)
         }
 
         return searchRequest

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
@@ -59,6 +59,7 @@ import org.opensearch.alerting.util.destinationmigration.getTitle
 import org.opensearch.alerting.util.destinationmigration.publishLegacyNotification
 import org.opensearch.alerting.util.destinationmigration.sendNotification
 import org.opensearch.alerting.util.getActionExecutionPolicy
+import org.opensearch.alerting.util.getCancelAfterTimeInterval
 import org.opensearch.alerting.util.isAllowed
 import org.opensearch.alerting.util.isTestAction
 import org.opensearch.alerting.util.parseSampleDocTags
@@ -68,6 +69,7 @@ import org.opensearch.cluster.routing.Preference
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
 import org.opensearch.common.settings.Settings
+import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.alerting.AlertingPluginInterface
@@ -970,6 +972,11 @@ class TransportDocLevelMonitorFanOutAction
                     .query(boolQueryBuilder)
             )
 
+        val cancelTimeout = getCancelAfterTimeInterval()
+        if (cancelTimeout != -1L) {
+            request.cancelAfterTimeInterval = TimeValue.timeValueMinutes(cancelTimeout)
+        }
+
         val response: SearchResponse = client.suspendUntil { client.search(request, it) }
         if (response.status() !== RestStatus.OK) {
             throw IOException(
@@ -1014,6 +1021,10 @@ class TransportDocLevelMonitorFanOutAction
         val searchSourceBuilder = SearchSourceBuilder()
         searchSourceBuilder.query(boolQueryBuilder)
         searchRequest.source(searchSourceBuilder)
+        val cancelTimeout = getCancelAfterTimeInterval()
+        if (cancelTimeout != -1L) {
+            searchRequest.cancelAfterTimeInterval = TimeValue.timeValueMinutes(cancelTimeout)
+        }
         log.debug(
             "Monitor ${monitor.id}: " +
                 "Executing percolate query for docs from source indices " +
@@ -1092,6 +1103,11 @@ class TransportDocLevelMonitorFanOutAction
                     .query(boolQueryBuilder)
                     .size(docLevelMonitorShardFetchSize)
             )
+
+        val cancelTimeout = getCancelAfterTimeInterval()
+        if (cancelTimeout != -1L) {
+            request.cancelAfterTimeInterval = TimeValue.timeValueMinutes(cancelTimeout)
+        }
 
         if (fieldsToFetch.isNotEmpty() && fetchOnlyQueryFieldNames) {
             request.source().fetchSource(false)

--- a/alerting/src/test/kotlin/org/opensearch/alerting/util/AlertingUtilsTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/util/AlertingUtilsTests.kt
@@ -5,6 +5,8 @@
 
 package org.opensearch.alerting.util
 
+import org.opensearch.alerting.AlertService
+import org.opensearch.alerting.MonitorRunnerService
 import org.opensearch.alerting.model.AlertContext
 import org.opensearch.alerting.randomAction
 import org.opensearch.alerting.randomBucketLevelTrigger
@@ -14,6 +16,7 @@ import org.opensearch.alerting.randomQueryLevelTrigger
 import org.opensearch.alerting.randomTemplateScript
 import org.opensearch.alerting.script.BucketLevelTriggerExecutionContext
 import org.opensearch.alerting.script.DocumentLevelTriggerExecutionContext
+import org.opensearch.common.unit.TimeValue
 import org.opensearch.test.OpenSearchTestCase
 
 class AlertingUtilsTests : OpenSearchTestCase() {
@@ -175,5 +178,36 @@ class AlertingUtilsTests : OpenSearchTestCase() {
         )
 
         triggers.forEach { trigger -> assertFalse(printsSampleDocData(trigger)) }
+    }
+
+    fun `test getCancelAfterTimeInterval returns -1 when setting is default`() {
+        val original = MonitorRunnerService.monitorCtx.cancelAfterTimeInterval
+        try {
+            MonitorRunnerService.monitorCtx.cancelAfterTimeInterval = TimeValue.timeValueMinutes(-1)
+            assertEquals(-1L, getCancelAfterTimeInterval())
+        } finally {
+            MonitorRunnerService.monitorCtx.cancelAfterTimeInterval = original
+        }
+    }
+
+    fun `test getCancelAfterTimeInterval returns at least ALERTS_SEARCH_TIMEOUT`() {
+        val original = MonitorRunnerService.monitorCtx.cancelAfterTimeInterval
+        try {
+            // Setting lower than ALERTS_SEARCH_TIMEOUT (5 min) should return 5 min
+            MonitorRunnerService.monitorCtx.cancelAfterTimeInterval = TimeValue.timeValueMinutes(1)
+            assertEquals(AlertService.ALERTS_SEARCH_TIMEOUT.minutes, getCancelAfterTimeInterval())
+        } finally {
+            MonitorRunnerService.monitorCtx.cancelAfterTimeInterval = original
+        }
+    }
+
+    fun `test getCancelAfterTimeInterval returns setting when higher than ALERTS_SEARCH_TIMEOUT`() {
+        val original = MonitorRunnerService.monitorCtx.cancelAfterTimeInterval
+        try {
+            MonitorRunnerService.monitorCtx.cancelAfterTimeInterval = TimeValue.timeValueMinutes(10)
+            assertEquals(10L, getCancelAfterTimeInterval())
+        } finally {
+            MonitorRunnerService.monitorCtx.cancelAfterTimeInterval = original
+        }
     }
 }


### PR DESCRIPTION

### Description

PR #1366 set `cancelAfterTimeInterval` on `SearchRequest` in `BucketLevelMonitorRunner` and `DocumentLevelMonitorRunner` to prevent the global `search.cancel_after_time_interval` cluster setting from prematurely cancelling monitor searches.

However, it missed:
- `InputService.getSearchRequest()` — used by QueryLevel and BucketLevel monitors for input collection
- `InputService.collectInputResultsForADMonitor()` — used by Anomaly Detection monitors
- `TransportDocLevelMonitorFanOutAction` — added after #1366, has 3 `SearchRequest` sites (max seq no query, percolate query, shard fetch) with no `cancelAfterTimeInterval`

This PR sets `cancelAfterTimeInterval` on all remaining `SearchRequest` constructions, with a guard against the `-1` default to avoid setting a negative timeout.

Also adds unit tests for `getCancelAfterTimeInterval()`.

Resolves #827

### Testing

```
> Task :alerting:testClasses UP-TO-DATE
> Task :alerting-core:processResources UP-TO-DATE
> Task :alerting-core:classes UP-TO-DATE
> Task :alerting-core:jar UP-TO-DATE
> Task :alerting:test

[Incubating] Problems report is available at: file:///workplace/ragamanu/alerting/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/9.4.0/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 3s
14 actionable tasks: 1 executed, 13 up-to-date
```

### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
