### PR TITLE
Fix listener leak in TransportExecuteMonitorAction for empty source

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
@@ -135,6 +135,15 @@ class TransportExecuteMonitorAction @Inject constructor(
                                 val monitor = ScheduledJob.parse(xcp, getResponse.id, getResponse.version) as Monitor
                                 executeMonitor(monitor)
                             }
+                        } else {
+                            actionListener.onFailure(
+                                AlertingException.wrap(
+                                    OpenSearchStatusException(
+                                        "Monitor source is empty for id: ${execMonitorRequest.monitorId}",
+                                        RestStatus.NOT_FOUND
+                                    )
+                                )
+                            )
                         }
                     } catch (e: Exception) {
                         log.error("Failed to get monitor ${execMonitorRequest.monitorId} for execution", e)


### PR DESCRIPTION
PR description:
### Description
Add else block in TransportExecuteMonitorAction when `getResponse.isSourceEmpty` is true. Without this, the action listener is never notified when the monitor source is empty, causing the thread to hang indefinitely and potentially dropping nodes.

### Related Issues
Follow-up from #2061 (review comment from @eirsep)

Part of #2094

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
