### PR TITLE
Use SdkClient for persistence in MonitorMetadataService

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -357,6 +357,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             xContentRegistry,
             settings
         )
+        MonitorMetadataService.sdkClient = sdkClient
 
         WorkflowMetadataService.initialize(
             client,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt
@@ -13,26 +13,19 @@ import org.apache.logging.log4j.LogManager
 import org.opensearch.ExceptionsHelper
 import org.opensearch.OpenSearchSecurityException
 import org.opensearch.OpenSearchStatusException
-import org.opensearch.action.DocWriteRequest
-import org.opensearch.action.DocWriteResponse
 import org.opensearch.action.admin.indices.get.GetIndexRequest
 import org.opensearch.action.admin.indices.get.GetIndexResponse
 import org.opensearch.action.admin.indices.stats.IndicesStatsAction
 import org.opensearch.action.admin.indices.stats.IndicesStatsRequest
 import org.opensearch.action.admin.indices.stats.IndicesStatsResponse
-import org.opensearch.action.get.GetRequest
-import org.opensearch.action.get.GetResponse
-import org.opensearch.action.index.IndexRequest
-import org.opensearch.action.index.IndexResponse
-import org.opensearch.action.support.WriteRequest
 import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.util.IndexUtils
+import org.opensearch.alerting.util.await
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
-import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.alerting.model.DocLevelMonitorInput
@@ -44,9 +37,13 @@ import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.core.rest.RestStatus
 import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.core.xcontent.ToXContentObject
 import org.opensearch.core.xcontent.XContentParser
 import org.opensearch.core.xcontent.XContentParserUtils
 import org.opensearch.index.seqno.SequenceNumbers
+import org.opensearch.remote.metadata.client.GetDataObjectRequest
+import org.opensearch.remote.metadata.client.PutDataObjectRequest
+import org.opensearch.remote.metadata.client.SdkClient
 import org.opensearch.transport.RemoteTransportException
 import org.opensearch.transport.client.Client
 
@@ -59,6 +56,7 @@ object MonitorMetadataService :
     private lateinit var xContentRegistry: NamedXContentRegistry
     private lateinit var clusterService: ClusterService
     private lateinit var settings: Settings
+    lateinit var sdkClient: SdkClient
 
     @Volatile
     private lateinit var indexTimeout: TimeValue
@@ -77,49 +75,43 @@ object MonitorMetadataService :
         this.clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.INDEX_TIMEOUT) { indexTimeout = it }
     }
 
