### PR TITLE
Migrates AlertService to use SdkClient for all alert persistence operations (

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt
@@ -7,30 +7,21 @@ package org.opensearch.alerting
 
 import org.apache.logging.log4j.LogManager
 import org.opensearch.ExceptionsHelper
-import org.opensearch.action.DocWriteRequest
 import org.opensearch.action.bulk.BackoffPolicy
-import org.opensearch.action.bulk.BulkRequest
-import org.opensearch.action.bulk.BulkResponse
-import org.opensearch.action.delete.DeleteRequest
-import org.opensearch.action.index.IndexRequest
-import org.opensearch.action.index.IndexResponse
-import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.search.SearchResponse
-import org.opensearch.action.support.WriteRequest
 import org.opensearch.alerting.alerts.AlertIndices
 import org.opensearch.alerting.opensearchapi.firstFailureOrNull
 import org.opensearch.alerting.opensearchapi.retry
-import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.script.ChainedAlertTriggerExecutionContext
 import org.opensearch.alerting.script.DocumentLevelTriggerExecutionContext
 import org.opensearch.alerting.script.QueryLevelTriggerExecutionContext
 import org.opensearch.alerting.util.CommentsUtils
 import org.opensearch.alerting.util.IndexUtils
 import org.opensearch.alerting.util.MAX_SEARCH_SIZE
+import org.opensearch.alerting.util.await
 import org.opensearch.alerting.util.getBucketKeysHash
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
-import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.alerting.alerts.AlertError
@@ -53,13 +44,18 @@ import org.opensearch.core.action.ActionListener
 import org.opensearch.core.common.bytes.BytesReference
 import org.opensearch.core.rest.RestStatus
 import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.core.xcontent.ToXContentObject
 import org.opensearch.core.xcontent.XContentParser
 import org.opensearch.core.xcontent.XContentParserUtils
-import org.opensearch.index.VersionType
 import org.opensearch.index.query.QueryBuilders
 import org.opensearch.index.reindex.BulkByScrollResponse
 import org.opensearch.index.reindex.DeleteByQueryAction
 import org.opensearch.index.reindex.DeleteByQueryRequestBuilder
+import org.opensearch.remote.metadata.client.BulkDataObjectRequest
+import org.opensearch.remote.metadata.client.DeleteDataObjectRequest
+import org.opensearch.remote.metadata.client.PutDataObjectRequest
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.search.sort.SortOrder
 import org.opensearch.transport.client.Client
@@ -69,12 +65,12 @@ import java.util.concurrent.TimeUnit
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
-
 /** Service that handles CRUD operations for alerts */
 class AlertService(
     val client: Client,
     val xContentRegistry: NamedXContentRegistry,
-    val alertIndices: AlertIndices
+    val alertIndices: AlertIndices,
+    val sdkClient: SdkClient
 ) {
 
     companion object {
@@ -483,8 +479,10 @@ class AlertService(
     ) {
         val newErrorAlertId = "$ERROR_ALERT_ID_PREFIX-${monitor.id}-${UUID.randomUUID()}"
 
-        val searchRequest = SearchRequest(monitor.dataSources.alertsIndex)
-            .source(
+        val searchRequest = SearchDataObjectRequest.builder()
+            .indices(monitor.dataSources.alertsIndex)
+            .routing(monitor.id)
+            .searchSourceBuilder(
                 SearchSourceBuilder()
                     .sort(Alert.START_TIME_FIELD, SortOrder.DESC)
                     .query(
@@ -493,7 +491,9 @@ class AlertService(
                             .must(QueryBuilders.termQuery(Alert.STATE_FIELD, Alert.State.ERROR.name))
                     )
             )
-        val searchResponse: SearchResponse = client.suspendUntil { search(searchRequest, it) }
+            .build()
+        val searchResponse: SearchResponse = sdkClient.searchDataObjectAsync(searchRequest).await()
+            .searchResponse() ?: throw RuntimeException("Unknown error searching for error alerts")
 
         var alert =
             composeMonitorErrorAlert(newErrorAlertId, monitor, AlertError(Instant.now(), errorMessage), executionId, workflowRunContext)
@@ -523,22 +523,29 @@ class AlertService(
             }
         }
 
-        val alertIndexRequest = IndexRequest(monitor.dataSources.alertsIndex)
-            .routing(alert.monitorId)
-            .source(alert.toXContentWithUser(XContentFactory.jsonBuilder()))
-            .opType(DocWriteRequest.OpType.INDEX)
-            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+        val putRequest = PutDataObjectRequest.builder()
+            .index(monitor.dataSources.alertsIndex)
             .id(alert.id)
-
-        val indexResponse: IndexResponse = client.suspendUntil { index(alertIndexRequest, it) }
-        logger.debug("Monitor error Alert successfully upserted. Op result: ${indexResponse.result}")
+            .routing(alert.monitorId)
+            .overwriteIfExists(true)
+            .dataObject(ToXContentObject { builder, _ -> alert.toXContentWithUser(builder) })
+            .build()
+        val putResponse = sdkClient.putDataObjectAsync(putRequest).await()
+        if (putResponse.isFailed) {
+            throw ExceptionsHelper.convertToOpenSearchException(
+                putResponse.cause() ?: RuntimeException("Failed to upsert monitor error alert")
+            )
+        }
+        logger.debug("Monitor error Alert successfully upserted. Op result: ${putResponse.indexResponse()?.result}")
     }
 
     suspend fun clearMonitorErrorAlert(monitor: Monitor) {
         val currentTime = Instant.now()
         try {
-            val searchRequest = SearchRequest("${monitor.dataSources.alertsIndex}")
-                .source(
+            val searchRequest = SearchDataObjectRequest.builder()
+                .indices(monitor.dataSources.alertsIndex)
+                .routing(monitor.id)
+                .searchSourceBuilder(
                     SearchSourceBuilder()
                         .size(MAX_SEARCH_SIZE)
                         .sort(Alert.START_TIME_FIELD, SortOrder.DESC)
@@ -547,46 +554,42 @@ class AlertService(
                                 .must(QueryBuilders.termQuery(Alert.MONITOR_ID_FIELD, monitor.id))
                                 .must(QueryBuilders.termQuery(Alert.STATE_FIELD, Alert.State.ERROR.name))
                         )
-
                 )
-            searchRequest.cancelAfterTimeInterval = ALERTS_SEARCH_TIMEOUT
-            val searchResponse: SearchResponse = client.suspendUntil { search(searchRequest, it) }
+                .build()
+            val searchResponse: SearchResponse = sdkClient.searchDataObjectAsync(searchRequest).await()
+                .searchResponse() ?: throw RuntimeException("Unknown error searching for error alerts")
             // If there's no error alert present, there's nothing to clear. We can stop here.
             if (searchResponse.hits.totalHits.value == 0L) {
                 return
             }
 
-            val indexRequests = mutableListOf<IndexRequest>()
+            val bulkRequest = BulkDataObjectRequest(monitor.dataSources.alertsIndex)
             searchResponse.hits.hits.forEach { hit ->
                 if (searchResponse.hits.totalHits.value > 1L) {
                     logger.warn("Found [${searchResponse.hits.totalHits.value}] error alerts for monitor [${monitor.id}] while clearing")
                 }
-                // Deserialize first/latest Alert
                 val xcp = contentParser(hit.sourceRef)
                 val existingErrorAlert = Alert.parse(xcp, hit.id, hit.version)
+                val updatedAlert = existingErrorAlert.copy(endTime = currentTime)
 
-                val updatedAlert = existingErrorAlert.copy(
-                    endTime = currentTime
+                bulkRequest.add(
+                    PutDataObjectRequest.builder()
+                        .index(monitor.dataSources.alertsIndex)
+                        .id(updatedAlert.id)
+                        .routing(monitor.id)
+                        .overwriteIfExists(true)
+                        .dataObject(ToXContentObject { builder, _ -> updatedAlert.toXContentWithUser(builder) })
+                        .build()
                 )
-
-                indexRequests += IndexRequest(monitor.dataSources.alertsIndex)
-                    .routing(monitor.id)
-                    .id(updatedAlert.id)
-                    .source(updatedAlert.toXContentWithUser(XContentFactory.jsonBuilder()))
-                    .opType(DocWriteRequest.OpType.INDEX)
             }
 
-            val bulkResponse: BulkResponse = client.suspendUntil {
-                bulk(BulkRequest().add(indexRequests).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE), it)
-            }
+            val bulkResponse = sdkClient.bulkDataObjectAsync(bulkRequest).await()
             if (bulkResponse.hasFailures()) {
-                bulkResponse.items.forEach { item ->
-                    if (item.isFailed) {
-                        logger.debug("Failed clearing error alert ${item.id} of monitor [${monitor.id}]")
-                    }
+                bulkResponse.responses.filter { it.isFailed }.forEach { item ->
+                    logger.debug("Failed clearing error alert ${item.id()} of monitor [${monitor.id}]")
                 }
             } else {
-                logger.debug("[${bulkResponse.items.size}] Error Alerts successfully cleared. End time set to: $currentTime")
+                logger.debug("[${searchResponse.hits.totalHits.value}] Error Alerts successfully cleared. End time set to: $currentTime")
             }
         } catch (e: Exception) {
             logger.error("Error clearing monitor error alerts for monitor [${monitor.id}]: ${ExceptionsHelper.detailedMessage(e)}")
@@ -599,8 +602,10 @@ class AlertService(
      * */
     suspend fun moveClearedErrorAlertsToHistory(monitorId: String, alertIndex: String, alertHistoryIndex: String) {
         try {
-            val searchRequest = SearchRequest(alertIndex)
-                .source(
+            val searchRequest = SearchDataObjectRequest.builder()
+                .indices(alertIndex)
+                .routing(monitorId)
+                .searchSourceBuilder(
                     SearchSourceBuilder()
                         .size(MAX_SEARCH_SIZE)
                         .query(
@@ -609,43 +614,37 @@ class AlertService(
                                 .must(QueryBuilders.termQuery(Alert.STATE_FIELD, Alert.State.ERROR.name))
                                 .must(QueryBuilders.existsQuery(Alert.END_TIME_FIELD))
                         )
-                        .version(true) // Do we need this?
+                        .version(true)
                 )
-            searchRequest.cancelAfterTimeInterval = ALERTS_SEARCH_TIMEOUT
-            val searchResponse: SearchResponse = client.suspendUntil { search(searchRequest, it) }
+                .build()
+            val searchResponse: SearchResponse = sdkClient.searchDataObjectAsync(searchRequest).await()
+                .searchResponse() ?: throw RuntimeException("Unknown error searching for cleared error alerts")
 
             if (searchResponse.hits.totalHits.value == 0L) {
                 return
             }
 
             // Copy to history index
-
-            val copyRequests = mutableListOf<IndexRequest>()
-
+            val bulkRequest = BulkDataObjectRequest(null)
             searchResponse.hits.hits.forEach { hit ->
-
                 val xcp = contentParser(hit.sourceRef)
                 val alert = Alert.parse(xcp, hit.id, hit.version)
 
-                copyRequests.add(
-                    IndexRequest(alertHistoryIndex)
-                        .routing(alert.monitorId)
-                        .source(hit.sourceRef, XContentType.JSON)
-                        .version(hit.version)
-                        .versionType(VersionType.EXTERNAL_GTE)
+                bulkRequest.add(
+                    PutDataObjectRequest.builder()
+                        .index(alertHistoryIndex)
                         .id(hit.id)
-                        .timeout(MonitorRunnerService.monitorCtx.indexTimeout)
+                        .routing(alert.monitorId)
+                        .overwriteIfExists(true)
+                        .dataObject(ToXContentObject { builder, _ -> alert.toXContentWithUser(builder) })
+                        .build()
                 )
             }
 
-            val bulkResponse: BulkResponse = client.suspendUntil {
-                bulk(BulkRequest().add(copyRequests).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE), it)
-            }
+            val bulkResponse = sdkClient.bulkDataObjectAsync(bulkRequest).await()
             if (bulkResponse.hasFailures()) {
-                bulkResponse.items.forEach { item ->
-                    if (item.isFailed) {
-                        logger.error("Failed copying error alert [${item.id}] to history index [$alertHistoryIndex]")
-                    }
+                bulkResponse.responses.filter { it.isFailed }.forEach { item ->
+                    logger.error("Failed copying error alert [${item.id()}] to history index [$alertHistoryIndex]")
                 }
                 return
             }
@@ -687,29 +686,32 @@ class AlertService(
 
         val commentIdsToDelete = mutableListOf<String>()
 
-        var requestsToRetry = alerts.flatMap { alert ->
-            // We don't want to set the version when saving alerts because the MonitorRunner has first priority when writing alerts.
-            // In the rare event that a user acknowledges an alert between when it's read and when it's written
-            // back we're ok if that acknowledgement is lost. It's easier to get the user to retry than for the runner to
-            // spend time reloading the alert and writing it back.
+        val putRequests = mutableListOf<PutDataObjectRequest>()
+        val deleteRequests = mutableListOf<DeleteDataObjectRequest>()
+
+        alerts.forEach { alert ->
             when (alert.state) {
                 Alert.State.ACTIVE, Alert.State.ERROR -> {
-                    listOf<DocWriteRequest<*>>(
-                        IndexRequest(alertsIndex)
-                            .routing(routingId)
-                            .source(alert.toXContentWithUser(XContentFactory.jsonBuilder()))
+                    putRequests.add(
+                        PutDataObjectRequest.builder()
+                            .index(alertsIndex)
                             .id(if (alert.id != Alert.NO_ID) alert.id else null)
+                            .routing(routingId)
+                            .overwriteIfExists(true)
+                            .dataObject(ToXContentObject { builder, _ -> alert.toXContentWithUser(builder) })
+                            .build()
                     )
                 }
                 Alert.State.ACKNOWLEDGED -> {
-                    // Allow ACKNOWLEDGED Alerts to be updated for Bucket-Level Monitors since de-duped Alerts can be ACKNOWLEDGED
-                    // and updated by the MonitorRunner
                     if (allowUpdatingAcknowledgedAlert) {
-                        listOf<DocWriteRequest<*>>(
-                            IndexRequest(alertsIndex)
-                                .routing(routingId)
-                                .source(alert.toXContentWithUser(XContentFactory.jsonBuilder()))
+                        putRequests.add(
+                            PutDataObjectRequest.builder()
+                                .index(alertsIndex)
                                 .id(if (alert.id != Alert.NO_ID) alert.id else null)
+                                .routing(routingId)
+                                .overwriteIfExists(true)
+                                .dataObject(ToXContentObject { builder, _ -> alert.toXContentWithUser(builder) })
+                                .build()
                         )
                     } else {
                         throw IllegalStateException("Unexpected attempt to save ${alert.state} alert: $alert")
@@ -719,52 +721,56 @@ class AlertService(
                     val index = if (alertIndices.isAlertHistoryEnabled()) {
                         dataSources.alertsHistoryIndex
                     } else dataSources.alertsIndex
-                    listOf<DocWriteRequest<*>>(
-                        IndexRequest(index)
-                            .routing(routingId)
-                            .source(alert.toXContentWithUser(XContentFactory.jsonBuilder()))
+                    putRequests.add(
+                        PutDataObjectRequest.builder()
+                            .index(index)
                             .id(if (alert.id != Alert.NO_ID) alert.id else null)
+                            .routing(routingId)
+                            .overwriteIfExists(true)
+                            .dataObject(ToXContentObject { builder, _ -> alert.toXContentWithUser(builder) })
+                            .build()
                     )
                 }
                 Alert.State.DELETED -> {
                     throw IllegalStateException("Unexpected attempt to save ${alert.state} alert: $alert")
                 }
                 Alert.State.COMPLETED -> {
-                    listOfNotNull<DocWriteRequest<*>>(
-                        DeleteRequest(alertsIndex, alert.id)
-                            .routing(routingId),
-                        if (alertIndices.isAlertHistoryEnabled()) {
-                            // Only add completed alert to history index if history is enabled
-                            IndexRequest(alertsHistoryIndex)
-                                .routing(routingId)
-                                .source(alert.toXContentWithUser(XContentFactory.jsonBuilder()))
-                                .id(alert.id)
-                        } else {
-                            // Otherwise, prepare the Alert's comments for deletion, and don't include
-                            // a request to index the Alert to an Alert history index.
-                            // The delete request can't be added to the list of DocWriteRequests because
-                            // Comments are stored in aliased history indices, not a concrete Comments
-                            // index like Alerts. A DeleteBy request will be used to delete Comments, instead
-                            // of a regular Delete request
-                            commentIdsToDelete.addAll(CommentsUtils.getCommentIDsByAlertIDs(client, listOf(alert.id)))
-                            null
-                        }
+                    deleteRequests.add(
+                        DeleteDataObjectRequest.builder()
+                            .index(alertsIndex)
+                            .id(alert.id)
+                            .routing(routingId)
+                            .build()
                     )
+                    if (alertIndices.isAlertHistoryEnabled()) {
+                        putRequests.add(
+                            PutDataObjectRequest.builder()
+                                .index(alertsHistoryIndex)
+                                .id(alert.id)
+                                .routing(routingId)
+                                .overwriteIfExists(true)
+                                .dataObject(ToXContentObject { builder, _ -> alert.toXContentWithUser(builder) })
+                                .build()
+                        )
+                    } else {
+                        commentIdsToDelete.addAll(CommentsUtils.getCommentIDsByAlertIDs(client, listOf(alert.id)))
+                    }
                 }
             }
         }
 
-        if (requestsToRetry.isEmpty()) return
+        if (putRequests.isEmpty() && deleteRequests.isEmpty()) return
         // Retry Bulk requests if there was any 429 response
         retryPolicy.retry(logger, listOf(RestStatus.TOO_MANY_REQUESTS)) {
-            val bulkRequest = BulkRequest().add(requestsToRetry).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-            val bulkResponse: BulkResponse = client.suspendUntil { client.bulk(bulkRequest, it) }
-            val failedResponses = (bulkResponse.items ?: arrayOf()).filter { it.isFailed }
-            requestsToRetry = failedResponses.filter { it.status() == RestStatus.TOO_MANY_REQUESTS }
-                .map { bulkRequest.requests()[it.itemId] as IndexRequest }
+            val bulkRequest = BulkDataObjectRequest(null)
+            putRequests.forEach { bulkRequest.add(it) }
+            deleteRequests.forEach { bulkRequest.add(it) }
+            val bulkResponse = sdkClient.bulkDataObjectAsync(bulkRequest).await()
+            val failedResponses = bulkResponse.responses.filter { it.isFailed }
+            val retryableFailures = failedResponses.filter { it.status() == RestStatus.TOO_MANY_REQUESTS }
 
-            if (requestsToRetry.isNotEmpty()) {
-                val retryCause = failedResponses.first { it.status() == RestStatus.TOO_MANY_REQUESTS }.failure.cause
+            if (retryableFailures.isNotEmpty()) {
+                val retryCause = retryableFailures.first().cause()
                 throw ExceptionsHelper.convertToOpenSearchException(retryCause)
             }
         }
@@ -784,7 +790,7 @@ class AlertService(
     suspend fun saveNewAlerts(dataSources: DataSources, alerts: List<Alert>, retryPolicy: BackoffPolicy): List<Alert> {
         val savedAlerts = mutableListOf<Alert>()
         var alertsBeingIndexed = alerts
-        var requestsToRetry: MutableList<IndexRequest> = alerts.map { alert ->
+        var requestsToRetry: MutableList<PutDataObjectRequest> = alerts.map { alert ->
             if (alert.state != Alert.State.ACTIVE && alert.state != Alert.State.AUDIT) {
                 throw IllegalStateException("Unexpected attempt to save new alert [$alert] with state [${alert.state}]")
             }
@@ -794,43 +800,48 @@ class AlertService(
             val alertIndex = if (alert.state == Alert.State.AUDIT && alertIndices.isAlertHistoryEnabled()) {
                 dataSources.alertsHistoryIndex
             } else dataSources.alertsIndex
-            IndexRequest(alertIndex)
+            PutDataObjectRequest.builder()
+                .index(alertIndex)
                 .routing(alert.monitorId)
-                .source(alert.toXContentWithUser(XContentFactory.jsonBuilder()))
+                .overwriteIfExists(false)
+                .dataObject(ToXContentObject { builder, _ -> alert.toXContentWithUser(builder) })
+                .build()
         }.toMutableList()
 
         if (requestsToRetry.isEmpty()) return listOf()
 
-        // Retry Bulk requests if there was any 429 response.
-        // The responses of a bulk request will be in the same order as the individual requests.
-        // If the index request succeeded for an Alert, the document ID from the response is taken and saved in the Alert.
-        // If the index request is to be retried, the Alert is saved separately as well so that its relative ordering is maintained in
-        // relation to index request in the retried bulk request for when it eventually succeeds.
         retryPolicy.retry(logger, listOf(RestStatus.TOO_MANY_REQUESTS)) {
-            val bulkRequest = BulkRequest().add(requestsToRetry).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-            val bulkResponse: BulkResponse = client.suspendUntil { client.bulk(bulkRequest, it) }
-            // TODO: This is only used to retrieve the retryCause, could instead fetch it from the bulkResponse iteration below
-            val failedResponses = (bulkResponse.items ?: arrayOf()).filter { it.isFailed }
+            val bulkRequest = BulkDataObjectRequest(null)
+            requestsToRetry.forEach { bulkRequest.add(it) }
+            val bulkResponse = sdkClient.bulkDataObjectAsync(bulkRequest).await()
+            val responses = bulkResponse.responses
 
             requestsToRetry = mutableListOf()
             val alertsBeingRetried = mutableListOf<Alert>()
-            bulkResponse.items.forEach { item ->
+            responses.forEachIndexed { index, item ->
                 if (item.isFailed) {
-                    // TODO: What if the failure cause was not TOO_MANY_REQUESTS, should these be saved and logged?
                     if (item.status() == RestStatus.TOO_MANY_REQUESTS) {
-                        requestsToRetry.add(bulkRequest.requests()[item.itemId] as IndexRequest)
-                        alertsBeingRetried.add(alertsBeingIndexed[item.itemId])
+                        requestsToRetry.add(
+                            PutDataObjectRequest.builder()
+                                .index(requestsToRetry.getOrNull(index)?.index() ?: dataSources.alertsIndex)
+                                .routing(alertsBeingIndexed[index].monitorId)
+                                .overwriteIfExists(false)
+                                .dataObject(
+                                    ToXContentObject { builder, _ -> alertsBeingIndexed[index].toXContentWithUser(builder) }
+                                )
+                                .build()
+                        )
+                        alertsBeingRetried.add(alertsBeingIndexed[index])
                     }
                 } else {
-                    // The ID of the BulkItemResponse in this case is the document ID resulting from the DocWriteRequest operation
-                    savedAlerts.add(alertsBeingIndexed[item.itemId].copy(id = item.id))
+                    savedAlerts.add(alertsBeingIndexed[index].copy(id = item.id()))
                 }
             }
 
             alertsBeingIndexed = alertsBeingRetried
 
             if (requestsToRetry.isNotEmpty()) {
-                val retryCause = failedResponses.first { it.status() == RestStatus.TOO_MANY_REQUESTS }.failure.cause
+                val retryCause = responses.first { it.isFailed && it.status() == RestStatus.TOO_MANY_REQUESTS }.cause()
                 throw ExceptionsHelper.convertToOpenSearchException(retryCause)
             }
         }
@@ -866,10 +877,13 @@ class AlertService(
             .size(size)
             .query(queryBuilder)
 
-        val searchRequest = SearchRequest(alertIndex)
+        val searchRequest = SearchDataObjectRequest.builder()
+            .indices(alertIndex)
             .routing(monitorId)
-            .source(searchSourceBuilder)
-        val searchResponse: SearchResponse = client.suspendUntil { client.search(searchRequest, it) }
+            .searchSourceBuilder(searchSourceBuilder)
+            .build()
+        val searchResponse: SearchResponse = sdkClient.searchDataObjectAsync(searchRequest).await()
+            .searchResponse() ?: throw RuntimeException("Unknown error loading alerts")
         if (searchResponse.status() != RestStatus.OK) {
             throw (searchResponse.firstFailureOrNull()?.cause ?: RuntimeException("Unknown error loading alerts"))
         }
@@ -898,10 +912,13 @@ class AlertService(
             .size(size)
             .query(queryBuilder)
 
-        val searchRequest = SearchRequest(alertIndex)
+        val searchRequest = SearchDataObjectRequest.builder()
+            .indices(alertIndex)
             .routing(workflowId)
-            .source(searchSourceBuilder)
-        val searchResponse: SearchResponse = client.suspendUntil { client.search(searchRequest, it) }
+            .searchSourceBuilder(searchSourceBuilder)
+            .build()
+        val searchResponse: SearchResponse = sdkClient.searchDataObjectAsync(searchRequest).await()
+            .searchResponse() ?: throw RuntimeException("Unknown error loading alerts")
         if (searchResponse.status() != RestStatus.OK) {
             throw (searchResponse.firstFailureOrNull()?.cause ?: RuntimeException("Unknown error loading alerts"))
         }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -298,7 +298,21 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
         val settings = environment.settings()
         val lockService = LockService(client, clusterService)
         alertIndices = AlertIndices(settings, client, threadPool, clusterService)
-        val alertService = AlertService(client, xContentRegistry, alertIndices)
+
+        val sdkClient: SdkClient = SdkClientFactory.createSdkClient(
+            client,
+            xContentRegistry,
+            mapOf(
+                REMOTE_METADATA_TYPE_KEY to REMOTE_METADATA_STORE_TYPE.get(settings),
+                REMOTE_METADATA_ENDPOINT_KEY to REMOTE_METADATA_ENDPOINT.get(settings),
+                REMOTE_METADATA_REGION_KEY to REMOTE_METADATA_REGION.get(settings),
+                REMOTE_METADATA_SERVICE_NAME_KEY to REMOTE_METADATA_SERVICE_NAME.get(settings),
+                TENANT_AWARE_KEY to MULTI_TENANCY_ENABLED.get(settings).toString()
+            ),
+            client.threadPool().executor(ThreadPool.Names.GENERIC)
+        )
+
+        val alertService = AlertService(client, xContentRegistry, alertIndices, sdkClient)
         val triggerService = TriggerService(scriptService)
         runner = MonitorRunnerService
             .registerClusterService(clusterService)
@@ -338,26 +352,13 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
         this.threadPool = threadPool
         this.clusterService = clusterService
 
-        val sdkClient: SdkClient = SdkClientFactory.createSdkClient(
-            client,
-            xContentRegistry,
-            mapOf(
-                REMOTE_METADATA_TYPE_KEY to REMOTE_METADATA_STORE_TYPE.get(settings),
-                REMOTE_METADATA_ENDPOINT_KEY to REMOTE_METADATA_ENDPOINT.get(settings),
-                REMOTE_METADATA_REGION_KEY to REMOTE_METADATA_REGION.get(settings),
-                REMOTE_METADATA_SERVICE_NAME_KEY to REMOTE_METADATA_SERVICE_NAME.get(settings),
-                TENANT_AWARE_KEY to MULTI_TENANCY_ENABLED.get(settings).toString()
-            ),
-            client.threadPool().executor(ThreadPool.Names.GENERIC)
-        )
-
         MonitorMetadataService.initialize(
             client,
             clusterService,
             xContentRegistry,
-            settings
+            settings,
+            sdkClient
         )
-        MonitorMetadataService.sdkClient = sdkClient
 
         WorkflowMetadataService.initialize(
             client,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt
@@ -56,7 +56,7 @@ object MonitorMetadataService :
     private lateinit var xContentRegistry: NamedXContentRegistry
     private lateinit var clusterService: ClusterService
     private lateinit var settings: Settings
-    lateinit var sdkClient: SdkClient
+    private lateinit var sdkClient: SdkClient
 
     @Volatile
     private lateinit var indexTimeout: TimeValue
@@ -66,11 +66,13 @@ object MonitorMetadataService :
         clusterService: ClusterService,
         xContentRegistry: NamedXContentRegistry,
         settings: Settings,
+        sdkClient: SdkClient
     ) {
         this.clusterService = clusterService
         this.client = client
         this.xContentRegistry = xContentRegistry
         this.settings = settings
+        this.sdkClient = sdkClient
         this.indexTimeout = AlertingSettings.INDEX_TIMEOUT.get(settings)
         this.clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.INDEX_TIMEOUT) { indexTimeout = it }
     }
@@ -191,21 +193,12 @@ object MonitorMetadataService :
                 null
             }
         } catch (e: Exception) {
-            if (isIndexNotFoundException(e)) {
+            if (AlertingException.isIndexNotFoundException(e)) {
                 return null
             } else {
                 throw AlertingException.wrap(e)
             }
         }
-    }
-
-    private fun isIndexNotFoundException(e: Throwable): Boolean {
-        var cause: Throwable? = e
-        while (cause != null) {
-            if (cause.message?.contains("no such index") == true) return true
-            cause = cause.cause
-        }
-        return false
     }
 
     suspend fun recreateRunContext(metadata: MonitorMetadata, monitor: Monitor): MonitorMetadata {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertServiceTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertServiceTests.kt
@@ -22,13 +22,13 @@ import org.opensearch.commons.alerting.model.BucketLevelTrigger
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.action.AlertCategory
 import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.remote.metadata.client.SdkClient
 import org.opensearch.test.ClusterServiceUtils
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.threadpool.ThreadPool
 import org.opensearch.transport.client.Client
 import java.time.Instant
 import java.time.temporal.ChronoUnit
-
 class AlertServiceTests : OpenSearchTestCase() {
 
     private lateinit var client: Client
@@ -67,7 +67,7 @@ class AlertServiceTests : OpenSearchTestCase() {
         clusterService = Mockito.spy(testClusterService)
 
         alertIndices = AlertIndices(settings, client, threadPool, clusterService)
-        alertService = AlertService(client, xContentRegistry, alertIndices)
+        alertService = AlertService(client, xContentRegistry, alertIndices, Mockito.mock(SdkClient::class.java))
     }
 
     fun `test getting categorized alerts for bucket-level monitor with no current alerts`() {


### PR DESCRIPTION
Description:

Migrates AlertService to use SdkClient for all alert persistence operations (search, put, bulk, delete) as part of the remote metadata SDK migration for background services. Also addresses review feedback from PR #2083:

Changes:
- AlertService: Migrate searchAlerts, upsertMonitorErrorAlert, clearMonitorErrorAlert, moveClearedErrorAlertsToHistory, saveAlerts, saveNewAlerts to SdkClient. deleteByQuery stays on direct client (no SDK equivalent).
- AlertingPlugin: Move sdkClient creation before AlertService, pass to AlertService constructor and MonitorMetadataService.initialize()
- MonitorMetadataService: Move sdkClient into initialize() parameter, use AlertingException.isIndexNotFoundException() from common-utils

Part of #2094

Depends on:
- common-utils PR for isIndexNotFoundException: https://github.com/opensearch-project/common-utils/pull/XXX
- SDK routing support: https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/351
