### PR TITLE
Fix sample-remote-monitor-plugin compilation after Target field addition

### DIFF
--- a/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/SampleRemoteMonitorRestHandler.java
+++ b/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/SampleRemoteMonitorRestHandler.java
@@ -96,7 +96,8 @@ public class SampleRemoteMonitorRestHandler extends BaseRestHandler {
                 new DataSources(),
                 false,
                 false,
-                "sample-remote-monitor-plugin"
+                "sample-remote-monitor-plugin",
+                null
         );
         IndexMonitorRequest indexMonitorRequest1 = new IndexMonitorRequest(
                 Monitor.NO_ID,
@@ -158,7 +159,8 @@ public class SampleRemoteMonitorRestHandler extends BaseRestHandler {
                     new DataSources(),
                     false,
                     false,
-                    "sample-remote-monitor-plugin"
+                    "sample-remote-monitor-plugin",
+                null
             );
             IndexMonitorRequest indexMonitorRequest2 = new IndexMonitorRequest(
                     Monitor.NO_ID,
@@ -243,7 +245,8 @@ public class SampleRemoteMonitorRestHandler extends BaseRestHandler {
                     new DataSources(),
                     false,
                     false,
-                    "sample-remote-monitor-plugin"
+                    "sample-remote-monitor-plugin",
+                null
             );
             IndexMonitorRequest indexDocLevelMonitorRequest = new IndexMonitorRequest(
                     Monitor.NO_ID,


### PR DESCRIPTION
### Description

Fix compilation error in sample-remote-monitor-plugin after the Target field was added to the Monitor constructor in common-utils. The Monitor constructor now requires a Target parameter — added null (default LOCAL target) to all 3 Monitor construct
or calls in SampleRemoteMonitorRestHandler.

### Related Issues
Depends on opensearch-project/common-utils#916

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