+    private fun getTenantId(): String? =
+        client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+
     @Suppress("ComplexMethod", "ReturnCount")
     suspend fun upsertMetadata(metadata: MonitorMetadata, updating: Boolean): MonitorMetadata {
         try {
             if (clusterService.state().routingTable.hasIndex(ScheduledJob.SCHEDULED_JOBS_INDEX)) {
-                val indexRequest = IndexRequest(ScheduledJob.SCHEDULED_JOBS_INDEX)
-                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                    .source(
-                        metadata.toXContent(
-                            XContentFactory.jsonBuilder(),
-                            ToXContent.MapParams(mapOf("with_type" to "true"))
-                        )
-                    )
+                val metadataObj = ToXContentObject { builder, _ ->
+                    metadata.toXContent(builder, ToXContent.MapParams(mapOf("with_type" to "true")))
+                }
+                val putRequestBuilder = PutDataObjectRequest.builder()
+                    .index(ScheduledJob.SCHEDULED_JOBS_INDEX)
                     .id(metadata.id)
-                    .routing(metadata.monitorId)
-                    .setIfSeqNo(metadata.seqNo)
-                    .setIfPrimaryTerm(metadata.primaryTerm)
-                    .timeout(indexTimeout)
+                    .tenantId(getTenantId())
+                    .dataObject(metadataObj)
 
                 if (updating) {
-                    indexRequest.id(metadata.id).setIfSeqNo(metadata.seqNo).setIfPrimaryTerm(metadata.primaryTerm)
+                    putRequestBuilder.ifSeqNo(metadata.seqNo).ifPrimaryTerm(metadata.primaryTerm)
+                        .overwriteIfExists(true)
                 } else {
-                    indexRequest.opType(DocWriteRequest.OpType.CREATE)
+                    putRequestBuilder.overwriteIfExists(false)
                 }
-                val response: IndexResponse = client.suspendUntil { index(indexRequest, it) }
-                when (response.result) {
-                    DocWriteResponse.Result.DELETED, DocWriteResponse.Result.NOOP, DocWriteResponse.Result.NOT_FOUND, null -> {
-                        val failureReason =
-                            "The upsert metadata call failed with a ${response.result?.lowercase} result"
-                        log.error(failureReason)
-                        throw AlertingException(
-                            failureReason,
-                            RestStatus.INTERNAL_SERVER_ERROR,
-                            IllegalStateException(failureReason)
-                        )
-                    }
 
-                    DocWriteResponse.Result.CREATED, DocWriteResponse.Result.UPDATED -> {
-                        log.debug("Successfully upserted MonitorMetadata:${metadata.id} ")
-                    }
+                val putResponse = sdkClient.putDataObjectAsync(putRequestBuilder.build()).await()
+                if (putResponse.isFailed) {
+                    val failureReason = "The upsert metadata call failed: ${putResponse.cause()?.message}"
+                    log.error(failureReason)
+                    throw AlertingException(
+                        failureReason,
+                        putResponse.status() ?: RestStatus.INTERNAL_SERVER_ERROR,
+                        putResponse.cause() ?: IllegalStateException(failureReason)
+                    )
                 }
+                log.debug("Successfully upserted MonitorMetadata:${metadata.id} ")
                 return metadata.copy(
-                    seqNo = response.seqNo,
-                    primaryTerm = response.primaryTerm
+                    seqNo = putResponse.indexResponse()?.seqNo ?: SequenceNumbers.UNASSIGNED_SEQ_NO,
+                    primaryTerm = putResponse.indexResponse()?.primaryTerm ?: SequenceNumbers.UNASSIGNED_PRIMARY_TERM
                 )
             } else {
                 val failureReason = "Job index ${ScheduledJob.SCHEDULED_JOBS_INDEX} does not exist to update monitor metadata"
@@ -180,10 +172,15 @@ object MonitorMetadataService :
     suspend fun getMetadata(monitor: Monitor, workflowMetadataId: String? = null): MonitorMetadata? {
         try {
             val metadataId = MonitorMetadata.getId(monitor, workflowMetadataId)
-            val getRequest = GetRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, metadataId).routing(monitor.id)
+            val getRequest = GetDataObjectRequest.builder()
+                .index(ScheduledJob.SCHEDULED_JOBS_INDEX)
+                .id(metadataId)
+                .tenantId(getTenantId())
+                .build()
 
-            val getResponse: GetResponse = client.suspendUntil { get(getRequest, it) }
-            return if (getResponse.isExists) {
+            val response = sdkClient.getDataObjectAsync(getRequest).await()
+            val getResponse = response.getResponse()
+            return if (getResponse != null && getResponse.isExists) {
                 val xcp = XContentHelper.createParser(
                     xContentRegistry, LoggingDeprecationHandler.INSTANCE,
                     getResponse.sourceAsBytesRef, XContentType.JSON
@@ -194,12 +191,21 @@ object MonitorMetadataService :
                 null
             }
         } catch (e: Exception) {
-            if (e.message?.contains("no such index") == true) {
+            if (isIndexNotFoundException(e)) {
                 return null
             } else {
                 throw AlertingException.wrap(e)
             }
         }
+    }
+
+    private fun isIndexNotFoundException(e: Throwable): Boolean {
+        var cause: Throwable? = e
+        while (cause != null) {
+            if (cause.message?.contains("no such index") == true) return true
+            cause = cause.cause
+        }
+        return false
     }
 
     suspend fun recreateRunContext(metadata: MonitorMetadata, monitor: Monitor): MonitorMetadata {


### PR DESCRIPTION
### Description                                                                                                                                                                                                   
Migrates MonitorMetadataService.upsertMetadata() and getMetadata() to use SdkClient instead of direct OpenSearch client calls, as part of the remote metadata SDK migration for background services.

Changes:
- MonitorMetadataService.upsertMetadata(): Replaced IndexRequest with PutDataObjectRequest via sdkClient.putDataObjectAsync()
- MonitorMetadataService.getMetadata(): Replaced GetRequest with GetDataObjectRequest via sdkClient.getDataObjectAsync()
- AlertingPlugin.kt: Set sdkClient on MonitorMetadataService after SDK client creation
- SdkUtils.kt: Added suspend fun CompletionStage<T>.await() helper for coroutine-safe SDK calls (same as #2081)

Notes:
- createFullRunContext() calls (getIndex, indicesStats) are admin/infrastructure operations and remain on direct client
- Routing was previously used on SCHEDULED_JOBS_INDEX but is optional (not _routing.required: true), so SDK migration works without routing support
- Depends on #2081 for SdkUtils.kt

### Related Issues
Part of #2094 

Part of #2094

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using --signoff.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate
-of-origin).