### PR TITLE
Remote metadata support - merge from feature branch to main branch

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -102,7 +102,12 @@ configurations.all {
     resolutionStrategy {
         force "joda-time:joda-time:${versions.joda}"
         force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+        force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
+        force "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"
         force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${versions.jackson}"
+        force "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:${versions.jackson}"
+        force "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions.jackson}"
+        force "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson}"
         force "commons-logging:commons-logging:${versions.commonslogging}"
         // force the version until OpenSearch upgrade to an invulnerable one, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
         force "commons-codec:commons-codec:1.13"
@@ -171,6 +176,8 @@ dependencies {
     api project(":alerting-core")
     implementation "com.github.seancfoley:ipaddress:5.4.1"
     implementation project(path: ":alerting-spi", configuration: 'shadow')
+
+    implementation "org.opensearch:opensearch-remote-metadata-sdk:${opensearch_build}"
 
     testImplementation "org.antlr:antlr4-runtime:${versions.antlr4}"
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt
@@ -7,30 +7,21 @@ package org.opensearch.alerting
 
 import org.apache.logging.log4j.LogManager
 import org.opensearch.ExceptionsHelper
-import org.opensearch.action.DocWriteRequest
 import org.opensearch.action.bulk.BackoffPolicy
-import org.opensearch.action.bulk.BulkRequest
-import org.opensearch.action.bulk.BulkResponse
-import org.opensearch.action.delete.DeleteRequest
-import org.opensearch.action.index.IndexRequest
-import org.opensearch.action.index.IndexResponse
-import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.search.SearchResponse
-import org.opensearch.action.support.WriteRequest
 import org.opensearch.alerting.alerts.AlertIndices
 import org.opensearch.alerting.opensearchapi.firstFailureOrNull
 import org.opensearch.alerting.opensearchapi.retry
-import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.script.ChainedAlertTriggerExecutionContext
 import org.opensearch.alerting.script.DocumentLevelTriggerExecutionContext
 import org.opensearch.alerting.script.QueryLevelTriggerExecutionContext
 import org.opensearch.alerting.util.CommentsUtils
 import org.opensearch.alerting.util.IndexUtils
 import org.opensearch.alerting.util.MAX_SEARCH_SIZE
+import org.opensearch.alerting.util.await
 import org.opensearch.alerting.util.getBucketKeysHash
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
-import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.alerting.alerts.AlertError
@@ -53,13 +44,18 @@ import org.opensearch.core.action.ActionListener
 import org.opensearch.core.common.bytes.BytesReference
 import org.opensearch.core.rest.RestStatus
 import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.core.xcontent.ToXContentObject
 import org.opensearch.core.xcontent.XContentParser
 import org.opensearch.core.xcontent.XContentParserUtils
-import org.opensearch.index.VersionType
 import org.opensearch.index.query.QueryBuilders
 import org.opensearch.index.reindex.BulkByScrollResponse
 import org.opensearch.index.reindex.DeleteByQueryAction
 import org.opensearch.index.reindex.DeleteByQueryRequestBuilder
+import org.opensearch.remote.metadata.client.BulkDataObjectRequest
+import org.opensearch.remote.metadata.client.DeleteDataObjectRequest
+import org.opensearch.remote.metadata.client.PutDataObjectRequest
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.search.sort.SortOrder
 import org.opensearch.transport.client.Client
@@ -69,12 +65,12 @@ import java.util.concurrent.TimeUnit
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
-
 /** Service that handles CRUD operations for alerts */
 class AlertService(
     val client: Client,
     val xContentRegistry: NamedXContentRegistry,
-    val alertIndices: AlertIndices
+    val alertIndices: AlertIndices,
+    val sdkClient: SdkClient
 ) {
 
     companion object {
@@ -483,8 +479,10 @@ class AlertService(
     ) {
         val newErrorAlertId = "$ERROR_ALERT_ID_PREFIX-${monitor.id}-${UUID.randomUUID()}"
 
-        val searchRequest = SearchRequest(monitor.dataSources.alertsIndex)
-            .source(
+        val searchRequest = SearchDataObjectRequest.builder()
+            .indices(monitor.dataSources.alertsIndex)
+            .routing(monitor.id)
+            .searchSourceBuilder(
                 SearchSourceBuilder()
                     .sort(Alert.START_TIME_FIELD, SortOrder.DESC)
                     .query(
@@ -493,7 +491,9 @@ class AlertService(
                             .must(QueryBuilders.termQuery(Alert.STATE_FIELD, Alert.State.ERROR.name))
                     )
             )
-        val searchResponse: SearchResponse = client.suspendUntil { search(searchRequest, it) }
+            .build()
+        val searchResponse: SearchResponse = sdkClient.searchDataObjectAsync(searchRequest).await()
+            .searchResponse() ?: throw RuntimeException("Unknown error searching for error alerts")
 
         var alert =
             composeMonitorErrorAlert(newErrorAlertId, monitor, AlertError(Instant.now(), errorMessage), executionId, workflowRunContext)
@@ -523,22 +523,29 @@ class AlertService(
             }
         }
 
-        val alertIndexRequest = IndexRequest(monitor.dataSources.alertsIndex)
-            .routing(alert.monitorId)
-            .source(alert.toXContentWithUser(XContentFactory.jsonBuilder()))
-            .opType(DocWriteRequest.OpType.INDEX)
-            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+        val putRequest = PutDataObjectRequest.builder()
+            .index(monitor.dataSources.alertsIndex)
             .id(alert.id)
-
-        val indexResponse: IndexResponse = client.suspendUntil { index(alertIndexRequest, it) }
-        logger.debug("Monitor error Alert successfully upserted. Op result: ${indexResponse.result}")
+            .routing(alert.monitorId)
+            .overwriteIfExists(true)
+            .dataObject(ToXContentObject { builder, _ -> alert.toXContentWithUser(builder) })
+            .build()
+        val putResponse = sdkClient.putDataObjectAsync(putRequest).await()
+        if (putResponse.isFailed) {
+            throw ExceptionsHelper.convertToOpenSearchException(
+                putResponse.cause() ?: RuntimeException("Failed to upsert monitor error alert")
+            )
+        }
+        logger.debug("Monitor error Alert successfully upserted. Op result: ${putResponse.indexResponse()?.result}")
     }
 
     suspend fun clearMonitorErrorAlert(monitor: Monitor) {
         val currentTime = Instant.now()
         try {
-            val searchRequest = SearchRequest("${monitor.dataSources.alertsIndex}")
-                .source(
+            val searchRequest = SearchDataObjectRequest.builder()
+                .indices(monitor.dataSources.alertsIndex)
+                .routing(monitor.id)
+                .searchSourceBuilder(
                     SearchSourceBuilder()
                         .size(MAX_SEARCH_SIZE)
                         .sort(Alert.START_TIME_FIELD, SortOrder.DESC)
@@ -547,46 +554,42 @@ class AlertService(
                                 .must(QueryBuilders.termQuery(Alert.MONITOR_ID_FIELD, monitor.id))
                                 .must(QueryBuilders.termQuery(Alert.STATE_FIELD, Alert.State.ERROR.name))
                         )
-
                 )
-            searchRequest.cancelAfterTimeInterval = ALERTS_SEARCH_TIMEOUT
-            val searchResponse: SearchResponse = client.suspendUntil { search(searchRequest, it) }
+                .build()
+            val searchResponse: SearchResponse = sdkClient.searchDataObjectAsync(searchRequest).await()
+                .searchResponse() ?: throw RuntimeException("Unknown error searching for error alerts")
             // If there's no error alert present, there's nothing to clear. We can stop here.
             if (searchResponse.hits.totalHits.value == 0L) {
                 return
             }
 
-            val indexRequests = mutableListOf<IndexRequest>()
+            val bulkRequest = BulkDataObjectRequest(monitor.dataSources.alertsIndex)
             searchResponse.hits.hits.forEach { hit ->
                 if (searchResponse.hits.totalHits.value > 1L) {
                     logger.warn("Found [${searchResponse.hits.totalHits.value}] error alerts for monitor [${monitor.id}] while clearing")
                 }
-                // Deserialize first/latest Alert
                 val xcp = contentParser(hit.sourceRef)
                 val existingErrorAlert = Alert.parse(xcp, hit.id, hit.version)
+                val updatedAlert = existingErrorAlert.copy(endTime = currentTime)
 
-                val updatedAlert = existingErrorAlert.copy(
-                    endTime = currentTime
+                bulkRequest.add(
+                    PutDataObjectRequest.builder()
+                        .index(monitor.dataSources.alertsIndex)
+                        .id(updatedAlert.id)
+                        .routing(monitor.id)
+                        .overwriteIfExists(true)
+                        .dataObject(ToXContentObject { builder, _ -> updatedAlert.toXContentWithUser(builder) })
+                        .build()
                 )
-
-                indexRequests += IndexRequest(monitor.dataSources.alertsIndex)
-                    .routing(monitor.id)
-                    .id(updatedAlert.id)
-                    .source(updatedAlert.toXContentWithUser(XContentFactory.jsonBuilder()))
-                    .opType(DocWriteRequest.OpType.INDEX)
             }
 
-            val bulkResponse: BulkResponse = client.suspendUntil {
-                bulk(BulkRequest().add(indexRequests).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE), it)
-            }
+            val bulkResponse = sdkClient.bulkDataObjectAsync(bulkRequest).await()
             if (bulkResponse.hasFailures()) {
-                bulkResponse.items.forEach { item ->
-                    if (item.isFailed) {
-                        logger.debug("Failed clearing error alert ${item.id} of monitor [${monitor.id}]")
-                    }
+                bulkResponse.responses.filter { it.isFailed }.forEach { item ->
+                    logger.debug("Failed clearing error alert ${item.id()} of monitor [${monitor.id}]")
                 }
             } else {
-                logger.debug("[${bulkResponse.items.size}] Error Alerts successfully cleared. End time set to: $currentTime")
+                logger.debug("[${searchResponse.hits.totalHits.value}] Error Alerts successfully cleared. End time set to: $currentTime")
             }
         } catch (e: Exception) {
             logger.error("Error clearing monitor error alerts for monitor [${monitor.id}]: ${ExceptionsHelper.detailedMessage(e)}")
@@ -599,8 +602,10 @@ class AlertService(
      * */
     suspend fun moveClearedErrorAlertsToHistory(monitorId: String, alertIndex: String, alertHistoryIndex: String) {
         try {
-            val searchRequest = SearchRequest(alertIndex)
-                .source(
+            val searchRequest = SearchDataObjectRequest.builder()
+                .indices(alertIndex)
+                .routing(monitorId)
+                .searchSourceBuilder(
                     SearchSourceBuilder()
                         .size(MAX_SEARCH_SIZE)
                         .query(
@@ -609,43 +614,37 @@ class AlertService(
                                 .must(QueryBuilders.termQuery(Alert.STATE_FIELD, Alert.State.ERROR.name))
                                 .must(QueryBuilders.existsQuery(Alert.END_TIME_FIELD))
                         )
-                        .version(true) // Do we need this?
+                        .version(true)
                 )
-            searchRequest.cancelAfterTimeInterval = ALERTS_SEARCH_TIMEOUT
-            val searchResponse: SearchResponse = client.suspendUntil { search(searchRequest, it) }
+                .build()
+            val searchResponse: SearchResponse = sdkClient.searchDataObjectAsync(searchRequest).await()
+                .searchResponse() ?: throw RuntimeException("Unknown error searching for cleared error alerts")
 
             if (searchResponse.hits.totalHits.value == 0L) {
                 return
             }
 
             // Copy to history index
-
-            val copyRequests = mutableListOf<IndexRequest>()
-
+            val bulkRequest = BulkDataObjectRequest(null)
             searchResponse.hits.hits.forEach { hit ->
-
                 val xcp = contentParser(hit.sourceRef)
                 val alert = Alert.parse(xcp, hit.id, hit.version)
 
-                copyRequests.add(
-                    IndexRequest(alertHistoryIndex)
-                        .routing(alert.monitorId)
-                        .source(hit.sourceRef, XContentType.JSON)
-                        .version(hit.version)
-                        .versionType(VersionType.EXTERNAL_GTE)
+                bulkRequest.add(
+                    PutDataObjectRequest.builder()
+                        .index(alertHistoryIndex)
                         .id(hit.id)
-                        .timeout(MonitorRunnerService.monitorCtx.indexTimeout)
+                        .routing(alert.monitorId)
+                        .overwriteIfExists(true)
+                        .dataObject(ToXContentObject { builder, _ -> alert.toXContentWithUser(builder) })
+                        .build()
                 )
             }
 
-            val bulkResponse: BulkResponse = client.suspendUntil {
-                bulk(BulkRequest().add(copyRequests).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE), it)
-            }
+            val bulkResponse = sdkClient.bulkDataObjectAsync(bulkRequest).await()
             if (bulkResponse.hasFailures()) {
-                bulkResponse.items.forEach { item ->
-                    if (item.isFailed) {
-                        logger.error("Failed copying error alert [${item.id}] to history index [$alertHistoryIndex]")
-                    }
+                bulkResponse.responses.filter { it.isFailed }.forEach { item ->
+                    logger.error("Failed copying error alert [${item.id()}] to history index [$alertHistoryIndex]")
                 }
                 return
             }
@@ -687,29 +686,32 @@ class AlertService(
 
         val commentIdsToDelete = mutableListOf<String>()
 
-        var requestsToRetry = alerts.flatMap { alert ->
-            // We don't want to set the version when saving alerts because the MonitorRunner has first priority when writing alerts.
-            // In the rare event that a user acknowledges an alert between when it's read and when it's written
-            // back we're ok if that acknowledgement is lost. It's easier to get the user to retry than for the runner to
-            // spend time reloading the alert and writing it back.
+        val putRequests = mutableListOf<PutDataObjectRequest>()
+        val deleteRequests = mutableListOf<DeleteDataObjectRequest>()
+
+        alerts.forEach { alert ->
             when (alert.state) {
                 Alert.State.ACTIVE, Alert.State.ERROR -> {
-                    listOf<DocWriteRequest<*>>(
-                        IndexRequest(alertsIndex)
-                            .routing(routingId)
-                            .source(alert.toXContentWithUser(XContentFactory.jsonBuilder()))
+                    putRequests.add(
+                        PutDataObjectRequest.builder()
+                            .index(alertsIndex)
                             .id(if (alert.id != Alert.NO_ID) alert.id else null)
+                            .routing(routingId)
+                            .overwriteIfExists(true)
+                            .dataObject(ToXContentObject { builder, _ -> alert.toXContentWithUser(builder) })
+                            .build()
                     )
                 }
                 Alert.State.ACKNOWLEDGED -> {
-                    // Allow ACKNOWLEDGED Alerts to be updated for Bucket-Level Monitors since de-duped Alerts can be ACKNOWLEDGED
-                    // and updated by the MonitorRunner
                     if (allowUpdatingAcknowledgedAlert) {
-                        listOf<DocWriteRequest<*>>(
-                            IndexRequest(alertsIndex)
-                                .routing(routingId)
-                                .source(alert.toXContentWithUser(XContentFactory.jsonBuilder()))
+                        putRequests.add(
+                            PutDataObjectRequest.builder()
+                                .index(alertsIndex)
                                 .id(if (alert.id != Alert.NO_ID) alert.id else null)
+                                .routing(routingId)
+                                .overwriteIfExists(true)
+                                .dataObject(ToXContentObject { builder, _ -> alert.toXContentWithUser(builder) })
+                                .build()
                         )
                     } else {
                         throw IllegalStateException("Unexpected attempt to save ${alert.state} alert: $alert")
@@ -719,52 +721,56 @@ class AlertService(
                     val index = if (alertIndices.isAlertHistoryEnabled()) {
                         dataSources.alertsHistoryIndex
                     } else dataSources.alertsIndex
-                    listOf<DocWriteRequest<*>>(
-                        IndexRequest(index)
-                            .routing(routingId)
-                            .source(alert.toXContentWithUser(XContentFactory.jsonBuilder()))
+                    putRequests.add(
+                        PutDataObjectRequest.builder()
+                            .index(index)
                             .id(if (alert.id != Alert.NO_ID) alert.id else null)
+                            .routing(routingId)
+                            .overwriteIfExists(true)
+                            .dataObject(ToXContentObject { builder, _ -> alert.toXContentWithUser(builder) })
+                            .build()
                     )
                 }
                 Alert.State.DELETED -> {
                     throw IllegalStateException("Unexpected attempt to save ${alert.state} alert: $alert")
                 }
                 Alert.State.COMPLETED -> {
-                    listOfNotNull<DocWriteRequest<*>>(
-                        DeleteRequest(alertsIndex, alert.id)
-                            .routing(routingId),
-                        if (alertIndices.isAlertHistoryEnabled()) {
-                            // Only add completed alert to history index if history is enabled
-                            IndexRequest(alertsHistoryIndex)
-                                .routing(routingId)
-                                .source(alert.toXContentWithUser(XContentFactory.jsonBuilder()))
-                                .id(alert.id)
-                        } else {
-                            // Otherwise, prepare the Alert's comments for deletion, and don't include
-                            // a request to index the Alert to an Alert history index.
-                            // The delete request can't be added to the list of DocWriteRequests because
-                            // Comments are stored in aliased history indices, not a concrete Comments
-                            // index like Alerts. A DeleteBy request will be used to delete Comments, instead
-                            // of a regular Delete request
-                            commentIdsToDelete.addAll(CommentsUtils.getCommentIDsByAlertIDs(client, listOf(alert.id)))
-                            null
-                        }
+                    deleteRequests.add(
+                        DeleteDataObjectRequest.builder()
+                            .index(alertsIndex)
+                            .id(alert.id)
+                            .routing(routingId)
+                            .build()
                     )
+                    if (alertIndices.isAlertHistoryEnabled()) {
+                        putRequests.add(
+                            PutDataObjectRequest.builder()
+                                .index(alertsHistoryIndex)
+                                .id(alert.id)
+                                .routing(routingId)
+                                .overwriteIfExists(true)
+                                .dataObject(ToXContentObject { builder, _ -> alert.toXContentWithUser(builder) })
+                                .build()
+                        )
+                    } else {
+                        commentIdsToDelete.addAll(CommentsUtils.getCommentIDsByAlertIDs(client, listOf(alert.id)))
+                    }
                 }
             }
         }
 
-        if (requestsToRetry.isEmpty()) return
+        if (putRequests.isEmpty() && deleteRequests.isEmpty()) return
         // Retry Bulk requests if there was any 429 response
         retryPolicy.retry(logger, listOf(RestStatus.TOO_MANY_REQUESTS)) {
-            val bulkRequest = BulkRequest().add(requestsToRetry).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-            val bulkResponse: BulkResponse = client.suspendUntil { client.bulk(bulkRequest, it) }
-            val failedResponses = (bulkResponse.items ?: arrayOf()).filter { it.isFailed }
-            requestsToRetry = failedResponses.filter { it.status() == RestStatus.TOO_MANY_REQUESTS }
-                .map { bulkRequest.requests()[it.itemId] as IndexRequest }
+            val bulkRequest = BulkDataObjectRequest(null)
+            putRequests.forEach { bulkRequest.add(it) }
+            deleteRequests.forEach { bulkRequest.add(it) }
+            val bulkResponse = sdkClient.bulkDataObjectAsync(bulkRequest).await()
+            val failedResponses = bulkResponse.responses.filter { it.isFailed }
+            val retryableFailures = failedResponses.filter { it.status() == RestStatus.TOO_MANY_REQUESTS }
 
-            if (requestsToRetry.isNotEmpty()) {
-                val retryCause = failedResponses.first { it.status() == RestStatus.TOO_MANY_REQUESTS }.failure.cause
+            if (retryableFailures.isNotEmpty()) {
+                val retryCause = retryableFailures.first().cause()
                 throw ExceptionsHelper.convertToOpenSearchException(retryCause)
             }
         }
@@ -784,7 +790,7 @@ class AlertService(
     suspend fun saveNewAlerts(dataSources: DataSources, alerts: List<Alert>, retryPolicy: BackoffPolicy): List<Alert> {
         val savedAlerts = mutableListOf<Alert>()
         var alertsBeingIndexed = alerts
-        var requestsToRetry: MutableList<IndexRequest> = alerts.map { alert ->
+        var requestsToRetry: MutableList<PutDataObjectRequest> = alerts.map { alert ->
             if (alert.state != Alert.State.ACTIVE && alert.state != Alert.State.AUDIT) {
                 throw IllegalStateException("Unexpected attempt to save new alert [$alert] with state [${alert.state}]")
             }
@@ -794,43 +800,48 @@ class AlertService(
             val alertIndex = if (alert.state == Alert.State.AUDIT && alertIndices.isAlertHistoryEnabled()) {
                 dataSources.alertsHistoryIndex
             } else dataSources.alertsIndex
-            IndexRequest(alertIndex)
+            PutDataObjectRequest.builder()
+                .index(alertIndex)
                 .routing(alert.monitorId)
-                .source(alert.toXContentWithUser(XContentFactory.jsonBuilder()))
+                .overwriteIfExists(false)
+                .dataObject(ToXContentObject { builder, _ -> alert.toXContentWithUser(builder) })
+                .build()
         }.toMutableList()
 
         if (requestsToRetry.isEmpty()) return listOf()
 
-        // Retry Bulk requests if there was any 429 response.
-        // The responses of a bulk request will be in the same order as the individual requests.
-        // If the index request succeeded for an Alert, the document ID from the response is taken and saved in the Alert.
-        // If the index request is to be retried, the Alert is saved separately as well so that its relative ordering is maintained in
-        // relation to index request in the retried bulk request for when it eventually succeeds.
         retryPolicy.retry(logger, listOf(RestStatus.TOO_MANY_REQUESTS)) {
-            val bulkRequest = BulkRequest().add(requestsToRetry).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-            val bulkResponse: BulkResponse = client.suspendUntil { client.bulk(bulkRequest, it) }
-            // TODO: This is only used to retrieve the retryCause, could instead fetch it from the bulkResponse iteration below
-            val failedResponses = (bulkResponse.items ?: arrayOf()).filter { it.isFailed }
+            val bulkRequest = BulkDataObjectRequest(null)
+            requestsToRetry.forEach { bulkRequest.add(it) }
+            val bulkResponse = sdkClient.bulkDataObjectAsync(bulkRequest).await()
+            val responses = bulkResponse.responses
 
             requestsToRetry = mutableListOf()
             val alertsBeingRetried = mutableListOf<Alert>()
-            bulkResponse.items.forEach { item ->
+            responses.forEachIndexed { index, item ->
                 if (item.isFailed) {
-                    // TODO: What if the failure cause was not TOO_MANY_REQUESTS, should these be saved and logged?
                     if (item.status() == RestStatus.TOO_MANY_REQUESTS) {
-                        requestsToRetry.add(bulkRequest.requests()[item.itemId] as IndexRequest)
-                        alertsBeingRetried.add(alertsBeingIndexed[item.itemId])
+                        requestsToRetry.add(
+                            PutDataObjectRequest.builder()
+                                .index(requestsToRetry.getOrNull(index)?.index() ?: dataSources.alertsIndex)
+                                .routing(alertsBeingIndexed[index].monitorId)
+                                .overwriteIfExists(false)
+                                .dataObject(
+                                    ToXContentObject { builder, _ -> alertsBeingIndexed[index].toXContentWithUser(builder) }
+                                )
+                                .build()
+                        )
+                        alertsBeingRetried.add(alertsBeingIndexed[index])
                     }
                 } else {
-                    // The ID of the BulkItemResponse in this case is the document ID resulting from the DocWriteRequest operation
-                    savedAlerts.add(alertsBeingIndexed[item.itemId].copy(id = item.id))
+                    savedAlerts.add(alertsBeingIndexed[index].copy(id = item.id()))
                 }
             }
 
             alertsBeingIndexed = alertsBeingRetried
 
             if (requestsToRetry.isNotEmpty()) {
-                val retryCause = failedResponses.first { it.status() == RestStatus.TOO_MANY_REQUESTS }.failure.cause
+                val retryCause = responses.first { it.isFailed && it.status() == RestStatus.TOO_MANY_REQUESTS }.cause()
                 throw ExceptionsHelper.convertToOpenSearchException(retryCause)
             }
         }
@@ -866,10 +877,13 @@ class AlertService(
             .size(size)
             .query(queryBuilder)
 
-        val searchRequest = SearchRequest(alertIndex)
+        val searchRequest = SearchDataObjectRequest.builder()
+            .indices(alertIndex)
             .routing(monitorId)
-            .source(searchSourceBuilder)
-        val searchResponse: SearchResponse = client.suspendUntil { client.search(searchRequest, it) }
+            .searchSourceBuilder(searchSourceBuilder)
+            .build()
+        val searchResponse: SearchResponse = sdkClient.searchDataObjectAsync(searchRequest).await()
+            .searchResponse() ?: throw RuntimeException("Unknown error loading alerts")
         if (searchResponse.status() != RestStatus.OK) {
             throw (searchResponse.firstFailureOrNull()?.cause ?: RuntimeException("Unknown error loading alerts"))
         }
@@ -898,10 +912,13 @@ class AlertService(
             .size(size)
             .query(queryBuilder)
 
-        val searchRequest = SearchRequest(alertIndex)
+        val searchRequest = SearchDataObjectRequest.builder()
+            .indices(alertIndex)
             .routing(workflowId)
-            .source(searchSourceBuilder)
-        val searchResponse: SearchResponse = client.suspendUntil { client.search(searchRequest, it) }
+            .searchSourceBuilder(searchSourceBuilder)
+            .build()
+        val searchResponse: SearchResponse = sdkClient.searchDataObjectAsync(searchRequest).await()
+            .searchResponse() ?: throw RuntimeException("Unknown error loading alerts")
         if (searchResponse.status() != RestStatus.OK) {
             throw (searchResponse.firstFailureOrNull()?.cause ?: RuntimeException("Unknown error loading alerts"))
         }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -55,6 +55,11 @@ import org.opensearch.alerting.script.TriggerScript
 import org.opensearch.alerting.service.DeleteMonitorService
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.settings.AlertingSettings.Companion.DOC_LEVEL_MONITOR_SHARD_FETCH_SIZE
+import org.opensearch.alerting.settings.AlertingSettings.Companion.MULTI_TENANCY_ENABLED
+import org.opensearch.alerting.settings.AlertingSettings.Companion.REMOTE_METADATA_ENDPOINT
+import org.opensearch.alerting.settings.AlertingSettings.Companion.REMOTE_METADATA_REGION
+import org.opensearch.alerting.settings.AlertingSettings.Companion.REMOTE_METADATA_SERVICE_NAME
+import org.opensearch.alerting.settings.AlertingSettings.Companion.REMOTE_METADATA_STORE_TYPE
 import org.opensearch.alerting.settings.DestinationSettings
 import org.opensearch.alerting.settings.LegacyOpenDistroAlertingSettings
 import org.opensearch.alerting.settings.LegacyOpenDistroDestinationSettings
@@ -129,6 +134,13 @@ import org.opensearch.plugins.ReloadablePlugin
 import org.opensearch.plugins.ScriptPlugin
 import org.opensearch.plugins.SearchPlugin
 import org.opensearch.plugins.SystemIndexPlugin
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.remote.metadata.client.impl.SdkClientFactory
+import org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_ENDPOINT_KEY
+import org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_REGION_KEY
+import org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_SERVICE_NAME_KEY
+import org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_TYPE_KEY
+import org.opensearch.remote.metadata.common.CommonValue.TENANT_AWARE_KEY
 import org.opensearch.repositories.RepositoriesService
 import org.opensearch.rest.RestController
 import org.opensearch.rest.RestHandler
@@ -156,6 +168,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
     companion object {
         @JvmField val OPEN_SEARCH_DASHBOARDS_USER_AGENT = "OpenSearch-Dashboards"
         @JvmField val UI_METADATA_EXCLUDE = arrayOf("monitor.${Monitor.UI_METADATA_FIELD}")
+        @JvmField val TENANT_ID_HEADER = "x-tenant-id"
         @JvmField val MONITOR_BASE_URI = "/_plugins/_alerting/monitors"
         @JvmField val WORKFLOW_BASE_URI = "/_plugins/_alerting/workflows"
         @JvmField val REMOTE_BASE_URI = "/_plugins/_alerting/remote"
@@ -285,7 +298,21 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
         val settings = environment.settings()
         val lockService = LockService(client, clusterService)
         alertIndices = AlertIndices(settings, client, threadPool, clusterService)
-        val alertService = AlertService(client, xContentRegistry, alertIndices)
+
+        val sdkClient: SdkClient = SdkClientFactory.createSdkClient(
+            client,
+            xContentRegistry,
+            mapOf(
+                REMOTE_METADATA_TYPE_KEY to REMOTE_METADATA_STORE_TYPE.get(settings),
+                REMOTE_METADATA_ENDPOINT_KEY to REMOTE_METADATA_ENDPOINT.get(settings),
+                REMOTE_METADATA_REGION_KEY to REMOTE_METADATA_REGION.get(settings),
+                REMOTE_METADATA_SERVICE_NAME_KEY to REMOTE_METADATA_SERVICE_NAME.get(settings),
+                TENANT_AWARE_KEY to MULTI_TENANCY_ENABLED.get(settings).toString()
+            ),
+            client.threadPool().executor(ThreadPool.Names.GENERIC)
+        )
+
+        val alertService = AlertService(client, xContentRegistry, alertIndices, sdkClient)
         val triggerService = TriggerService(scriptService)
         runner = MonitorRunnerService
             .registerClusterService(clusterService)
@@ -329,7 +356,8 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             client,
             clusterService,
             xContentRegistry,
-            settings
+            settings,
+            sdkClient
         )
 
         WorkflowMetadataService.initialize(
@@ -351,7 +379,8 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             destinationMigrationCoordinator,
             lockService,
             alertService,
-            triggerService
+            triggerService,
+            sdkClient
         )
     }
 
@@ -434,6 +463,11 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             AlertingSettings.MAX_COMMENTS_PER_ALERT,
             AlertingSettings.MAX_COMMENTS_PER_NOTIFICATION,
             AlertingSettings.NOTIFICATION_CONTEXT_RESULTS_ALLOWED_ROLES,
+            AlertingSettings.MULTI_TENANCY_ENABLED,
+            AlertingSettings.REMOTE_METADATA_STORE_TYPE,
+            AlertingSettings.REMOTE_METADATA_ENDPOINT,
+            AlertingSettings.REMOTE_METADATA_REGION,
+            AlertingSettings.REMOTE_METADATA_SERVICE_NAME,
             AlertingSettings.MULTI_TENANT_TRIGGER_EVAL_ENABLED
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt
@@ -13,26 +13,19 @@ import org.apache.logging.log4j.LogManager
 import org.opensearch.ExceptionsHelper
 import org.opensearch.OpenSearchSecurityException
 import org.opensearch.OpenSearchStatusException
-import org.opensearch.action.DocWriteRequest
-import org.opensearch.action.DocWriteResponse
 import org.opensearch.action.admin.indices.get.GetIndexRequest
 import org.opensearch.action.admin.indices.get.GetIndexResponse
 import org.opensearch.action.admin.indices.stats.IndicesStatsAction
 import org.opensearch.action.admin.indices.stats.IndicesStatsRequest
 import org.opensearch.action.admin.indices.stats.IndicesStatsResponse
-import org.opensearch.action.get.GetRequest
-import org.opensearch.action.get.GetResponse
-import org.opensearch.action.index.IndexRequest
-import org.opensearch.action.index.IndexResponse
-import org.opensearch.action.support.WriteRequest
 import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.util.IndexUtils
+import org.opensearch.alerting.util.await
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
-import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.alerting.model.DocLevelMonitorInput
@@ -44,9 +37,13 @@ import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.core.rest.RestStatus
 import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.core.xcontent.ToXContentObject
 import org.opensearch.core.xcontent.XContentParser
 import org.opensearch.core.xcontent.XContentParserUtils
 import org.opensearch.index.seqno.SequenceNumbers
+import org.opensearch.remote.metadata.client.GetDataObjectRequest
+import org.opensearch.remote.metadata.client.PutDataObjectRequest
+import org.opensearch.remote.metadata.client.SdkClient
 import org.opensearch.transport.RemoteTransportException
 import org.opensearch.transport.client.Client
 
@@ -59,6 +56,7 @@ object MonitorMetadataService :
     private lateinit var xContentRegistry: NamedXContentRegistry
     private lateinit var clusterService: ClusterService
     private lateinit var settings: Settings
+    private lateinit var sdkClient: SdkClient
 
     @Volatile
     private lateinit var indexTimeout: TimeValue
@@ -68,58 +66,54 @@ object MonitorMetadataService :
         clusterService: ClusterService,
         xContentRegistry: NamedXContentRegistry,
         settings: Settings,
+        sdkClient: SdkClient
     ) {
         this.clusterService = clusterService
         this.client = client
         this.xContentRegistry = xContentRegistry
         this.settings = settings
+        this.sdkClient = sdkClient
         this.indexTimeout = AlertingSettings.INDEX_TIMEOUT.get(settings)
         this.clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.INDEX_TIMEOUT) { indexTimeout = it }
     }
+
+    private fun getTenantId(): String? =
+        client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
 
     @Suppress("ComplexMethod", "ReturnCount")
     suspend fun upsertMetadata(metadata: MonitorMetadata, updating: Boolean): MonitorMetadata {
         try {
             if (clusterService.state().routingTable.hasIndex(ScheduledJob.SCHEDULED_JOBS_INDEX)) {
-                val indexRequest = IndexRequest(ScheduledJob.SCHEDULED_JOBS_INDEX)
-                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                    .source(
-                        metadata.toXContent(
-                            XContentFactory.jsonBuilder(),
-                            ToXContent.MapParams(mapOf("with_type" to "true"))
-                        )
-                    )
+                val metadataObj = ToXContentObject { builder, _ ->
+                    metadata.toXContent(builder, ToXContent.MapParams(mapOf("with_type" to "true")))
+                }
+                val putRequestBuilder = PutDataObjectRequest.builder()
+                    .index(ScheduledJob.SCHEDULED_JOBS_INDEX)
                     .id(metadata.id)
-                    .routing(metadata.monitorId)
-                    .setIfSeqNo(metadata.seqNo)
-                    .setIfPrimaryTerm(metadata.primaryTerm)
-                    .timeout(indexTimeout)
+                    .tenantId(getTenantId())
+                    .dataObject(metadataObj)
 
                 if (updating) {
-                    indexRequest.id(metadata.id).setIfSeqNo(metadata.seqNo).setIfPrimaryTerm(metadata.primaryTerm)
+                    putRequestBuilder.ifSeqNo(metadata.seqNo).ifPrimaryTerm(metadata.primaryTerm)
+                        .overwriteIfExists(true)
                 } else {
-                    indexRequest.opType(DocWriteRequest.OpType.CREATE)
+                    putRequestBuilder.overwriteIfExists(false)
                 }
-                val response: IndexResponse = client.suspendUntil { index(indexRequest, it) }
-                when (response.result) {
-                    DocWriteResponse.Result.DELETED, DocWriteResponse.Result.NOOP, DocWriteResponse.Result.NOT_FOUND, null -> {
-                        val failureReason =
-                            "The upsert metadata call failed with a ${response.result?.lowercase} result"
-                        log.error(failureReason)
-                        throw AlertingException(
-                            failureReason,
-                            RestStatus.INTERNAL_SERVER_ERROR,
-                            IllegalStateException(failureReason)
-                        )
-                    }
 
-                    DocWriteResponse.Result.CREATED, DocWriteResponse.Result.UPDATED -> {
-                        log.debug("Successfully upserted MonitorMetadata:${metadata.id} ")
-                    }
+                val putResponse = sdkClient.putDataObjectAsync(putRequestBuilder.build()).await()
+                if (putResponse.isFailed) {
+                    val failureReason = "The upsert metadata call failed: ${putResponse.cause()?.message}"
+                    log.error(failureReason)
+                    throw AlertingException(
+                        failureReason,
+                        putResponse.status() ?: RestStatus.INTERNAL_SERVER_ERROR,
+                        putResponse.cause() ?: IllegalStateException(failureReason)
+                    )
                 }
+                log.debug("Successfully upserted MonitorMetadata:${metadata.id} ")
                 return metadata.copy(
-                    seqNo = response.seqNo,
-                    primaryTerm = response.primaryTerm
+                    seqNo = putResponse.indexResponse()?.seqNo ?: SequenceNumbers.UNASSIGNED_SEQ_NO,
+                    primaryTerm = putResponse.indexResponse()?.primaryTerm ?: SequenceNumbers.UNASSIGNED_PRIMARY_TERM
                 )
             } else {
                 val failureReason = "Job index ${ScheduledJob.SCHEDULED_JOBS_INDEX} does not exist to update monitor metadata"
@@ -180,10 +174,15 @@ object MonitorMetadataService :
     suspend fun getMetadata(monitor: Monitor, workflowMetadataId: String? = null): MonitorMetadata? {
         try {
             val metadataId = MonitorMetadata.getId(monitor, workflowMetadataId)
-            val getRequest = GetRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, metadataId).routing(monitor.id)
+            val getRequest = GetDataObjectRequest.builder()
+                .index(ScheduledJob.SCHEDULED_JOBS_INDEX)
+                .id(metadataId)
+                .tenantId(getTenantId())
+                .build()
 
-            val getResponse: GetResponse = client.suspendUntil { get(getRequest, it) }
-            return if (getResponse.isExists) {
+            val response = sdkClient.getDataObjectAsync(getRequest).await()
+            val getResponse = response.getResponse()
+            return if (getResponse != null && getResponse.isExists) {
                 val xcp = XContentHelper.createParser(
                     xContentRegistry, LoggingDeprecationHandler.INSTANCE,
                     getResponse.sourceAsBytesRef, XContentType.JSON
@@ -194,7 +193,7 @@ object MonitorMetadataService :
                 null
             }
         } catch (e: Exception) {
-            if (e.message?.contains("no such index") == true) {
+            if (AlertingException.isIndexNotFoundException(e)) {
                 return null
             } else {
                 throw AlertingException.wrap(e)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
@@ -8,6 +8,10 @@ package org.opensearch.alerting.settings
 import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.common.settings.Setting
 import org.opensearch.common.unit.TimeValue
+import org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_ENDPOINT_KEY
+import org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_REGION_KEY
+import org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_SERVICE_NAME_KEY
+import org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_TYPE_KEY
 import java.util.concurrent.TimeUnit
 import java.util.function.Function
 
@@ -19,6 +23,7 @@ class AlertingSettings {
     companion object {
         const val DEFAULT_MAX_ACTIONABLE_ALERT_COUNT = 50L
         const val DEFAULT_FINDINGS_INDEXING_BATCH_SIZE = 1000
+        private const val REMOTE_METADATA_KEY_PREFIX = "plugins.alerting"
         const val DEFAULT_PERCOLATE_QUERY_NUM_DOCS_IN_MEMORY = 50000
         const val DEFAULT_PERCOLATE_QUERY_DOCS_SIZE_MEMORY_PERCENTAGE_LIMIT = 10
         const val DEFAULT_DOC_LEVEL_MONITOR_SHARD_FETCH_SIZE = 10000
@@ -310,6 +315,37 @@ class AlertingSettings {
             Function.identity(),
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
+        )
+
+        val MULTI_TENANCY_ENABLED: Setting<Boolean> = Setting.boolSetting(
+            "$REMOTE_METADATA_KEY_PREFIX.multi_tenancy_enabled",
+            false,
+            Setting.Property.NodeScope,
+            Setting.Property.Final
+        )
+
+        val REMOTE_METADATA_STORE_TYPE: Setting<String?> = Setting.simpleString(
+            "$REMOTE_METADATA_KEY_PREFIX.$REMOTE_METADATA_TYPE_KEY",
+            Setting.Property.NodeScope,
+            Setting.Property.Final
+        )
+
+        val REMOTE_METADATA_ENDPOINT: Setting<String?> = Setting.simpleString(
+            "$REMOTE_METADATA_KEY_PREFIX.$REMOTE_METADATA_ENDPOINT_KEY",
+            Setting.Property.NodeScope,
+            Setting.Property.Final
+        )
+
+        val REMOTE_METADATA_REGION: Setting<String?> = Setting.simpleString(
+            "$REMOTE_METADATA_KEY_PREFIX.$REMOTE_METADATA_REGION_KEY",
+            Setting.Property.NodeScope,
+            Setting.Property.Final
+        )
+
+        val REMOTE_METADATA_SERVICE_NAME: Setting<String?> = Setting.simpleString(
+            "$REMOTE_METADATA_KEY_PREFIX.$REMOTE_METADATA_SERVICE_NAME_KEY",
+            Setting.Property.NodeScope,
+            Setting.Property.Final
         )
 
         val MULTI_TENANT_TRIGGER_EVAL_ENABLED = Setting.boolSetting(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
@@ -11,23 +11,17 @@ import kotlinx.coroutines.launch
 import org.apache.logging.log4j.LogManager
 import org.opensearch.ResourceNotFoundException
 import org.opensearch.action.ActionRequest
-import org.opensearch.action.bulk.BulkRequest
-import org.opensearch.action.bulk.BulkResponse
-import org.opensearch.action.delete.DeleteRequest
-import org.opensearch.action.index.IndexRequest
-import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
-import org.opensearch.action.update.UpdateRequest
 import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.settings.AlertingSettings
+import org.opensearch.alerting.util.await
 import org.opensearch.alerting.util.use
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
-import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.alerting.action.AcknowledgeAlertRequest
@@ -42,9 +36,17 @@ import org.opensearch.commons.alerting.util.optionalTimeField
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.core.xcontent.ToXContentObject
 import org.opensearch.core.xcontent.XContentParser
 import org.opensearch.core.xcontent.XContentParserUtils
 import org.opensearch.index.query.QueryBuilders
+import org.opensearch.remote.metadata.client.BulkDataObjectRequest
+import org.opensearch.remote.metadata.client.BulkDataObjectResponse
+import org.opensearch.remote.metadata.client.DeleteDataObjectRequest
+import org.opensearch.remote.metadata.client.PutDataObjectRequest
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest
+import org.opensearch.remote.metadata.client.UpdateDataObjectRequest
 import org.opensearch.rest.RestRequest
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.search.fetch.subphase.FetchSourceContext
@@ -64,7 +66,8 @@ class TransportAcknowledgeAlertAction @Inject constructor(
     actionFilters: ActionFilters,
     val settings: Settings,
     val xContentRegistry: NamedXContentRegistry,
-    val transportGetMonitorAction: TransportGetMonitorAction
+    val transportGetMonitorAction: TransportGetMonitorAction,
+    val sdkClient: SdkClient
 ) : HandledTransportAction<ActionRequest, AcknowledgeAlertResponse>(
     AlertingActions.ACKNOWLEDGE_ALERTS_ACTION_NAME, transportService, actionFilters, ::AcknowledgeAlertRequest
 ) {
@@ -127,18 +130,19 @@ class TransportAcknowledgeAlertAction @Inject constructor(
             val queryBuilder = QueryBuilders.boolQuery()
                 .filter(QueryBuilders.termQuery(Alert.MONITOR_ID_FIELD, request.monitorId))
                 .filter(QueryBuilders.termsQuery("_id", request.alertIds))
-            val searchRequest = SearchRequest()
+            val searchSourceBuilder = SearchSourceBuilder()
+                .query(queryBuilder)
+                .version(true)
+                .seqNoAndPrimaryTerm(true)
+                .size(request.alertIds.size)
+            val sdkSearchRequest = SearchDataObjectRequest.builder()
                 .indices(monitor.dataSources.alertsIndex)
                 .routing(request.monitorId)
-                .source(
-                    SearchSourceBuilder()
-                        .query(queryBuilder)
-                        .version(true)
-                        .seqNoAndPrimaryTerm(true)
-                        .size(request.alertIds.size)
-                )
+                .searchSourceBuilder(searchSourceBuilder)
+                .build()
             try {
-                val searchResponse: SearchResponse = client.suspendUntil { client.search(searchRequest, it) }
+                val searchResponse = sdkClient.searchDataObjectAsync(sdkSearchRequest).await()
+                    .searchResponse() ?: throw RuntimeException("Unknown error loading alerts")
                 onSearchResponse(searchResponse, monitor)
             } catch (t: Exception) {
                 actionListener.onFailure(AlertingException.wrap(t))
@@ -147,8 +151,8 @@ class TransportAcknowledgeAlertAction @Inject constructor(
 
         private suspend fun onSearchResponse(response: SearchResponse, monitor: Monitor) {
             val alertsHistoryIndex = monitor.dataSources.alertsHistoryIndex
-            val updateRequests = mutableListOf<UpdateRequest>()
-            val copyRequests = mutableListOf<IndexRequest>()
+            val updateRequests = mutableListOf<UpdateDataObjectRequest>()
+            val copyRequests = mutableListOf<PutDataObjectRequest>()
             response.hits.forEach { hit ->
                 val xcp = XContentHelper.createParser(
                     xContentRegistry, LoggingDeprecationHandler.INSTANCE,
@@ -163,41 +167,49 @@ class TransportAcknowledgeAlertAction @Inject constructor(
                         alert.findingIds.isEmpty() ||
                         !isAlertHistoryEnabled
                     ) {
-                        val updateRequest = UpdateRequest(monitor.dataSources.alertsIndex, alert.id)
-                            .routing(request.monitorId)
-                            .setIfSeqNo(hit.seqNo)
-                            .setIfPrimaryTerm(hit.primaryTerm)
-                            .doc(
-                                XContentFactory.jsonBuilder().startObject()
-                                    .field(Alert.STATE_FIELD, Alert.State.ACKNOWLEDGED.toString())
-                                    .optionalTimeField(Alert.ACKNOWLEDGED_TIME_FIELD, Instant.now())
-                                    .endObject()
-                            )
-                        updateRequests.add(updateRequest)
+                        updateRequests.add(
+                            UpdateDataObjectRequest.builder()
+                                .index(monitor.dataSources.alertsIndex)
+                                .id(alert.id)
+                                .routing(request.monitorId)
+                                .ifSeqNo(hit.seqNo)
+                                .ifPrimaryTerm(hit.primaryTerm)
+                                .dataObject(
+                                    ToXContentObject { builder, _ ->
+                                        builder.startObject()
+                                            .field(Alert.STATE_FIELD, Alert.State.ACKNOWLEDGED.toString())
+                                            .optionalTimeField(Alert.ACKNOWLEDGED_TIME_FIELD, Instant.now())
+                                            .endObject()
+                                    }
+                                )
+                                .build()
+                        )
                     } else {
-                        val copyRequest = IndexRequest(alertsHistoryIndex)
-                            .routing(request.monitorId)
-                            .id(alert.id)
-                            .source(
-                                alert.copy(state = Alert.State.ACKNOWLEDGED, acknowledgedTime = Instant.now())
-                                    .toXContentWithUser(XContentFactory.jsonBuilder())
-                            )
-                        copyRequests.add(copyRequest)
+                        val ackedAlert = alert.copy(state = Alert.State.ACKNOWLEDGED, acknowledgedTime = Instant.now())
+                        copyRequests.add(
+                            PutDataObjectRequest.builder()
+                                .index(alertsHistoryIndex)
+                                .id(alert.id)
+                                .routing(request.monitorId)
+                                .overwriteIfExists(true)
+                                .dataObject(ToXContentObject { builder, _ -> ackedAlert.toXContentWithUser(builder) })
+                                .build()
+                        )
                     }
                 }
             }
 
             try {
-                val updateResponse: BulkResponse? = if (updateRequests.isNotEmpty())
-                    client.suspendUntil {
-                        client.bulk(BulkRequest().add(updateRequests).setRefreshPolicy(request.refreshPolicy), it)
-                    }
-                else null
-                val copyResponse: BulkResponse? = if (copyRequests.isNotEmpty())
-                    client.suspendUntil {
-                        client.bulk(BulkRequest().add(copyRequests).setRefreshPolicy(request.refreshPolicy), it)
-                    }
-                else null
+                val updateResponse = if (updateRequests.isNotEmpty()) {
+                    val bulkRequest = BulkDataObjectRequest(null)
+                    updateRequests.forEach { bulkRequest.add(it) }
+                    sdkClient.bulkDataObjectAsync(bulkRequest).await()
+                } else null
+                val copyResponse = if (copyRequests.isNotEmpty()) {
+                    val bulkRequest = BulkDataObjectRequest(null)
+                    copyRequests.forEach { bulkRequest.add(it) }
+                    sdkClient.bulkDataObjectAsync(bulkRequest).await()
+                } else null
                 onBulkResponse(updateResponse, copyResponse, monitor)
             } catch (t: Exception) {
                 log.error("ack error: ${t.message}")
@@ -205,8 +217,12 @@ class TransportAcknowledgeAlertAction @Inject constructor(
             }
         }
 
-        private suspend fun onBulkResponse(updateResponse: BulkResponse?, copyResponse: BulkResponse?, monitor: Monitor) {
-            val deleteRequests = mutableListOf<DeleteRequest>()
+        private suspend fun onBulkResponse(
+            updateResponse: BulkDataObjectResponse?,
+            copyResponse: BulkDataObjectResponse?,
+            monitor: Monitor
+        ) {
+            val deleteRequests = mutableListOf<DeleteDataObjectRequest>()
             val missing = request.alertIds.toMutableSet()
             val acknowledged = mutableListOf<Alert>()
             val failed = mutableListOf<Alert>()
@@ -218,39 +234,43 @@ class TransportAcknowledgeAlertAction @Inject constructor(
                 }
             }
 
-            updateResponse?.items?.forEach { item ->
-                missing.remove(item.id)
+            updateResponse?.responses?.forEach { item ->
+                missing.remove(item.id())
                 if (item.isFailed) {
-                    failed.add(alerts[item.id]!!)
+                    failed.add(alerts[item.id()]!!)
                 } else {
-                    acknowledged.add(alerts[item.id]!!)
+                    acknowledged.add(alerts[item.id()]!!)
                 }
             }
 
-            copyResponse?.items?.forEach { item ->
+            copyResponse?.responses?.forEach { item ->
                 log.info("got a copyResponse: $item")
-                missing.remove(item.id)
+                missing.remove(item.id())
                 if (item.isFailed) {
-                    log.info("got a failureResponse: ${item.failureMessage}")
-                    failed.add(alerts[item.id]!!)
+                    log.info("got a failureResponse: ${item.cause()?.message}")
+                    failed.add(alerts[item.id()]!!)
                 } else {
-                    val deleteRequest = DeleteRequest(monitor.dataSources.alertsIndex, item.id)
-                        .routing(request.monitorId)
-                    deleteRequests.add(deleteRequest)
+                    deleteRequests.add(
+                        DeleteDataObjectRequest.builder()
+                            .index(monitor.dataSources.alertsIndex)
+                            .id(item.id())
+                            .routing(request.monitorId)
+                            .build()
+                    )
                 }
             }
 
             if (deleteRequests.isNotEmpty()) {
                 try {
-                    val deleteResponse: BulkResponse = client.suspendUntil {
-                        client.bulk(BulkRequest().add(deleteRequests).setRefreshPolicy(request.refreshPolicy), it)
-                    }
-                    deleteResponse.items.forEach { item ->
-                        missing.remove(item.id)
+                    val bulkRequest = BulkDataObjectRequest(null)
+                    deleteRequests.forEach { bulkRequest.add(it) }
+                    val deleteResponse = sdkClient.bulkDataObjectAsync(bulkRequest).await()
+                    deleteResponse.responses.forEach { item ->
+                        missing.remove(item.id())
                         if (item.isFailed) {
-                            failed.add(alerts[item.id]!!)
+                            failed.add(alerts[item.id()]!!)
                         } else {
-                            acknowledged.add(alerts[item.id]!!)
+                            acknowledged.add(alerts[item.id()]!!)
                         }
                     }
                 } catch (t: Exception) {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeChainedAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeChainedAlertAction.kt
@@ -52,6 +52,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.core.xcontent.XContentParser
 import org.opensearch.core.xcontent.XContentParserUtils
 import org.opensearch.index.query.QueryBuilders
+import org.opensearch.remote.metadata.client.SdkClient
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService
@@ -69,6 +70,7 @@ class TransportAcknowledgeChainedAlertAction @Inject constructor(
     actionFilters: ActionFilters,
     val settings: Settings,
     val xContentRegistry: NamedXContentRegistry,
+    val sdkClient: SdkClient,
 ) : HandledTransportAction<ActionRequest, AcknowledgeAlertResponse>(
     AlertingActions.ACKNOWLEDGE_CHAINED_ALERTS_ACTION_NAME,
     transportService,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteAlertingCommentAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteAlertingCommentAction.kt
@@ -11,13 +11,10 @@ import kotlinx.coroutines.launch
 import org.apache.logging.log4j.LogManager
 import org.opensearch.OpenSearchStatusException
 import org.opensearch.action.ActionRequest
-import org.opensearch.action.delete.DeleteRequest
-import org.opensearch.action.search.SearchRequest
-import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
+import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.comments.CommentsIndices.Companion.ALL_COMMENTS_INDEX_PATTERN
-import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
@@ -38,6 +35,9 @@ import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.core.xcontent.XContentParser
 import org.opensearch.core.xcontent.XContentParserUtils
 import org.opensearch.index.query.QueryBuilders
+import org.opensearch.remote.metadata.client.DeleteDataObjectRequest
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService
@@ -52,7 +52,8 @@ class TransportDeleteAlertingCommentAction @Inject constructor(
     actionFilters: ActionFilters,
     val clusterService: ClusterService,
     settings: Settings,
-    val xContentRegistry: NamedXContentRegistry
+    val xContentRegistry: NamedXContentRegistry,
+    val sdkClient: SdkClient
 ) : HandledTransportAction<ActionRequest, DeleteCommentResponse>(
     AlertingActions.DELETE_COMMENT_ACTION_NAME, transportService, actionFilters, ::DeleteCommentRequest
 ),
@@ -125,12 +126,16 @@ class TransportDeleteAlertingCommentAction @Inject constructor(
                 // or if the user is Admin
                 val canDelete = user == null || user.name == comment.user?.name || isAdmin(user)
 
-                val deleteRequest = DeleteRequest(sourceIndex, commentId)
+                val deleteRequest = DeleteDataObjectRequest.builder()
+                    .index(sourceIndex)
+                    .id(commentId)
+                    .tenantId(client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER))
+                    .build()
 
                 if (canDelete) {
-                    log.debug("Deleting the comment with id ${deleteRequest.id()}")
-                    val deleteResponse = client.suspendUntil { delete(deleteRequest, it) }
-                    actionListener.onResponse(DeleteCommentResponse(deleteResponse.id))
+                    log.debug("Deleting the comment with id $commentId")
+                    val deleteResponse = sdkClient.deleteDataObject(deleteRequest)
+                    actionListener.onResponse(DeleteCommentResponse(deleteResponse.id()))
                 } else {
                     actionListener.onFailure(
                         AlertingException("Not allowed to delete this comment!", RestStatus.FORBIDDEN, IllegalStateException())
@@ -151,12 +156,15 @@ class TransportDeleteAlertingCommentAction @Inject constructor(
                     .version(true)
                     .seqNoAndPrimaryTerm(true)
                     .query(queryBuilder)
-            val searchRequest = SearchRequest()
-                .source(searchSourceBuilder)
+            val searchRequest = SearchDataObjectRequest.builder()
                 .indices(ALL_COMMENTS_INDEX_PATTERN)
+                .tenantId(client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER))
+                .searchSourceBuilder(searchSourceBuilder)
+                .build()
 
-            val searchResponse: SearchResponse = client.suspendUntil { search(searchRequest, it) }
-            val comments = searchResponse.hits.map { hit ->
+            val sdkResponse = sdkClient.searchDataObject(searchRequest)
+            val searchResponse = sdkResponse.searchResponse()
+            val comments = searchResponse?.hits?.map { hit ->
                 val xcp = XContentHelper.createParser(
                     NamedXContentRegistry.EMPTY,
                     LoggingDeprecationHandler.INSTANCE,
@@ -169,7 +177,7 @@ class TransportDeleteAlertingCommentAction @Inject constructor(
                 comment
             }
 
-            if (comments.isEmpty()) {
+            if (comments.isNullOrEmpty()) {
                 actionListener.onFailure(
                     AlertingException.wrap(
                         OpenSearchStatusException("Comment not found", RestStatus.NOT_FOUND),

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
@@ -11,12 +11,10 @@ import kotlinx.coroutines.launch
 import org.apache.logging.log4j.LogManager
 import org.opensearch.OpenSearchStatusException
 import org.opensearch.action.ActionRequest
-import org.opensearch.action.get.GetRequest
-import org.opensearch.action.get.GetResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.action.support.WriteRequest.RefreshPolicy
-import org.opensearch.alerting.opensearchapi.suspendUntil
+import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.service.DeleteMonitorService
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.cluster.service.ClusterService
@@ -36,6 +34,8 @@ import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.rest.RestStatus
 import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.remote.metadata.client.GetDataObjectRequest
+import org.opensearch.remote.metadata.client.SdkClient
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService
 import org.opensearch.transport.client.Client
@@ -49,7 +49,8 @@ class TransportDeleteMonitorAction @Inject constructor(
     actionFilters: ActionFilters,
     val clusterService: ClusterService,
     settings: Settings,
-    val xContentRegistry: NamedXContentRegistry
+    val xContentRegistry: NamedXContentRegistry,
+    val sdkClient: SdkClient
 ) : HandledTransportAction<ActionRequest, DeleteMonitorResponse>(
     AlertingActions.DELETE_MONITOR_ACTION_NAME, transportService, actionFilters, ::DeleteMonitorRequest
 ),
@@ -100,6 +101,7 @@ class TransportDeleteMonitorAction @Inject constructor(
                             IllegalStateException()
                         )
                     )
+                    return
                 } else if (canDelete) {
                     actionListener.onResponse(
                         DeleteMonitorService.deleteMonitor(monitor, refreshPolicy)
@@ -109,6 +111,9 @@ class TransportDeleteMonitorAction @Inject constructor(
                         AlertingException("Not allowed to delete this monitor!", RestStatus.FORBIDDEN, IllegalStateException())
                     )
                 }
+            } catch (t: OpenSearchStatusException) {
+                log.error("Failed to delete monitor $monitorId", t)
+                actionListener.onFailure(t)
             } catch (t: Exception) {
                 log.error("Failed to delete monitor $monitorId", t)
                 actionListener.onFailure(AlertingException.wrap(t))
@@ -116,21 +121,29 @@ class TransportDeleteMonitorAction @Inject constructor(
         }
 
         private suspend fun getMonitor(): Monitor {
-            val getRequest = GetRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, monitorId)
+            val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+            val getRequest = GetDataObjectRequest.builder()
+                .index(ScheduledJob.SCHEDULED_JOBS_INDEX)
+                .id(monitorId)
+                .tenantId(tenantId)
+                .build()
 
-            val getResponse: GetResponse = client.suspendUntil { get(getRequest, it) }
-            if (getResponse.isExists == false) {
-                actionListener.onFailure(
-                    AlertingException.wrap(
-                        OpenSearchStatusException("Monitor with $monitorId is not found", RestStatus.NOT_FOUND)
-                    )
+            try {
+                val response = sdkClient.getDataObject(getRequest)
+                val getResponse = response.getResponse()
+                if (getResponse == null || !getResponse.isExists) {
+                    throw OpenSearchStatusException("Monitor with $monitorId is not found", RestStatus.NOT_FOUND)
+                }
+                val xcp = XContentHelper.createParser(
+                    xContentRegistry, LoggingDeprecationHandler.INSTANCE,
+                    getResponse.sourceAsBytesRef, XContentType.JSON
                 )
+                return ScheduledJob.parse(xcp, getResponse.id, getResponse.version) as Monitor
+            } catch (e: Exception) {
+                if (e is OpenSearchStatusException && e.status() == RestStatus.NOT_FOUND) throw e
+                log.error("GetMonitor operation failed for $monitorId", e)
+                throw OpenSearchStatusException("Monitor with $monitorId is not found", RestStatus.NOT_FOUND)
             }
-            val xcp = XContentHelper.createParser(
-                xContentRegistry, LoggingDeprecationHandler.INSTANCE,
-                getResponse.sourceAsBytesRef, XContentType.JSON
-            )
-            return ScheduledJob.parse(xcp, getResponse.id, getResponse.version) as Monitor
         }
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
@@ -11,11 +11,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.apache.logging.log4j.LogManager
 import org.opensearch.OpenSearchStatusException
-import org.opensearch.action.get.GetRequest
-import org.opensearch.action.get.GetResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.action.support.WriteRequest
+import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.MonitorMetadataService
 import org.opensearch.alerting.MonitorRunnerService
 import org.opensearch.alerting.action.ExecuteMonitorAction
@@ -39,12 +38,14 @@ import org.opensearch.commons.authuser.User
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.rest.RestStatus
 import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.remote.metadata.client.GetDataObjectRequest
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.remote.metadata.common.SdkClientUtils
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService
 import org.opensearch.transport.client.Client
 import java.time.Instant
 import java.util.Locale
-
 private val log = LogManager.getLogger(TransportExecuteMonitorAction::class.java)
 private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 
@@ -56,7 +57,8 @@ class TransportExecuteMonitorAction @Inject constructor(
     actionFilters: ActionFilters,
     val xContentRegistry: NamedXContentRegistry,
     private val docLevelMonitorQueries: DocLevelMonitorQueries,
-    private val settings: Settings
+    private val settings: Settings,
+    private val sdkClient: SdkClient
 ) : HandledTransportAction<ExecuteMonitorRequest, ExecuteMonitorResponse> (
     ExecuteMonitorAction.NAME, transportService, actionFilters, ::ExecuteMonitorRequest
 ) {
@@ -101,35 +103,53 @@ class TransportExecuteMonitorAction @Inject constructor(
             }
 
             if (execMonitorRequest.monitorId != null) {
-                val getRequest = GetRequest(ScheduledJob.SCHEDULED_JOBS_INDEX).id(execMonitorRequest.monitorId)
-                client.get(
-                    getRequest,
-                    object : ActionListener<GetResponse> {
-                        override fun onResponse(response: GetResponse) {
-                            if (!response.isExists) {
-                                actionListener.onFailure(
-                                    AlertingException.wrap(
-                                        OpenSearchStatusException("Can't find monitor with id: ${response.id}", RestStatus.NOT_FOUND)
+                val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+                val getRequest = GetDataObjectRequest.builder()
+                    .index(ScheduledJob.SCHEDULED_JOBS_INDEX)
+                    .id(execMonitorRequest.monitorId)
+                    .tenantId(tenantId)
+                    .build()
+                sdkClient.getDataObjectAsync(getRequest).whenComplete { response, throwable ->
+                    if (throwable != null) {
+                        actionListener.onFailure(AlertingException.wrap(SdkClientUtils.unwrapAndConvertToException(throwable)))
+                        return@whenComplete
+                    }
+                    try {
+                        val getResponse = response.getResponse()
+                        if (getResponse == null || !getResponse.isExists) {
+                            actionListener.onFailure(
+                                AlertingException.wrap(
+                                    OpenSearchStatusException(
+                                        "Can't find monitor with id: ${execMonitorRequest.monitorId}",
+                                        RestStatus.NOT_FOUND
                                     )
                                 )
-                                return
-                            }
-                            if (!response.isSourceEmpty) {
-                                XContentHelper.createParser(
-                                    xContentRegistry, LoggingDeprecationHandler.INSTANCE,
-                                    response.sourceAsBytesRef, XContentType.JSON
-                                ).use { xcp ->
-                                    val monitor = ScheduledJob.parse(xcp, response.id, response.version) as Monitor
-                                    executeMonitor(monitor)
-                                }
-                            }
+                            )
+                            return@whenComplete
                         }
-
-                        override fun onFailure(t: Exception) {
-                            actionListener.onFailure(AlertingException.wrap(t))
+                        if (!getResponse.isSourceEmpty) {
+                            XContentHelper.createParser(
+                                xContentRegistry, LoggingDeprecationHandler.INSTANCE,
+                                getResponse.sourceAsBytesRef, XContentType.JSON
+                            ).use { xcp ->
+                                val monitor = ScheduledJob.parse(xcp, getResponse.id, getResponse.version) as Monitor
+                                executeMonitor(monitor)
+                            }
+                        } else {
+                            actionListener.onFailure(
+                                AlertingException.wrap(
+                                    OpenSearchStatusException(
+                                        "Monitor source is empty for id: ${execMonitorRequest.monitorId}",
+                                        RestStatus.NOT_FOUND
+                                    )
+                                )
+                            )
                         }
+                    } catch (e: Exception) {
+                        log.error("Failed to get monitor ${execMonitorRequest.monitorId} for execution", e)
+                        actionListener.onFailure(AlertingException.wrap(e))
                     }
-                )
+                }
             } else {
                 val monitor = when (user?.name.isNullOrEmpty()) {
                     true -> execMonitorRequest.monitor as Monitor

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
@@ -10,15 +10,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.apache.logging.log4j.LogManager
 import org.opensearch.action.ActionRequest
-import org.opensearch.action.get.GetRequest
-import org.opensearch.action.get.GetResponse
-import org.opensearch.action.search.SearchRequest
-import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
+import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.alerts.AlertIndices
 import org.opensearch.alerting.opensearchapi.addFilter
-import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.util.use
 import org.opensearch.cluster.service.ClusterService
@@ -44,6 +40,10 @@ import org.opensearch.core.xcontent.XContentParserUtils
 import org.opensearch.index.query.BoolQueryBuilder
 import org.opensearch.index.query.Operator
 import org.opensearch.index.query.QueryBuilders
+import org.opensearch.remote.metadata.client.GetDataObjectRequest
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest
+import org.opensearch.remote.metadata.common.SdkClientUtils
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.search.sort.SortBuilders
 import org.opensearch.search.sort.SortOrder
@@ -62,7 +62,8 @@ class TransportGetAlertsAction @Inject constructor(
     actionFilters: ActionFilters,
     val settings: Settings,
     val xContentRegistry: NamedXContentRegistry,
-    val namedWriteableRegistry: NamedWriteableRegistry
+    val namedWriteableRegistry: NamedWriteableRegistry,
+    val sdkClient: SdkClient
 ) : HandledTransportAction<ActionRequest, GetAlertsResponse>(
     AlertingActions.GET_ALERTS_ACTION_NAME,
     transportService,
@@ -201,10 +202,16 @@ class TransportGetAlertsAction @Inject constructor(
     }
 
     private suspend fun getMonitor(getAlertsRequest: GetAlertsRequest): Monitor? {
-        val getRequest = GetRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, getAlertsRequest.monitorId!!)
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+        val getRequest = GetDataObjectRequest.builder()
+            .index(ScheduledJob.SCHEDULED_JOBS_INDEX)
+            .id(getAlertsRequest.monitorId!!)
+            .tenantId(tenantId)
+            .build()
         try {
-            val getResponse: GetResponse = client.suspendUntil { client.get(getRequest, it) }
-            if (!getResponse.isExists) {
+            val response = sdkClient.getDataObject(getRequest)
+            val getResponse = response.getResponse()
+            if (getResponse == null || !getResponse.isExists) {
                 return null
             }
             val xcp = XContentHelper.createParser(
@@ -244,33 +251,40 @@ class TransportGetAlertsAction @Inject constructor(
     }
 
     fun search(alertIndex: String, searchSourceBuilder: SearchSourceBuilder, actionListener: ActionListener<GetAlertsResponse>) {
-        val searchRequest = SearchRequest()
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+        val sdkSearchRequest = SearchDataObjectRequest.builder()
             .indices(alertIndex)
-            .source(searchSourceBuilder)
+            .tenantId(tenantId)
+            .searchSourceBuilder(searchSourceBuilder)
+            .build()
 
-        client.search(
-            searchRequest,
-            object : ActionListener<SearchResponse> {
-                override fun onResponse(response: SearchResponse) {
-                    val totalAlertCount = response.hits.totalHits?.value?.toInt()
-                    val alerts = response.hits.map { hit ->
-                        val xcp = XContentHelper.createParser(
-                            xContentRegistry,
-                            LoggingDeprecationHandler.INSTANCE,
-                            hit.sourceRef,
-                            XContentType.JSON
-                        )
-                        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp)
-                        val alert = Alert.parse(xcp, hit.id, hit.version)
-                        alert
-                    }
-                    actionListener.onResponse(GetAlertsResponse(alerts, totalAlertCount))
-                }
-
-                override fun onFailure(t: Exception) {
-                    actionListener.onFailure(t)
-                }
+        sdkClient.searchDataObjectAsync(sdkSearchRequest).whenComplete { response, throwable ->
+            if (throwable != null) {
+                actionListener.onFailure(SdkClientUtils.unwrapAndConvertToException(throwable))
+                return@whenComplete
             }
-        )
+            try {
+                val searchResponse = response.searchResponse()
+                if (searchResponse == null) {
+                    actionListener.onResponse(GetAlertsResponse(emptyList(), 0))
+                    return@whenComplete
+                }
+                val totalAlertCount = searchResponse.hits.totalHits?.value?.toInt()
+                val alerts = searchResponse.hits.map { hit ->
+                    val xcp = XContentHelper.createParser(
+                        xContentRegistry,
+                        LoggingDeprecationHandler.INSTANCE,
+                        hit.sourceRef,
+                        XContentType.JSON
+                    )
+                    XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp)
+                    Alert.parse(xcp, hit.id, hit.version)
+                }
+                actionListener.onResponse(GetAlertsResponse(alerts, totalAlertCount))
+            } catch (e: Exception) {
+                log.error("Failed to search alerts", e)
+                actionListener.onFailure(AlertingException.wrap(e))
+            }
+        }
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetDestinationsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetDestinationsAction.kt
@@ -6,10 +6,9 @@
 package org.opensearch.alerting.transport
 
 import org.apache.logging.log4j.LogManager
-import org.opensearch.action.search.SearchRequest
-import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
+import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.action.GetDestinationsAction
 import org.opensearch.alerting.action.GetDestinationsRequest
 import org.opensearch.alerting.action.GetDestinationsResponse
@@ -33,6 +32,9 @@ import org.opensearch.core.xcontent.XContentParser
 import org.opensearch.core.xcontent.XContentParserUtils
 import org.opensearch.index.query.Operator
 import org.opensearch.index.query.QueryBuilders
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest
+import org.opensearch.remote.metadata.common.SdkClientUtils
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.search.fetch.subphase.FetchSourceContext
 import org.opensearch.search.sort.SortBuilders
@@ -41,7 +43,6 @@ import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService
 import org.opensearch.transport.client.Client
 import java.io.IOException
-
 private val log = LogManager.getLogger(TransportGetDestinationsAction::class.java)
 
 class TransportGetDestinationsAction @Inject constructor(
@@ -50,7 +51,8 @@ class TransportGetDestinationsAction @Inject constructor(
     clusterService: ClusterService,
     actionFilters: ActionFilters,
     val settings: Settings,
-    val xContentRegistry: NamedXContentRegistry
+    val xContentRegistry: NamedXContentRegistry,
+    val sdkClient: SdkClient
 ) : HandledTransportAction<GetDestinationsRequest, GetDestinationsResponse> (
     GetDestinationsAction.NAME, transportService, actionFilters, ::GetDestinationsRequest
 ),
@@ -134,34 +136,42 @@ class TransportGetDestinationsAction @Inject constructor(
     }
 
     fun search(searchSourceBuilder: SearchSourceBuilder, actionListener: ActionListener<GetDestinationsResponse>) {
-        val searchRequest = SearchRequest()
-            .source(searchSourceBuilder)
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+        val sdkSearchRequest = SearchDataObjectRequest.builder()
             .indices(ScheduledJob.SCHEDULED_JOBS_INDEX)
-        client.search(
-            searchRequest,
-            object : ActionListener<SearchResponse> {
-                override fun onResponse(response: SearchResponse) {
-                    val totalDestinationCount = response.hits.totalHits?.value?.toInt()
-                    val destinations = mutableListOf<Destination>()
-                    for (hit in response.hits) {
-                        val id = hit.id
-                        val version = hit.version
-                        val seqNo = hit.seqNo.toInt()
-                        val primaryTerm = hit.primaryTerm.toInt()
-                        val xcp = XContentType.JSON.xContent()
-                            .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, hit.sourceAsString)
-                        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp)
-                        XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, xcp.nextToken(), xcp)
-                        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp)
-                        destinations.add(Destination.parse(xcp, id, version, seqNo, primaryTerm))
-                    }
-                    actionListener.onResponse(GetDestinationsResponse(RestStatus.OK, totalDestinationCount, destinations))
-                }
+            .tenantId(tenantId)
+            .searchSourceBuilder(searchSourceBuilder)
+            .build()
 
-                override fun onFailure(t: Exception) {
-                    actionListener.onFailure(AlertingException.wrap(t))
-                }
+        sdkClient.searchDataObjectAsync(sdkSearchRequest).whenComplete { response, throwable ->
+            if (throwable != null) {
+                actionListener.onFailure(AlertingException.wrap(SdkClientUtils.unwrapAndConvertToException(throwable)))
+                return@whenComplete
             }
-        )
+            try {
+                val searchResponse = response.searchResponse()
+                if (searchResponse == null) {
+                    actionListener.onResponse(GetDestinationsResponse(RestStatus.OK, 0, emptyList()))
+                    return@whenComplete
+                }
+                val totalDestinationCount = searchResponse.hits.totalHits?.value?.toInt()
+                val destinations = mutableListOf<Destination>()
+                for (hit in searchResponse.hits) {
+                    val id = hit.id
+                    val version = hit.version
+                    val seqNo = hit.seqNo.toInt()
+                    val primaryTerm = hit.primaryTerm.toInt()
+                    val xcp = XContentType.JSON.xContent()
+                        .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, hit.sourceAsString)
+                    XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp)
+                    XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, xcp.nextToken(), xcp)
+                    XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp)
+                    destinations.add(Destination.parse(xcp, id, version, seqNo, primaryTerm))
+                }
+                actionListener.onResponse(GetDestinationsResponse(RestStatus.OK, totalDestinationCount, destinations))
+            } catch (e: Exception) {
+                actionListener.onFailure(AlertingException.wrap(e))
+            }
+        }
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetMonitorAction.kt
@@ -12,12 +12,11 @@ import org.apache.logging.log4j.LogManager
 import org.apache.lucene.search.join.ScoreMode
 import org.opensearch.OpenSearchStatusException
 import org.opensearch.action.ActionRequest
-import org.opensearch.action.get.GetRequest
-import org.opensearch.action.get.GetResponse
 import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
+import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.util.ScheduledJobUtils.Companion.WORKFLOW_DELEGATE_PATH
@@ -43,9 +42,11 @@ import org.opensearch.core.rest.RestStatus
 import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.index.IndexNotFoundException
 import org.opensearch.index.query.QueryBuilders
+import org.opensearch.remote.metadata.client.GetDataObjectRequest
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.remote.metadata.common.SdkClientUtils
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.tasks.Task
-import org.opensearch.transport.RemoteTransportException
 import org.opensearch.transport.TransportService
 import org.opensearch.transport.client.Client
 
@@ -59,6 +60,7 @@ class TransportGetMonitorAction @Inject constructor(
     val xContentRegistry: NamedXContentRegistry,
     val clusterService: ClusterService,
     settings: Settings,
+    val sdkClient: SdkClient,
 ) : HandledTransportAction<ActionRequest, GetMonitorResponse>(
     AlertingActions.GET_MONITOR_ACTION_NAME,
     transportService,
@@ -82,102 +84,78 @@ class TransportGetMonitorAction @Inject constructor(
 
         val user = readUserFromThreadContext(client)
 
-        val getRequest = GetRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, transformedRequest.monitorId)
-            .version(transformedRequest.version)
-            .fetchSourceContext(transformedRequest.srcContext)
-
         if (!validateUserBackendRoles(user, actionListener)) {
             return
         }
 
-        /*
-         * Remove security context before you call elasticsearch api's. By this time, permissions required
-         * to call this api are validated.
-         * Once system-indices [https://github.com/opendistro-for-elasticsearch/security/issues/666] is done, we
-         * might further improve this logic. Also change try to kotlin-use for auto-closable.
-         */
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+        val getRequest = GetDataObjectRequest.builder()
+            .index(ScheduledJob.SCHEDULED_JOBS_INDEX)
+            .id(transformedRequest.monitorId)
+            .tenantId(tenantId)
+            .fetchSourceContext(transformedRequest.srcContext)
+            .build()
+
         client.threadPool().threadContext.stashContext().use {
-            client.get(
-                getRequest,
-                object : ActionListener<GetResponse> {
-                    override fun onResponse(response: GetResponse) {
-                        if (!response.isExists) {
-                            actionListener.onFailure(
-                                AlertingException.wrap(OpenSearchStatusException("Monitor not found.", RestStatus.NOT_FOUND))
+            sdkClient.getDataObjectAsync(getRequest).whenComplete { response, throwable ->
+                if (throwable != null) {
+                    val cause = SdkClientUtils.unwrapAndConvertToException(throwable)
+                    if (isIndexNotFoundException(cause)) {
+                        actionListener.onFailure(
+                            AlertingException.wrap(
+                                OpenSearchStatusException("Monitor not found.", RestStatus.NOT_FOUND, cause)
                             )
-                            return
-                        }
-
-                        var monitor: Monitor? = null
-                        if (!response.isSourceEmpty) {
-                            XContentHelper.createParser(
-                                xContentRegistry,
-                                LoggingDeprecationHandler.INSTANCE,
-                                response.sourceAsBytesRef,
-                                XContentType.JSON
-                            ).use { xcp ->
-                                monitor = ScheduledJob.parse(xcp, response.id, response.version) as Monitor
-
-                                // security is enabled and filterby is enabled
-                                if (!checkUserPermissionsWithResource(
-                                        user,
-                                        monitor?.user,
-                                        actionListener,
-                                        "monitor",
-                                        transformedRequest.monitorId
-                                    )
-                                ) {
-                                    return
-                                }
-                            }
-                        }
-                        try {
-                            scope.launch {
-                                val associatedCompositeMonitors = getAssociatedWorkflows(response.id)
-                                actionListener.onResponse(
-                                    GetMonitorResponse(
-                                        response.id,
-                                        response.version,
-                                        response.seqNo,
-                                        response.primaryTerm,
-                                        monitor,
-                                        associatedCompositeMonitors
-                                    )
-                                )
-                            }
-                        } catch (e: Exception) {
-                            log.error("Failed to get associate workflows in get monitor action", e)
-                        }
+                        )
+                    } else {
+                        actionListener.onFailure(AlertingException.wrap(cause))
                     }
-
-                    override fun onFailure(ex: Exception) {
-                        if (isIndexNotFoundException(ex)) {
-                            log.error("Index not found while getting monitor", ex)
-                            actionListener.onFailure(
-                                AlertingException.wrap(
-                                    OpenSearchStatusException("Monitor not found. Backing index is missing.", RestStatus.NOT_FOUND, ex)
-                                )
-                            )
-                        } else {
-                            log.error("Unexpected error while getting monitor", ex)
-                            actionListener.onFailure(AlertingException.wrap(ex))
-                        }
-                    }
+                    return@whenComplete
                 }
-            )
+                try {
+                    val getResponse = response.getResponse()
+                    if (getResponse == null || !getResponse.isExists) {
+                        actionListener.onFailure(
+                            AlertingException.wrap(OpenSearchStatusException("Monitor not found.", RestStatus.NOT_FOUND))
+                        )
+                        return@whenComplete
+                    }
+                    var monitor: Monitor? = null
+                    if (!getResponse.isSourceEmpty) {
+                        XContentHelper.createParser(
+                            xContentRegistry, LoggingDeprecationHandler.INSTANCE,
+                            getResponse.sourceAsBytesRef, XContentType.JSON
+                        ).use { xcp ->
+                            monitor = ScheduledJob.parse(xcp, getResponse.id, getResponse.version) as Monitor
+                        }
+                    }
+                    if (!checkUserPermissionsWithResource(user, monitor?.user, actionListener, "monitor", transformedRequest.monitorId)) {
+                        return@whenComplete
+                    }
+                    scope.launch {
+                        val associatedCompositeMonitors = getAssociatedWorkflows(getResponse.id)
+                        actionListener.onResponse(
+                            GetMonitorResponse(
+                                getResponse.id, getResponse.version, getResponse.seqNo, getResponse.primaryTerm,
+                                monitor, associatedCompositeMonitors
+                            )
+                        )
+                    }
+                } catch (e: Exception) {
+                    log.error("Failed to parse monitor from SDK response", e)
+                    actionListener.onFailure(AlertingException.wrap(e))
+                }
+            }
         }
     }
 
     // Checks if the exception is caused by an IndexNotFoundException (directly or nested).
     private fun isIndexNotFoundException(e: Exception): Boolean {
-        if (e is IndexNotFoundException) {
-            return true
-        }
-        if (e is RemoteTransportException) {
-            val cause = e.cause
+        var cause: Throwable? = e
+        while (cause != null) {
             if (cause is IndexNotFoundException) {
                 return true
             }
+            cause = cause.cause
         }
         return false
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAlertsAction.kt
@@ -14,9 +14,9 @@ import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
+import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.alerts.AlertIndices
 import org.opensearch.alerting.opensearchapi.addFilter
-import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.util.use
 import org.opensearch.cluster.service.ClusterService
@@ -40,6 +40,8 @@ import org.opensearch.core.xcontent.XContentParser
 import org.opensearch.core.xcontent.XContentParserUtils
 import org.opensearch.index.query.Operator
 import org.opensearch.index.query.QueryBuilders
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.search.sort.SortBuilders
 import org.opensearch.search.sort.SortOrder
@@ -58,6 +60,7 @@ class TransportGetWorkflowAlertsAction @Inject constructor(
     actionFilters: ActionFilters,
     val settings: Settings,
     val xContentRegistry: NamedXContentRegistry,
+    val sdkClient: SdkClient,
 ) : HandledTransportAction<ActionRequest, GetWorkflowAlertsResponse>(
     AlertingActions.GET_WORKFLOW_ALERTS_ACTION_NAME,
     transportService,
@@ -205,17 +208,20 @@ class TransportGetWorkflowAlertsAction @Inject constructor(
         actionListener: ActionListener<GetWorkflowAlertsResponse>,
     ) {
         try {
-            val searchRequest = SearchRequest()
+            val searchRequest = SearchDataObjectRequest.builder()
                 .indices(alertIndex)
-                .source(searchSourceBuilder)
+                .tenantId(client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER))
+                .searchSourceBuilder(searchSourceBuilder)
+                .build()
             val alerts = mutableListOf<Alert>()
             val associatedAlerts = mutableListOf<Alert>()
 
-            val response: SearchResponse = client.suspendUntil { search(searchRequest, it) }
-            val totalAlertCount = response.hits.totalHits?.value?.toInt()
-            alerts.addAll(
-                parseAlertsFromSearchResponse(response)
-            )
+            val sdkResponse = sdkClient.searchDataObject(searchRequest)
+            val response = sdkResponse.searchResponse()
+            val totalAlertCount = response?.hits?.totalHits?.value?.toInt()
+            if (response != null) {
+                alerts.addAll(parseAlertsFromSearchResponse(response))
+            }
             if (alerts.isNotEmpty() && getWorkflowAlertsRequest.getAssociatedAlerts == true)
                 getAssociatedAlerts(
                     associatedAlerts,
@@ -254,8 +260,16 @@ class TransportGetWorkflowAlertsAction @Inject constructor(
             queryBuilder.must(QueryBuilders.termsQuery("_id", associatedAlertIds))
             queryBuilder.must(QueryBuilders.termQuery(Alert.STATE_FIELD, Alert.State.AUDIT.name))
             searchRequest.source().query(queryBuilder)
-            val response: SearchResponse = client.suspendUntil { search(searchRequest, it) }
-            associatedAlerts.addAll(parseAlertsFromSearchResponse(response))
+            val sdkSearchRequest = SearchDataObjectRequest.builder()
+                .indices(*searchRequest.indices())
+                .tenantId(client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER))
+                .searchSourceBuilder(searchRequest.source())
+                .build()
+            val sdkResponse = sdkClient.searchDataObject(sdkSearchRequest)
+            val response = sdkResponse.searchResponse()
+            if (response != null) {
+                associatedAlerts.addAll(parseAlertsFromSearchResponse(response))
+            }
         } catch (e: Exception) {
             log.error("Failed to get associated alerts in get workflow alerts action", e)
         }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexAlertingCommentAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexAlertingCommentAction.kt
@@ -11,28 +11,23 @@ import kotlinx.coroutines.launch
 import org.apache.logging.log4j.LogManager
 import org.opensearch.OpenSearchStatusException
 import org.opensearch.action.ActionRequest
-import org.opensearch.action.index.IndexRequest
-import org.opensearch.action.index.IndexResponse
-import org.opensearch.action.search.SearchRequest
-import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
-import org.opensearch.action.support.WriteRequest
+import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.alerts.AlertIndices
 import org.opensearch.alerting.comments.CommentsIndices
 import org.opensearch.alerting.comments.CommentsIndices.Companion.COMMENTS_HISTORY_WRITE_INDEX
-import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.settings.AlertingSettings.Companion.ALERTING_COMMENTS_ENABLED
 import org.opensearch.alerting.settings.AlertingSettings.Companion.COMMENTS_MAX_CONTENT_SIZE
 import org.opensearch.alerting.settings.AlertingSettings.Companion.INDEX_TIMEOUT
 import org.opensearch.alerting.settings.AlertingSettings.Companion.MAX_COMMENTS_PER_ALERT
 import org.opensearch.alerting.util.CommentsUtils
+import org.opensearch.alerting.util.await
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
-import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.alerting.action.AlertingActions
@@ -47,9 +42,13 @@ import org.opensearch.core.action.ActionListener
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry
 import org.opensearch.core.rest.RestStatus
 import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.core.xcontent.ToXContentObject
 import org.opensearch.core.xcontent.XContentParser
 import org.opensearch.core.xcontent.XContentParserUtils
 import org.opensearch.index.query.QueryBuilders
+import org.opensearch.remote.metadata.client.PutDataObjectRequest
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest
 import org.opensearch.rest.RestRequest
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.tasks.Task
@@ -72,6 +71,7 @@ constructor(
     val settings: Settings,
     val xContentRegistry: NamedXContentRegistry,
     val namedWriteableRegistry: NamedWriteableRegistry,
+    val sdkClient: SdkClient,
 ) : HandledTransportAction<ActionRequest, IndexCommentResponse>(
     AlertingActions.INDEX_COMMENT_ACTION_NAME,
     transportService,
@@ -189,30 +189,27 @@ constructor(
                 user = user
             )
 
-            val indexRequest =
-                IndexRequest(COMMENTS_HISTORY_WRITE_INDEX)
-                    .source(comment.toXContentWithUser(XContentFactory.jsonBuilder()))
-                    .setIfSeqNo(request.seqNo)
-                    .setIfPrimaryTerm(request.primaryTerm)
-                    .timeout(indexTimeout)
-                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+            val wrappedComment = ToXContentObject { builder, params ->
+                comment.toXContentWithUser(builder)
+            }
+            val putRequest = PutDataObjectRequest.builder()
+                .index(COMMENTS_HISTORY_WRITE_INDEX)
+                .tenantId(tenantId)
+                .dataObject(wrappedComment)
+                .build()
 
-            log.debug("Creating new comment: ${comment.toXContentWithUser(XContentFactory.jsonBuilder())}")
+            log.debug("Creating new comment")
 
             try {
-                val indexResponse: IndexResponse = client.suspendUntil { client.index(indexRequest, it) }
-                val failureReasons = checkShardsFailure(indexResponse)
-                if (failureReasons != null) {
-                    actionListener.onFailure(
-                        AlertingException.wrap(OpenSearchStatusException(failureReasons.toString(), indexResponse.status())),
-                    )
-                    return
-                }
-
+                val putResponse = sdkClient.putDataObjectAsync(putRequest).await()
+                val seqNo = putResponse.indexResponse()?.seqNo ?: 0L
+                val primaryTerm = putResponse.indexResponse()?.primaryTerm ?: 0L
                 actionListener.onResponse(
-                    IndexCommentResponse(indexResponse.id, indexResponse.seqNo, indexResponse.primaryTerm, comment)
+                    IndexCommentResponse(putResponse.id(), seqNo, primaryTerm, comment)
                 )
             } catch (t: Exception) {
+                log.error("Failed to create comment", t)
                 actionListener.onFailure(AlertingException.wrap(t))
             }
         }
@@ -238,40 +235,34 @@ constructor(
             // retains everything from the original comment except content and lastUpdatedTime
             val requestComment = currentComment.copy(content = request.content, lastUpdatedTime = Instant.now())
 
-            val indexRequest =
-                IndexRequest(COMMENTS_HISTORY_WRITE_INDEX)
-                    .source(requestComment.toXContentWithUser(XContentFactory.jsonBuilder()))
-                    .id(requestComment.id)
-                    .setIfSeqNo(request.seqNo)
-                    .setIfPrimaryTerm(request.primaryTerm)
-                    .timeout(indexTimeout)
-                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+            val wrappedComment = ToXContentObject { builder, params ->
+                requestComment.toXContentWithUser(builder)
+            }
+            val putRequest = PutDataObjectRequest.builder()
+                .index(COMMENTS_HISTORY_WRITE_INDEX)
+                .id(requestComment.id)
+                .tenantId(tenantId)
+                .ifSeqNo(request.seqNo)
+                .ifPrimaryTerm(request.primaryTerm)
+                .overwriteIfExists(true)
+                .dataObject(wrappedComment)
+                .build()
 
-            log.debug(
-                "Updating comment, ${currentComment.id}, from: " +
-                    "${currentComment.content} to: " +
-                    requestComment.content,
-            )
+            log.debug("Updating comment, ${currentComment.id}")
 
             try {
-                val indexResponse: IndexResponse = client.suspendUntil { client.index(indexRequest, it) }
-                val failureReasons = checkShardsFailure(indexResponse)
-                if (failureReasons != null) {
-                    actionListener.onFailure(
-                        AlertingException.wrap(OpenSearchStatusException(failureReasons.toString(), indexResponse.status())),
-                    )
-                    return
-                }
-
+                val putResponse = sdkClient.putDataObjectAsync(putRequest).await()
                 actionListener.onResponse(
                     IndexCommentResponse(
-                        indexResponse.id,
-                        indexResponse.seqNo,
-                        indexResponse.primaryTerm,
+                        putResponse.id(),
+                        putResponse.indexResponse()?.seqNo ?: 0L,
+                        putResponse.indexResponse()?.primaryTerm ?: 0L,
                         requestComment,
                     ),
                 )
             } catch (t: Exception) {
+                log.error("Failed to update comment ${currentComment.id}", t)
                 actionListener.onFailure(AlertingException.wrap(t))
             }
         }
@@ -288,14 +279,21 @@ constructor(
                     .seqNoAndPrimaryTerm(true)
                     .query(queryBuilder)
 
-            // search all alerts, since user might want to create a comment
-            // on a completed alert
-            val searchRequest =
-                SearchRequest()
-                    .indices(AlertIndices.ALL_ALERT_INDEX_PATTERN)
-                    .source(searchSourceBuilder)
-
-            val searchResponse: SearchResponse = client.suspendUntil { search(searchRequest, it) }
+            val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+            val sdkSearchRequest = SearchDataObjectRequest.builder()
+                .indices(AlertIndices.ALL_ALERT_INDEX_PATTERN)
+                .tenantId(tenantId)
+                .searchSourceBuilder(searchSourceBuilder)
+                .build()
+            val sdkResponse = sdkClient.searchDataObjectAsync(sdkSearchRequest).await()
+            val searchResponse = sdkResponse.searchResponse()
+            if (searchResponse == null) {
+                log.error("Failed to search for alert ${request.entityId}")
+                actionListener.onFailure(
+                    AlertingException.wrap(OpenSearchStatusException("Alert not found", RestStatus.NOT_FOUND))
+                )
+                return null
+            }
             val alerts = searchResponse.hits.map { hit ->
                 val xcp = XContentHelper.createParser(
                     NamedXContentRegistry.EMPTY,
@@ -337,14 +335,21 @@ constructor(
                     .seqNoAndPrimaryTerm(true)
                     .query(queryBuilder)
 
-            // search all alerts, since user might want to create a comment
-            // on a completed alert
-            val searchRequest =
-                SearchRequest()
-                    .indices(CommentsIndices.ALL_COMMENTS_INDEX_PATTERN)
-                    .source(searchSourceBuilder)
-
-            val searchResponse: SearchResponse = client.suspendUntil { search(searchRequest, it) }
+            val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+            val sdkSearchRequest = SearchDataObjectRequest.builder()
+                .indices(CommentsIndices.ALL_COMMENTS_INDEX_PATTERN)
+                .tenantId(tenantId)
+                .searchSourceBuilder(searchSourceBuilder)
+                .build()
+            val sdkResponse = sdkClient.searchDataObjectAsync(sdkSearchRequest).await()
+            val searchResponse = sdkResponse.searchResponse()
+            if (searchResponse == null) {
+                log.error("Failed to search for comment ${request.commentId}")
+                actionListener.onFailure(
+                    AlertingException.wrap(OpenSearchStatusException("Comment not found", RestStatus.NOT_FOUND))
+                )
+                return null
+            }
             val comments = searchResponse.hits.map { hit ->
                 val xcp = XContentHelper.createParser(
                     NamedXContentRegistry.EMPTY,
@@ -372,17 +377,6 @@ constructor(
             }
 
             return comments[0]
-        }
-
-        private fun checkShardsFailure(response: IndexResponse): String? {
-            val failureReasons = StringBuilder()
-            if (response.shardInfo.failed > 0) {
-                response.shardInfo.failures.forEach { entry ->
-                    failureReasons.append(entry.reason())
-                }
-                return failureReasons.toString()
-            }
-            return null
         }
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -19,9 +19,6 @@ import org.opensearch.action.admin.cluster.health.ClusterHealthAction
 import org.opensearch.action.admin.cluster.health.ClusterHealthRequest
 import org.opensearch.action.admin.cluster.health.ClusterHealthResponse
 import org.opensearch.action.admin.indices.create.CreateIndexResponse
-import org.opensearch.action.get.GetRequest
-import org.opensearch.action.get.GetResponse
-import org.opensearch.action.index.IndexRequest
 import org.opensearch.action.index.IndexResponse
 import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.search.SearchResponse
@@ -29,6 +26,7 @@ import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.action.support.WriteRequest.RefreshPolicy
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse
+import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.MonitorMetadataService
 import org.opensearch.alerting.core.ScheduledJobIndices
 import org.opensearch.alerting.opensearchapi.suspendUntil
@@ -43,6 +41,7 @@ import org.opensearch.alerting.settings.DestinationSettings.Companion.ALLOW_LIST
 import org.opensearch.alerting.util.DocLevelMonitorQueries
 import org.opensearch.alerting.util.IndexUtils
 import org.opensearch.alerting.util.addUserBackendRolesFilter
+import org.opensearch.alerting.util.await
 import org.opensearch.alerting.util.getRoleFilterEnabled
 import org.opensearch.alerting.util.isADMonitor
 import org.opensearch.alerting.util.use
@@ -51,7 +50,6 @@ import org.opensearch.common.inject.Inject
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
-import org.opensearch.common.xcontent.XContentFactory.jsonBuilder
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.alerting.action.AlertingActions
@@ -75,10 +73,14 @@ import org.opensearch.core.common.io.stream.NamedWriteableRegistry
 import org.opensearch.core.rest.RestStatus
 import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.core.xcontent.ToXContentObject
 import org.opensearch.index.query.QueryBuilders
 import org.opensearch.index.reindex.BulkByScrollResponse
 import org.opensearch.index.reindex.DeleteByQueryAction
 import org.opensearch.index.reindex.DeleteByQueryRequestBuilder
+import org.opensearch.remote.metadata.client.GetDataObjectRequest
+import org.opensearch.remote.metadata.client.PutDataObjectRequest
+import org.opensearch.remote.metadata.client.SdkClient
 import org.opensearch.rest.RestRequest
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.tasks.Task
@@ -101,6 +103,7 @@ class TransportIndexMonitorAction @Inject constructor(
     val settings: Settings,
     val xContentRegistry: NamedXContentRegistry,
     val namedWriteableRegistry: NamedWriteableRegistry,
+    val sdkClient: SdkClient,
 ) : HandledTransportAction<ActionRequest, IndexMonitorResponse>(
     AlertingActions.INDEX_MONITOR_ACTION_NAME, transportService, actionFilters, ::IndexMonitorRequest
 ),
@@ -506,30 +509,33 @@ class TransportIndexMonitorAction @Inject constructor(
                 log.debug("Created monitor's backend roles: $rbacRoles")
             }
 
-            val indexRequest = IndexRequest(SCHEDULED_JOBS_INDEX)
-                .setRefreshPolicy(request.refreshPolicy)
-                .source(request.monitor.toXContentWithUser(jsonBuilder(), ToXContent.MapParams(mapOf("with_type" to "true"))))
-                .setIfSeqNo(request.seqNo)
-                .setIfPrimaryTerm(request.primaryTerm)
-                .timeout(indexTimeout)
+            log.info("Creating new monitor: ${request.monitor.name}, type: ${request.monitor.monitorType}")
 
-            log.info(
-                "Creating new monitor: ${request.monitor.toXContentWithUser(
-                    jsonBuilder(),
-                    ToXContent.MapParams(mapOf("with_type" to "true"))
-                )}"
-            )
+            val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+            val monitorObj = ToXContentObject { builder, params ->
+                request.monitor.toXContentWithUser(builder, ToXContent.MapParams(mapOf("with_type" to "true")))
+            }
+            val putRequest = PutDataObjectRequest.builder()
+                .index(SCHEDULED_JOBS_INDEX)
+                .tenantId(tenantId)
+                .dataObject(monitorObj)
+                .build()
 
             try {
-                val indexResponse: IndexResponse = client.suspendUntil { client.index(indexRequest, it) }
-                val failureReasons = checkShardsFailure(indexResponse)
-                if (failureReasons != null) {
-                    log.info(failureReasons.toString())
+                val putResponse = sdkClient.putDataObjectAsync(putRequest).await()
+                if (putResponse.isFailed) {
                     actionListener.onFailure(
-                        AlertingException.wrap(OpenSearchStatusException(failureReasons.toString(), indexResponse.status()))
+                        AlertingException.wrap(
+                            OpenSearchStatusException(
+                                "Failed to create monitor: ${putResponse.cause()?.message}",
+                                putResponse.status() ?: RestStatus.INTERNAL_SERVER_ERROR
+                            )
+                        )
                     )
                     return
                 }
+                val indexResponse = putResponse.indexResponse()
+                    ?: throw OpenSearchStatusException("No index response from SDK", RestStatus.INTERNAL_SERVER_ERROR)
                 var metadata: MonitorMetadata?
                 try { // delete monitor if metadata creation fails, log the right error and re-throw the error to fail listener
                     request.monitor = request.monitor.copy(id = indexResponse.id)
@@ -609,10 +615,16 @@ class TransportIndexMonitorAction @Inject constructor(
         }
 
         private suspend fun updateMonitor() {
-            val getRequest = GetRequest(SCHEDULED_JOBS_INDEX, request.monitorId)
+            val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+            val getRequest = GetDataObjectRequest.builder()
+                .index(SCHEDULED_JOBS_INDEX)
+                .id(request.monitorId)
+                .tenantId(tenantId)
+                .build()
             try {
-                val getResponse: GetResponse = client.suspendUntil { client.get(getRequest, it) }
-                if (!getResponse.isExists) {
+                val response = sdkClient.getDataObjectAsync(getRequest).await()
+                val getResponse = response.getResponse()
+                if (getResponse == null || !getResponse.isExists) {
                     actionListener.onFailure(
                         AlertingException.wrap(
                             OpenSearchStatusException("Monitor with ${request.monitorId} is not found", RestStatus.NOT_FOUND)
@@ -678,30 +690,38 @@ class TransportIndexMonitorAction @Inject constructor(
             }
 
             request.monitor = request.monitor.copy(schemaVersion = IndexUtils.scheduledJobIndexSchemaVersion)
-            val indexRequest = IndexRequest(SCHEDULED_JOBS_INDEX)
-                .setRefreshPolicy(request.refreshPolicy)
-                .source(request.monitor.toXContentWithUser(jsonBuilder(), ToXContent.MapParams(mapOf("with_type" to "true"))))
-                .id(request.monitorId)
-                .setIfSeqNo(request.seqNo)
-                .setIfPrimaryTerm(request.primaryTerm)
-                .timeout(indexTimeout)
 
-            log.info(
-                "Updating monitor, ${currentMonitor.id}, from: ${currentMonitor.toXContentWithUser(
-                    jsonBuilder(),
-                    ToXContent.MapParams(mapOf("with_type" to "true"))
-                )} \n to: ${request.monitor.toXContentWithUser(jsonBuilder(), ToXContent.MapParams(mapOf("with_type" to "true")))}"
-            )
+            log.info("Updating monitor, ${currentMonitor.id}")
+
+            val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+            val monitorObj = ToXContentObject { builder, params ->
+                request.monitor.toXContentWithUser(builder, ToXContent.MapParams(mapOf("with_type" to "true")))
+            }
+            val putRequest = PutDataObjectRequest.builder()
+                .index(SCHEDULED_JOBS_INDEX)
+                .id(request.monitorId)
+                .tenantId(tenantId)
+                .ifSeqNo(request.seqNo)
+                .ifPrimaryTerm(request.primaryTerm)
+                .overwriteIfExists(true)
+                .dataObject(monitorObj)
+                .build()
 
             try {
-                val indexResponse: IndexResponse = client.suspendUntil { client.index(indexRequest, it) }
-                val failureReasons = checkShardsFailure(indexResponse)
-                if (failureReasons != null) {
+                val putResponse = sdkClient.putDataObjectAsync(putRequest).await()
+                if (putResponse.isFailed) {
                     actionListener.onFailure(
-                        AlertingException.wrap(OpenSearchStatusException(failureReasons.toString(), indexResponse.status()))
+                        AlertingException.wrap(
+                            OpenSearchStatusException(
+                                "Failed to update monitor: ${putResponse.cause()?.message}",
+                                putResponse.status() ?: RestStatus.INTERNAL_SERVER_ERROR
+                            )
+                        )
                     )
                     return
                 }
+                val indexResponse = putResponse.indexResponse()
+                    ?: throw OpenSearchStatusException("No index response from SDK", RestStatus.INTERNAL_SERVER_ERROR)
                 var isDocLevelMonitorRestarted = false
                 // Force re-creation of last run context if monitor is of type standard doc-level/threat-intel
                 // And monitor is re-enabled

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchAlertingCommentAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchAlertingCommentAction.kt
@@ -15,6 +15,7 @@ import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
+import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.alerts.AlertIndices.Companion.ALL_ALERT_INDEX_PATTERN
 import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.settings.AlertingSettings
@@ -40,12 +41,14 @@ import org.opensearch.core.xcontent.XContentParser
 import org.opensearch.core.xcontent.XContentParserUtils
 import org.opensearch.index.query.BoolQueryBuilder
 import org.opensearch.index.query.QueryBuilders
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest
+import org.opensearch.remote.metadata.common.SdkClientUtils
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService
 import org.opensearch.transport.client.Client
 import java.io.IOException
-
 private val log = LogManager.getLogger(TransportSearchAlertingCommentAction::class.java)
 private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 
@@ -55,7 +58,8 @@ class TransportSearchAlertingCommentAction @Inject constructor(
     val client: Client,
     clusterService: ClusterService,
     actionFilters: ActionFilters,
-    val namedWriteableRegistry: NamedWriteableRegistry
+    val namedWriteableRegistry: NamedWriteableRegistry,
+    val sdkClient: SdkClient
 ) : HandledTransportAction<ActionRequest, SearchResponse>(
     AlertingActions.SEARCH_COMMENTS_ACTION_NAME, transportService, actionFilters, ::SearchRequest
 ),
@@ -135,18 +139,29 @@ class TransportSearchAlertingCommentAction @Inject constructor(
     }
 
     fun search(searchRequest: SearchRequest, actionListener: ActionListener<SearchResponse>) {
-        client.search(
-            searchRequest,
-            object : ActionListener<SearchResponse> {
-                override fun onResponse(response: SearchResponse) {
-                    actionListener.onResponse(response)
-                }
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+        val sdkSearchRequest = SearchDataObjectRequest.builder()
+            .indices(*searchRequest.indices())
+            .tenantId(tenantId)
+            .searchSourceBuilder(searchRequest.source())
+            .build()
 
-                override fun onFailure(t: Exception) {
-                    actionListener.onFailure(AlertingException.wrap(t))
-                }
+        sdkClient.searchDataObjectAsync(sdkSearchRequest).whenComplete { response, throwable ->
+            if (throwable != null) {
+                actionListener.onFailure(AlertingException.wrap(SdkClientUtils.unwrapAndConvertToException(throwable)))
+                return@whenComplete
             }
-        )
+            val searchResponse = response.searchResponse()
+            if (searchResponse != null) {
+                actionListener.onResponse(searchResponse)
+            } else {
+                actionListener.onFailure(
+                    AlertingException.wrap(
+                        OpenSearchStatusException("Failed to search comments", RestStatus.INTERNAL_SERVER_ERROR)
+                    )
+                )
+            }
+        }
     }
 
     // retrieve the IDs of all Alerts after filtering by current User's

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
@@ -15,6 +15,7 @@ import org.opensearch.action.search.SearchResponse.Clusters
 import org.opensearch.action.search.ShardSearchFailure
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
+import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.opensearchapi.addFilter
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.util.use
@@ -36,17 +37,18 @@ import org.opensearch.index.query.BoolQueryBuilder
 import org.opensearch.index.query.ExistsQueryBuilder
 import org.opensearch.index.query.MatchQueryBuilder
 import org.opensearch.index.query.QueryBuilders
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest
+import org.opensearch.remote.metadata.common.SdkClientUtils
 import org.opensearch.search.SearchHits
 import org.opensearch.search.aggregations.InternalAggregations
 import org.opensearch.search.internal.InternalSearchResponse
 import org.opensearch.search.profile.SearchProfileShardResults
 import org.opensearch.search.suggest.Suggest
 import org.opensearch.tasks.Task
-import org.opensearch.transport.RemoteTransportException
 import org.opensearch.transport.TransportService
 import org.opensearch.transport.client.Client
 import java.util.Collections
-
 private val log = LogManager.getLogger(TransportSearchMonitorAction::class.java)
 
 class TransportSearchMonitorAction @Inject constructor(
@@ -55,7 +57,8 @@ class TransportSearchMonitorAction @Inject constructor(
     val client: Client,
     clusterService: ClusterService,
     actionFilters: ActionFilters,
-    val namedWriteableRegistry: NamedWriteableRegistry
+    val namedWriteableRegistry: NamedWriteableRegistry,
+    val sdkClient: SdkClient
 ) : HandledTransportAction<ActionRequest, SearchResponse>(
     AlertingActions.SEARCH_MONITORS_ACTION_NAME, transportService, actionFilters, ::SearchMonitorRequest
 ),
@@ -137,34 +140,40 @@ class TransportSearchMonitorAction @Inject constructor(
 
     // Checks if the exception is caused by an IndexNotFoundException (directly or nested).
     private fun isIndexNotFoundException(e: Exception): Boolean {
-        if (e is IndexNotFoundException) return true
-        if (e is RemoteTransportException) {
-            val cause = e.cause
+        var cause: Throwable? = e
+        while (cause != null) {
             if (cause is IndexNotFoundException) return true
+            cause = cause.cause
         }
         return false
     }
 
     fun search(searchRequest: SearchRequest, actionListener: ActionListener<SearchResponse>) {
-        client.search(
-            searchRequest,
-            object : ActionListener<SearchResponse> {
-                override fun onResponse(response: SearchResponse) {
-                    actionListener.onResponse(response)
-                }
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+        val sdkSearchRequest = SearchDataObjectRequest.builder()
+            .indices(*searchRequest.indices())
+            .tenantId(tenantId)
+            .searchSourceBuilder(searchRequest.source())
+            .build()
 
-                override fun onFailure(ex: Exception) {
-                    if (isIndexNotFoundException(ex)) {
-                        log.error("Index not found while searching monitor", ex)
-                        val emptyResponse = getEmptySearchResponse()
-                        actionListener.onResponse(emptyResponse)
-                    } else {
-                        log.error("Unexpected error while searching monitor", ex)
-                        actionListener.onFailure(AlertingException.wrap(ex))
-                    }
+        sdkClient.searchDataObjectAsync(sdkSearchRequest).whenComplete { response, throwable ->
+            if (throwable != null) {
+                val cause = SdkClientUtils.unwrapAndConvertToException(throwable)
+                if (isIndexNotFoundException(cause)) {
+                    actionListener.onResponse(getEmptySearchResponse())
+                } else {
+                    log.error("Unexpected error while searching monitor", cause)
+                    actionListener.onFailure(AlertingException.wrap(cause))
                 }
+                return@whenComplete
             }
-        )
+            val searchResponse = response.searchResponse()
+            if (searchResponse != null) {
+                actionListener.onResponse(searchResponse)
+            } else {
+                actionListener.onResponse(getEmptySearchResponse())
+            }
+        }
     }
 
     private fun addOwnerFieldIfNotExists(searchRequest: SearchRequest) {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/SdkUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/SdkUtils.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.util
+
+import java.util.concurrent.CompletionStage
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * Converts a [CompletionStage] to a suspend function, allowing it to be used
+ * inside coroutines without blocking the thread.
+ */
+suspend fun <T> CompletionStage<T>.await(): T = suspendCoroutine { cont ->
+    this.whenComplete { result, error ->
+        if (error != null) cont.resumeWithException(error)
+        else cont.resume(result)
+    }
+}

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertServiceTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertServiceTests.kt
@@ -22,13 +22,13 @@ import org.opensearch.commons.alerting.model.BucketLevelTrigger
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.action.AlertCategory
 import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.remote.metadata.client.SdkClient
 import org.opensearch.test.ClusterServiceUtils
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.threadpool.ThreadPool
 import org.opensearch.transport.client.Client
 import java.time.Instant
 import java.time.temporal.ChronoUnit
-
 class AlertServiceTests : OpenSearchTestCase() {
 
     private lateinit var client: Client
@@ -67,7 +67,7 @@ class AlertServiceTests : OpenSearchTestCase() {
         clusterService = Mockito.spy(testClusterService)
 
         alertIndices = AlertIndices(settings, client, threadPool, clusterService)
-        alertService = AlertService(client, xContentRegistry, alertIndices)
+        alertService = AlertService(client, xContentRegistry, alertIndices, Mockito.mock(SdkClient::class.java))
     }
 
     fun `test getting categorized alerts for bucket-level monitor with no current alerts`() {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/settings/AlertingSettingsTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/settings/AlertingSettingsTests.kt
@@ -98,7 +98,12 @@ class AlertingSettingsTests : OpenSearchTestCase() {
                     ScheduledJobSettings.SWEEP_BACKOFF_RETRY_COUNT,
                     ScheduledJobSettings.SWEEP_BACKOFF_MILLIS,
                     ScheduledJobSettings.SWEEPER_ENABLED,
-                    ScheduledJobSettings.REQUEST_TIMEOUT
+                    ScheduledJobSettings.REQUEST_TIMEOUT,
+                    AlertingSettings.MULTI_TENANCY_ENABLED,
+                    AlertingSettings.REMOTE_METADATA_STORE_TYPE,
+                    AlertingSettings.REMOTE_METADATA_ENDPOINT,
+                    AlertingSettings.REMOTE_METADATA_REGION,
+                    AlertingSettings.REMOTE_METADATA_SERVICE_NAME
                 )
             )
         )
@@ -198,5 +203,20 @@ class AlertingSettingsTests : OpenSearchTestCase() {
                 LegacyOpenDistroScheduledJobSettings.SWEEP_PERIOD
             )
         )
+    }
+
+    fun `test remote metadata settings defaults`() {
+        assertEquals(false, AlertingSettings.MULTI_TENANCY_ENABLED.getDefault(Settings.EMPTY))
+        assertEquals("", AlertingSettings.REMOTE_METADATA_STORE_TYPE.getDefault(Settings.EMPTY))
+        assertEquals("", AlertingSettings.REMOTE_METADATA_ENDPOINT.getDefault(Settings.EMPTY))
+        assertEquals("", AlertingSettings.REMOTE_METADATA_REGION.getDefault(Settings.EMPTY))
+        assertEquals("", AlertingSettings.REMOTE_METADATA_SERVICE_NAME.getDefault(Settings.EMPTY))
+    }
+
+    fun `test multi_tenancy_enabled setting reads from config`() {
+        val settings = Settings.builder()
+            .put("plugins.alerting.multi_tenancy_enabled", true)
+            .build()
+        assertEquals(true, AlertingSettings.MULTI_TENANCY_ENABLED.get(settings))
     }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorActionTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorActionTests.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.transport
+
+import com.carrotsearch.randomizedtesting.ThreadFilter
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters
+import org.junit.Before
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito
+import org.mockito.Mockito.timeout
+import org.mockito.Mockito.verify
+import org.opensearch.action.support.ActionFilters
+import org.opensearch.alerting.settings.AlertingSettings
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.ClusterSettings
+import org.opensearch.common.settings.Setting
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.util.concurrent.ThreadContext
+import org.opensearch.commons.alerting.action.DeleteMonitorRequest
+import org.opensearch.commons.alerting.action.DeleteMonitorResponse
+import org.opensearch.core.action.ActionListener
+import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.remote.metadata.client.GetDataObjectRequest
+import org.opensearch.remote.metadata.client.GetDataObjectResponse
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.threadpool.ThreadPool
+import org.opensearch.transport.TransportService
+import org.opensearch.transport.client.Client
+import org.mockito.Mockito.`when` as whenever
+
+@ThreadLeakFilters(filters = [TransportDeleteMonitorActionTests.CoroutineThreadFilter::class])
+class TransportDeleteMonitorActionTests : OpenSearchTestCase() {
+
+    class CoroutineThreadFilter : ThreadFilter {
+        override fun reject(t: Thread): Boolean = t.name.startsWith("DefaultDispatcher-worker")
+    }
+
+    private lateinit var client: Client
+    private lateinit var sdkClient: SdkClient
+    private lateinit var clusterService: ClusterService
+    private lateinit var threadPool: ThreadPool
+    private lateinit var threadContext: ThreadContext
+
+    @Before
+    fun setup() {
+        client = Mockito.mock(Client::class.java)
+        sdkClient = Mockito.mock(SdkClient::class.java)
+        clusterService = Mockito.mock(ClusterService::class.java)
+        threadPool = Mockito.mock(ThreadPool::class.java)
+        threadContext = ThreadContext(Settings.EMPTY)
+
+        whenever(client.threadPool()).thenReturn(threadPool)
+        whenever(threadPool.threadContext).thenReturn(threadContext)
+
+        val settingSet = hashSetOf<Setting<*>>()
+        settingSet.addAll(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        settingSet.add(AlertingSettings.FILTER_BY_BACKEND_ROLES)
+        val clusterSettings = ClusterSettings(Settings.EMPTY, settingSet)
+        whenever(clusterService.clusterSettings).thenReturn(clusterSettings)
+    }
+
+    fun `test SDK getDataObject is called`() {
+        val response = GetDataObjectResponse.builder()
+            .id("test-monitor-id")
+            .index(".opendistro-alerting-config")
+            .source(null)
+            .build()
+        whenever(sdkClient.getDataObject(any(GetDataObjectRequest::class.java))).thenReturn(response)
+
+        val action = createAction()
+        val request = DeleteMonitorRequest("test-monitor-id", org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE)
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<DeleteMonitorResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        verify(sdkClient, timeout(1000)).getDataObject(any(GetDataObjectRequest::class.java))
+    }
+
+    fun `test getMonitor not found calls onFailure`() {
+        val response = GetDataObjectResponse.builder()
+            .id("test-monitor-id")
+            .index(".opendistro-alerting-config")
+            .source(null)
+            .build()
+        whenever(sdkClient.getDataObject(any(GetDataObjectRequest::class.java))).thenReturn(response)
+
+        val action = createAction()
+        val request = DeleteMonitorRequest("test-monitor-id", org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE)
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<DeleteMonitorResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        verify(listener, timeout(1000)).onFailure(any())
+    }
+
+    fun `test SDK exception propagated to listener`() {
+        whenever(sdkClient.getDataObject(any(GetDataObjectRequest::class.java)))
+            .thenThrow(RuntimeException("SDK connection failed"))
+
+        val action = createAction()
+        val request = DeleteMonitorRequest("test-monitor-id", org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE)
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<DeleteMonitorResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        verify(listener, timeout(1000)).onFailure(any())
+    }
+
+    private fun invokeDoExecute(
+        action: TransportDeleteMonitorAction,
+        request: DeleteMonitorRequest,
+        listener: ActionListener<DeleteMonitorResponse>
+    ) {
+        val method = action.javaClass.getDeclaredMethod(
+            "doExecute",
+            org.opensearch.tasks.Task::class.java,
+            org.opensearch.action.ActionRequest::class.java,
+            ActionListener::class.java
+        )
+        method.isAccessible = true
+        method.invoke(action, Mockito.mock(org.opensearch.tasks.Task::class.java), request, listener)
+    }
+
+    private fun createAction(): TransportDeleteMonitorAction {
+        return TransportDeleteMonitorAction(
+            Mockito.mock(TransportService::class.java),
+            client,
+            Mockito.mock(ActionFilters::class.java),
+            clusterService,
+            Settings.EMPTY,
+            Mockito.mock(NamedXContentRegistry::class.java),
+            sdkClient
+        )
+    }
+}

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportGetDestinationsActionTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportGetDestinationsActionTests.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.transport
+
+import org.junit.Before
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito
+import org.mockito.Mockito.verify
+import org.opensearch.action.support.ActionFilters
+import org.opensearch.alerting.AlertingPlugin.Companion.TENANT_ID_HEADER
+import org.opensearch.alerting.action.GetDestinationsResponse
+import org.opensearch.alerting.settings.AlertingSettings
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.ClusterSettings
+import org.opensearch.common.settings.Setting
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.util.concurrent.ThreadContext
+import org.opensearch.core.action.ActionListener
+import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest
+import org.opensearch.remote.metadata.client.SearchDataObjectResponse
+import org.opensearch.search.builder.SearchSourceBuilder
+import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.threadpool.ThreadPool
+import org.opensearch.transport.TransportService
+import org.opensearch.transport.client.Client
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import org.mockito.Mockito.`when` as whenever
+class TransportGetDestinationsActionTests : OpenSearchTestCase() {
+
+    private lateinit var client: Client
+    private lateinit var sdkClient: SdkClient
+    private lateinit var clusterService: ClusterService
+    private lateinit var threadPool: ThreadPool
+    private lateinit var threadContext: ThreadContext
+
+    @Before
+    fun setup() {
+        client = Mockito.mock(Client::class.java)
+        sdkClient = Mockito.mock(SdkClient::class.java)
+        clusterService = Mockito.mock(ClusterService::class.java)
+        threadPool = Mockito.mock(ThreadPool::class.java)
+        threadContext = ThreadContext(Settings.EMPTY)
+
+        whenever(client.threadPool()).thenReturn(threadPool)
+        whenever(threadPool.threadContext).thenReturn(threadContext)
+
+        val settingSet = hashSetOf<Setting<*>>()
+        settingSet.addAll(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        settingSet.add(AlertingSettings.FILTER_BY_BACKEND_ROLES)
+        val clusterSettings = ClusterSettings(Settings.EMPTY, settingSet)
+        whenever(clusterService.clusterSettings).thenReturn(clusterSettings)
+    }
+
+    fun `test search passes tenantId to SDK`() {
+        val expectedTenantId = "test-tenant:test-scope"
+        threadContext.putHeader(TENANT_ID_HEADER, expectedTenantId)
+
+        val future: CompletionStage<SearchDataObjectResponse> =
+            CompletableFuture.completedFuture(SearchDataObjectResponse(null as org.opensearch.action.search.SearchResponse?))
+        whenever(sdkClient.searchDataObjectAsync(any(SearchDataObjectRequest::class.java))).thenReturn(future)
+
+        val action = TransportGetDestinationsAction(
+            Mockito.mock(TransportService::class.java),
+            client,
+            clusterService,
+            Mockito.mock(ActionFilters::class.java),
+            Settings.EMPTY,
+            Mockito.mock(NamedXContentRegistry::class.java),
+            sdkClient
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<GetDestinationsResponse>
+        action.search(SearchSourceBuilder(), listener)
+
+        val captor = ArgumentCaptor.forClass(SearchDataObjectRequest::class.java)
+        verify(sdkClient).searchDataObjectAsync(captor.capture())
+        assertEquals(expectedTenantId, captor.value.tenantId())
+    }
+
+    fun `test search SDK exception propagated to listener`() {
+        threadContext.putHeader(TENANT_ID_HEADER, "test-tenant:test-scope")
+
+        val future: CompletionStage<SearchDataObjectResponse> = CompletableFuture<SearchDataObjectResponse>().also {
+            it.completeExceptionally(RuntimeException("SDK search failed"))
+        }
+        whenever(sdkClient.searchDataObjectAsync(any(SearchDataObjectRequest::class.java))).thenReturn(future)
+
+        val action = TransportGetDestinationsAction(
+            Mockito.mock(TransportService::class.java),
+            client,
+            clusterService,
+            Mockito.mock(ActionFilters::class.java),
+            Settings.EMPTY,
+            Mockito.mock(NamedXContentRegistry::class.java),
+            sdkClient
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<GetDestinationsResponse>
+        action.search(SearchSourceBuilder(), listener)
+
+        verify(listener).onFailure(any())
+    }
+
+    fun `test search null response returns empty destinations`() {
+        threadContext.putHeader(TENANT_ID_HEADER, "test-tenant:test-scope")
+
+        val future: CompletionStage<SearchDataObjectResponse> =
+            CompletableFuture.completedFuture(SearchDataObjectResponse(null as org.opensearch.action.search.SearchResponse?))
+        whenever(sdkClient.searchDataObjectAsync(any(SearchDataObjectRequest::class.java))).thenReturn(future)
+
+        val action = TransportGetDestinationsAction(
+            Mockito.mock(TransportService::class.java),
+            client,
+            clusterService,
+            Mockito.mock(ActionFilters::class.java),
+            Settings.EMPTY,
+            Mockito.mock(NamedXContentRegistry::class.java),
+            sdkClient
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<GetDestinationsResponse>
+        action.search(SearchSourceBuilder(), listener)
+
+        val captor = ArgumentCaptor.forClass(GetDestinationsResponse::class.java)
+        verify(listener).onResponse(captor.capture())
+        assertEquals(0, captor.value.totalDestinations)
+    }
+}

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportGetMonitorActionTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportGetMonitorActionTests.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.transport
+
+import org.junit.Before
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito
+import org.mockito.Mockito.verify
+import org.opensearch.action.support.ActionFilters
+import org.opensearch.alerting.AlertingPlugin.Companion.TENANT_ID_HEADER
+import org.opensearch.alerting.settings.AlertingSettings
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.ClusterSettings
+import org.opensearch.common.settings.Setting
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.util.concurrent.ThreadContext
+import org.opensearch.commons.alerting.action.GetMonitorRequest
+import org.opensearch.commons.alerting.action.GetMonitorResponse
+import org.opensearch.core.action.ActionListener
+import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.remote.metadata.client.GetDataObjectRequest
+import org.opensearch.remote.metadata.client.GetDataObjectResponse
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.rest.RestRequest
+import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.threadpool.ThreadPool
+import org.opensearch.transport.TransportService
+import org.opensearch.transport.client.Client
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import org.mockito.Mockito.`when` as whenever
+
+class TransportGetMonitorActionTests : OpenSearchTestCase() {
+
+    private lateinit var client: Client
+    private lateinit var sdkClient: SdkClient
+    private lateinit var transportService: TransportService
+    private lateinit var actionFilters: ActionFilters
+    private lateinit var xContentRegistry: NamedXContentRegistry
+    private lateinit var clusterService: ClusterService
+    private lateinit var threadPool: ThreadPool
+    private lateinit var threadContext: ThreadContext
+
+    @Before
+    fun setup() {
+        client = Mockito.mock(Client::class.java)
+        sdkClient = Mockito.mock(SdkClient::class.java)
+        transportService = Mockito.mock(TransportService::class.java)
+        actionFilters = Mockito.mock(ActionFilters::class.java)
+        xContentRegistry = Mockito.mock(NamedXContentRegistry::class.java)
+        clusterService = Mockito.mock(ClusterService::class.java)
+        threadPool = Mockito.mock(ThreadPool::class.java)
+        threadContext = ThreadContext(Settings.EMPTY)
+
+        whenever(client.threadPool()).thenReturn(threadPool)
+        whenever(threadPool.threadContext).thenReturn(threadContext)
+
+        val settingSet = hashSetOf<Setting<*>>()
+        settingSet.addAll(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        settingSet.add(AlertingSettings.FILTER_BY_BACKEND_ROLES)
+        val clusterSettings = ClusterSettings(Settings.EMPTY, settingSet)
+        whenever(clusterService.clusterSettings).thenReturn(clusterSettings)
+    }
+
+    fun `test SDK called with correct tenantId and monitorId`() {
+        val expectedTenantId = "test-tenant:test-scope"
+        threadContext.putHeader(TENANT_ID_HEADER, expectedTenantId)
+
+        val future: CompletionStage<GetDataObjectResponse> = CompletableFuture.completedFuture(
+            GetDataObjectResponse.builder()
+                .id("test-monitor-id")
+                .index(".opendistro-alerting-config")
+                .source(emptyMap())
+                .build()
+        )
+        whenever(sdkClient.getDataObjectAsync(any(GetDataObjectRequest::class.java))).thenReturn(future)
+
+        val action = createAction(Settings.builder().build())
+        val request = GetMonitorRequest("test-monitor-id", 0L, RestRequest.Method.GET, null)
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<GetMonitorResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        val requestCaptor = ArgumentCaptor.forClass(GetDataObjectRequest::class.java)
+        verify(sdkClient).getDataObjectAsync(requestCaptor.capture())
+        assertEquals(expectedTenantId, requestCaptor.value.tenantId())
+        assertEquals("test-monitor-id", requestCaptor.value.id())
+    }
+
+    fun `test SDK called with null tenantId when header absent`() {
+        val future: CompletionStage<GetDataObjectResponse> = CompletableFuture.completedFuture(
+            GetDataObjectResponse.builder()
+                .id("test-monitor-id")
+                .index(".opendistro-alerting-config")
+                .source(emptyMap())
+                .build()
+        )
+        whenever(sdkClient.getDataObjectAsync(any(GetDataObjectRequest::class.java))).thenReturn(future)
+
+        val action = createAction(Settings.builder().build())
+        val request = GetMonitorRequest("test-monitor-id", 0L, RestRequest.Method.GET, null)
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<GetMonitorResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        val requestCaptor = ArgumentCaptor.forClass(GetDataObjectRequest::class.java)
+        verify(sdkClient).getDataObjectAsync(requestCaptor.capture())
+        assertNull(requestCaptor.value.tenantId())
+    }
+
+    fun `test SDK exception propagated to listener`() {
+        threadContext.putHeader(TENANT_ID_HEADER, "test-tenant:test-scope")
+
+        val future: CompletionStage<GetDataObjectResponse> = CompletableFuture<GetDataObjectResponse>().also {
+            it.completeExceptionally(RuntimeException("SDK connection failed"))
+        }
+        whenever(sdkClient.getDataObjectAsync(any(GetDataObjectRequest::class.java))).thenReturn(future)
+
+        val action = createAction(Settings.builder().build())
+        val request = GetMonitorRequest("test-monitor-id", 0L, RestRequest.Method.GET, null)
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<GetMonitorResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        verify(listener).onFailure(any())
+    }
+
+    private fun invokeDoExecute(
+        action: TransportGetMonitorAction,
+        request: GetMonitorRequest,
+        listener: ActionListener<GetMonitorResponse>
+    ) {
+        val method = action.javaClass.getDeclaredMethod(
+            "doExecute",
+            org.opensearch.tasks.Task::class.java,
+            org.opensearch.action.ActionRequest::class.java,
+            ActionListener::class.java
+        )
+        method.isAccessible = true
+        method.invoke(action, Mockito.mock(org.opensearch.tasks.Task::class.java), request, listener)
+    }
+
+    private fun createAction(settings: Settings): TransportGetMonitorAction {
+        val settingSet = hashSetOf<Setting<*>>()
+        settingSet.addAll(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        settingSet.add(AlertingSettings.FILTER_BY_BACKEND_ROLES)
+        val clusterSettings = ClusterSettings(settings, settingSet)
+        whenever(clusterService.clusterSettings).thenReturn(clusterSettings)
+
+        return TransportGetMonitorAction(
+            transportService, client, actionFilters, xContentRegistry, clusterService, settings, sdkClient
+        )
+    }
+}

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportSearchAlertingCommentActionTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportSearchAlertingCommentActionTests.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.transport
+
+import org.junit.Before
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito
+import org.mockito.Mockito.verify
+import org.opensearch.action.search.SearchRequest
+import org.opensearch.action.search.SearchResponse
+import org.opensearch.action.support.ActionFilters
+import org.opensearch.alerting.AlertingPlugin.Companion.TENANT_ID_HEADER
+import org.opensearch.alerting.settings.AlertingSettings
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.ClusterSettings
+import org.opensearch.common.settings.Setting
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.util.concurrent.ThreadContext
+import org.opensearch.core.action.ActionListener
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest
+import org.opensearch.remote.metadata.client.SearchDataObjectResponse
+import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.threadpool.ThreadPool
+import org.opensearch.transport.TransportService
+import org.opensearch.transport.client.Client
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import org.mockito.Mockito.`when` as whenever
+
+class TransportSearchAlertingCommentActionTests : OpenSearchTestCase() {
+
+    private lateinit var client: Client
+    private lateinit var sdkClient: SdkClient
+    private lateinit var clusterService: ClusterService
+    private lateinit var threadPool: ThreadPool
+    private lateinit var threadContext: ThreadContext
+
+    @Before
+    fun setup() {
+        client = Mockito.mock(Client::class.java)
+        sdkClient = Mockito.mock(SdkClient::class.java)
+        clusterService = Mockito.mock(ClusterService::class.java)
+        threadPool = Mockito.mock(ThreadPool::class.java)
+        threadContext = ThreadContext(Settings.EMPTY)
+
+        whenever(client.threadPool()).thenReturn(threadPool)
+        whenever(threadPool.threadContext).thenReturn(threadContext)
+
+        val settingSet = hashSetOf<Setting<*>>()
+        settingSet.addAll(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        settingSet.add(AlertingSettings.FILTER_BY_BACKEND_ROLES)
+        settingSet.add(AlertingSettings.ALERTING_COMMENTS_ENABLED)
+        val clusterSettings = ClusterSettings(Settings.EMPTY, settingSet)
+        whenever(clusterService.clusterSettings).thenReturn(clusterSettings)
+    }
+
+    fun `test search passes tenantId to SDK`() {
+        val expectedTenantId = "test-tenant:test-scope"
+        threadContext.putHeader(TENANT_ID_HEADER, expectedTenantId)
+
+        val future: CompletionStage<SearchDataObjectResponse> =
+            CompletableFuture.completedFuture(SearchDataObjectResponse(null as SearchResponse?))
+        whenever(sdkClient.searchDataObjectAsync(any(SearchDataObjectRequest::class.java))).thenReturn(future)
+
+        val action = createAction()
+
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<SearchResponse>
+        action.search(SearchRequest(".opensearch-alerting-comments-history-*"), listener)
+
+        val captor = ArgumentCaptor.forClass(SearchDataObjectRequest::class.java)
+        verify(sdkClient).searchDataObjectAsync(captor.capture())
+        assertEquals(expectedTenantId, captor.value.tenantId())
+    }
+
+    fun `test search SDK exception propagated to listener`() {
+        threadContext.putHeader(TENANT_ID_HEADER, "test-tenant:test-scope")
+
+        val future: CompletionStage<SearchDataObjectResponse> = CompletableFuture<SearchDataObjectResponse>().also {
+            it.completeExceptionally(RuntimeException("SDK search failed"))
+        }
+        whenever(sdkClient.searchDataObjectAsync(any(SearchDataObjectRequest::class.java))).thenReturn(future)
+
+        val action = createAction()
+
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<SearchResponse>
+        action.search(SearchRequest(".opensearch-alerting-comments-history-*"), listener)
+
+        verify(listener).onFailure(any())
+    }
+
+    fun `test search null response calls onFailure`() {
+        threadContext.putHeader(TENANT_ID_HEADER, "test-tenant:test-scope")
+
+        val future: CompletionStage<SearchDataObjectResponse> =
+            CompletableFuture.completedFuture(SearchDataObjectResponse(null as SearchResponse?))
+        whenever(sdkClient.searchDataObjectAsync(any(SearchDataObjectRequest::class.java))).thenReturn(future)
+
+        val action = createAction()
+
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<SearchResponse>
+        action.search(SearchRequest(".opensearch-alerting-comments-history-*"), listener)
+
+        verify(listener).onFailure(any())
+    }
+
+    private fun createAction(): TransportSearchAlertingCommentAction {
+        val settings = Settings.builder()
+            .put(AlertingSettings.ALERTING_COMMENTS_ENABLED.key, true)
+            .build()
+        return TransportSearchAlertingCommentAction(
+            Mockito.mock(TransportService::class.java),
+            settings,
+            client,
+            clusterService,
+            Mockito.mock(ActionFilters::class.java),
+            Mockito.mock(NamedWriteableRegistry::class.java),
+            sdkClient
+        )
+    }
+}

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorActionTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorActionTests.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.transport
+
+import org.junit.Before
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito
+import org.mockito.Mockito.verify
+import org.opensearch.action.support.ActionFilters
+import org.opensearch.alerting.AlertingPlugin.Companion.TENANT_ID_HEADER
+import org.opensearch.alerting.settings.AlertingSettings
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.ClusterSettings
+import org.opensearch.common.settings.Setting
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.util.concurrent.ThreadContext
+import org.opensearch.core.action.ActionListener
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest
+import org.opensearch.remote.metadata.client.SearchDataObjectResponse
+import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.threadpool.ThreadPool
+import org.opensearch.transport.TransportService
+import org.opensearch.transport.client.Client
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import org.mockito.Mockito.`when` as whenever
+class TransportSearchMonitorActionTests : OpenSearchTestCase() {
+
+    private lateinit var client: Client
+    private lateinit var sdkClient: SdkClient
+    private lateinit var clusterService: ClusterService
+    private lateinit var threadPool: ThreadPool
+    private lateinit var threadContext: ThreadContext
+
+    @Before
+    fun setup() {
+        client = Mockito.mock(Client::class.java)
+        sdkClient = Mockito.mock(SdkClient::class.java)
+        clusterService = Mockito.mock(ClusterService::class.java)
+        threadPool = Mockito.mock(ThreadPool::class.java)
+        threadContext = ThreadContext(Settings.EMPTY)
+
+        whenever(client.threadPool()).thenReturn(threadPool)
+        whenever(threadPool.threadContext).thenReturn(threadContext)
+
+        val settingSet = hashSetOf<Setting<*>>()
+        settingSet.addAll(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        settingSet.add(AlertingSettings.FILTER_BY_BACKEND_ROLES)
+        val clusterSettings = ClusterSettings(Settings.EMPTY, settingSet)
+        whenever(clusterService.clusterSettings).thenReturn(clusterSettings)
+    }
+
+    fun `test search passes tenantId to SDK`() {
+        val expectedTenantId = "test-tenant:test-scope"
+        threadContext.putHeader(TENANT_ID_HEADER, expectedTenantId)
+
+        val future: CompletionStage<SearchDataObjectResponse> =
+            CompletableFuture.completedFuture(SearchDataObjectResponse(null as org.opensearch.action.search.SearchResponse?))
+        whenever(sdkClient.searchDataObjectAsync(any(SearchDataObjectRequest::class.java))).thenReturn(future)
+
+        val action = createAction()
+
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<org.opensearch.action.search.SearchResponse>
+        action.search(
+            org.opensearch.action.search.SearchRequest(".opendistro-alerting-config"),
+            listener
+        )
+
+        val captor = ArgumentCaptor.forClass(SearchDataObjectRequest::class.java)
+        verify(sdkClient).searchDataObjectAsync(captor.capture())
+        assertEquals(expectedTenantId, captor.value.tenantId())
+    }
+
+    fun `test search SDK exception propagated to listener`() {
+        threadContext.putHeader(TENANT_ID_HEADER, "test-tenant:test-scope")
+
+        val future: CompletionStage<SearchDataObjectResponse> = CompletableFuture<SearchDataObjectResponse>().also {
+            it.completeExceptionally(RuntimeException("SDK search failed"))
+        }
+        whenever(sdkClient.searchDataObjectAsync(any(SearchDataObjectRequest::class.java))).thenReturn(future)
+
+        val action = createAction()
+
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<org.opensearch.action.search.SearchResponse>
+        action.search(
+            org.opensearch.action.search.SearchRequest(".opendistro-alerting-config"),
+            listener
+        )
+
+        verify(listener).onFailure(any())
+    }
+
+    fun `test search null response returns empty search response`() {
+        threadContext.putHeader(TENANT_ID_HEADER, "test-tenant:test-scope")
+
+        val future: CompletionStage<SearchDataObjectResponse> =
+            CompletableFuture.completedFuture(SearchDataObjectResponse(null as org.opensearch.action.search.SearchResponse?))
+        whenever(sdkClient.searchDataObjectAsync(any(SearchDataObjectRequest::class.java))).thenReturn(future)
+
+        val action = createAction()
+
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<org.opensearch.action.search.SearchResponse>
+        action.search(
+            org.opensearch.action.search.SearchRequest(".opendistro-alerting-config"),
+            listener
+        )
+
+        verify(listener).onResponse(any())
+    }
+
+    fun `test search IndexNotFoundException returns empty response`() {
+        threadContext.putHeader(TENANT_ID_HEADER, "test-tenant:test-scope")
+
+        val future: CompletionStage<SearchDataObjectResponse> = CompletableFuture<SearchDataObjectResponse>().also {
+            it.completeExceptionally(org.opensearch.index.IndexNotFoundException(".opendistro-alerting-config"))
+        }
+        whenever(sdkClient.searchDataObjectAsync(any(SearchDataObjectRequest::class.java))).thenReturn(future)
+
+        val action = createAction()
+
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<org.opensearch.action.search.SearchResponse>
+        action.search(
+            org.opensearch.action.search.SearchRequest(".opendistro-alerting-config"),
+            listener
+        )
+
+        verify(listener).onResponse(any())
+    }
+
+    private fun createAction(): TransportSearchMonitorAction {
+        return TransportSearchMonitorAction(
+            Mockito.mock(TransportService::class.java),
+            Settings.EMPTY,
+            client,
+            clusterService,
+            Mockito.mock(ActionFilters::class.java),
+            Mockito.mock(NamedWriteableRegistry::class.java),
+            sdkClient
+        )
+    }
+}


### PR DESCRIPTION
### Description
Merges the remote-metadata-support feature branch into main. This PR completes the migration of all alerting persistence operations from direct OpenSearch client calls to SdkClient, enabling remote metadata 
store support for multi-cluster architectures.

Changes included:
- Migrate TransportGetMonitorAction to use SdkClient (#2053)
- Migrate GetAlerts, DeleteComment, GetWorkflowAlerts, ExecuteMonitor to SdkClient (#2061)
- Migrate 4 transport actions (DeleteMonitor, GetDestinations, SearchAlertingComment, SearchMonitor) to SdkClient (#2060)
- Migrate IndexAlertingComment, IndexMonitor to SdkClient (#2081)
- Migrate MonitorMetadataService to SdkClient (#2083)
- Migrate AlertService to SdkClient (#2088)
- Migrate TransportAcknowledgeAlertAction to SdkClient (#2089)
- Add new query level trigger evaluation independent of ScriptingService (#2079, #2090)
- Fix listener leak in TransportExecuteMonitorAction for empty source (#2080)

### Related Issues
Resolves #2053, #2061, #2060, #2081, #2083, #2088, #2089

Part of #2094 

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using --signoff.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate
-of-origin).
