### PR TITLE
Fix NPE when nested field type has no properties in doc-level monitor

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
@@ -237,7 +237,7 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
                 // This is all information we need to update this node
                 val (oldName, newName, props) = processLeafFn(it.key, fullPath, it.value as MutableMap<String, Any>)
                 newNodes.add(Triple(oldName, newName, props))
-            } else {
+            } else if (nodeProps.containsKey(PROPERTIES) && nodeProps[PROPERTIES] != null) {
                 // Internal(non-leaf) node - visit children
                 traverseMappingsAndUpdate(nodeProps[PROPERTIES] as MutableMap<String, Any>, fullPath, processLeafFn, flattenPaths)
             }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/util/AlertingUtilsTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/util/AlertingUtilsTests.kt
@@ -5,6 +5,7 @@
 
 package org.opensearch.alerting.util
 
+import org.mockito.Mockito.mock
 import org.opensearch.alerting.AlertService
 import org.opensearch.alerting.MonitorRunnerService
 import org.opensearch.alerting.model.AlertContext
@@ -16,9 +17,10 @@ import org.opensearch.alerting.randomQueryLevelTrigger
 import org.opensearch.alerting.randomTemplateScript
 import org.opensearch.alerting.script.BucketLevelTriggerExecutionContext
 import org.opensearch.alerting.script.DocumentLevelTriggerExecutionContext
+import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.test.OpenSearchTestCase
-
+import org.opensearch.transport.client.Client
 class AlertingUtilsTests : OpenSearchTestCase() {
     fun `test parseSampleDocTags only returns expected tags`() {
         val expectedDocSourceTags = (0..3).map { "field$it" }
@@ -209,5 +211,49 @@ class AlertingUtilsTests : OpenSearchTestCase() {
         } finally {
             MonitorRunnerService.monitorCtx.cancelAfterTimeInterval = original
         }
+    }
+
+    fun `test traverseMappingsAndUpdate with nested field type without properties succeeds`() {
+        // Verifies fix for https://github.com/opensearch-project/security-analytics/issues/1472
+        val docLevelMonitorQueries = DocLevelMonitorQueries(mock(Client::class.java), mock(ClusterService::class.java))
+        val mappings = mutableMapOf<String, Any>(
+            "message" to mutableMapOf<String, Any>("type" to "text"),
+            "http_request_headers" to mutableMapOf<String, Any>("type" to "nested")
+        )
+        val flattenPaths = mutableMapOf<String, MutableMap<String, Any>>()
+        val leafProcessor =
+            fun(fieldName: String, _: String, props: MutableMap<String, Any>):
+                Triple<String, String, MutableMap<String, Any>> {
+                return Triple(fieldName, fieldName, props)
+            }
+
+        docLevelMonitorQueries.traverseMappingsAndUpdate(mappings, "", leafProcessor, flattenPaths)
+
+        assertTrue("Expected 'message' in flatten paths", flattenPaths.containsKey("message"))
+        assertFalse("Expected nested field to be skipped", flattenPaths.containsKey("http_request_headers"))
+    }
+
+    fun `test traverseMappingsAndUpdate with nested field type with properties works`() {
+        val docLevelMonitorQueries = DocLevelMonitorQueries(mock(Client::class.java), mock(ClusterService::class.java))
+        val mappings = mutableMapOf<String, Any>(
+            "message" to mutableMapOf<String, Any>("type" to "text"),
+            "dll" to mutableMapOf<String, Any>(
+                "type" to "nested",
+                "properties" to mutableMapOf<String, Any>(
+                    "name" to mutableMapOf<String, Any>("type" to "keyword")
+                )
+            )
+        )
+        val flattenPaths = mutableMapOf<String, MutableMap<String, Any>>()
+        val leafProcessor =
+            fun(fieldName: String, _: String, props: MutableMap<String, Any>):
+                Triple<String, String, MutableMap<String, Any>> {
+                return Triple(fieldName, fieldName, props)
+            }
+
+        docLevelMonitorQueries.traverseMappingsAndUpdate(mappings, "", leafProcessor, flattenPaths)
+
+        assertTrue("Expected 'message' in flatten paths", flattenPaths.containsKey("message"))
+        assertTrue("Expected 'dll.name' in flatten paths", flattenPaths.containsKey("dll.name"))
     }
 }


### PR DESCRIPTION
### Description

A nested field with type nested but no sub-properties (e.g. "http_request_headers": {"type": "nested"}) causes a NullPointerException during doc-level monitor creation.

In DocLevelMonitorQueries.traverseMappingsAndUpdate(), the code assumes all non-leaf nodes have a properties map. When a field has type: "nested", it's treated as an internal node and the code unconditionally 
casts nodeProps["properties"] to MutableMap<String, Any>. If the nested field has no sub-properties, this is null, causing the crash.

Fix: Added a null guard before recursing into nested field properties. Fields with type: "nested" and no properties are now safely skipped during traversal.

Testing: Added unit tests to AlertingUtilsTests covering both cases:
- Nested field without properties — skipped, no exception
- Nested field with properties — sub-fields traversed correctly

### Related Issues
Resolves https://github.com/opensearch-project/security-analytics/issues/1472

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using --signoff.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of
-origin).