### PR TITLE
fix: Set number_of_shards to 1 for plugin-created system indices

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
@@ -375,7 +375,13 @@ class AlertIndices(
         logger.debug("index: [$index] schema mappings: [$schemaMapping]")
         val request = CreateIndexRequest(index)
             .mapping(schemaMapping)
-            .settings(Settings.builder().put("index.hidden", true).build())
+            .settings(
+                Settings.builder()
+                    .put("index.hidden", true)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put("index.auto_expand_replicas", "1-20")
+                    .build()
+            )
 
         if (alias != null) request.alias(Alias(alias))
         return try {
@@ -448,7 +454,13 @@ class AlertIndices(
         val request = RolloverRequest(index, null)
         request.createIndexRequest.index(pattern)
             .mapping(map)
-            .settings(Settings.builder().put("index.hidden", true).build())
+            .settings(
+                Settings.builder()
+                    .put("index.hidden", true)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put("index.auto_expand_replicas", "1-20")
+                    .build()
+            )
         request.addMaxIndexDocsCondition(docsCondition)
         request.addMaxIndexAgeCondition(ageCondition)
         client.admin().indices().rolloverIndex(


### PR DESCRIPTION
Description:

AlertIndices.createIndex() and rolloverIndex() did not explicitly set number_of_shards, causing plugin-created system indices (alerts, alerts-history, findings-history) to use the cluster default shard count instead of 1. This adds number_of_shards: 1 and auto_expand_replicas: 1-20 to both methods, consistent with the fix in Security Analytics [opensearch-project/security-analytics#1358](https://github.com/opensearch-project/security-analytics/pull/1358).

Related Issues:

Resolves #2082

Testing:

Verified locally by running a single-node cluster with the alerting plugin:
1. Created a query-level monitor with a trigger
2. Executed the monitor to trigger alert index creation
3. Confirmed .opendistro-alerting-alerts settings: number_of_shards: 1, auto_expand_replicas: 1-20
4. Confirmed .opendistro-alerting-alert-history-* settings: number_of_shards: 1, auto_expand_replicas: 1-20
5. AlertIndicesIT and MonitorRunnerServiceIT integ tests pass

Check List:
- [x] Commits are signed per the DCO using --signoff.
