### PR TITLE
feat(scheduler): Disable internal job scheduler when multi-tenancy is enabled

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -333,7 +333,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
         commentsIndices = CommentsIndices(environment.settings(), client, threadPool, clusterService)
         docLevelMonitorQueries = DocLevelMonitorQueries(client, clusterService)
         scheduler = JobScheduler(threadPool, runner)
-        sweeper = JobSweeper(environment.settings(), client, clusterService, threadPool, xContentRegistry, scheduler, ALERTING_JOB_TYPES)
+        sweeper = JobSweeper(environment.settings(), client, clusterService, threadPool, xContentRegistry, scheduler, ALERTING_JOB_TYPES, MULTI_TENANCY_ENABLED)
         destinationMigrationCoordinator = DestinationMigrationCoordinator(client, clusterService, threadPool, scheduledJobIndices)
         this.threadPool = threadPool
         this.clusterService = clusterService

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/JobSchedulerDisabledIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/JobSchedulerDisabledIT.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.transport
+
+import org.opensearch.alerting.core.action.node.ScheduledJobsStatsAction
+import org.opensearch.alerting.core.action.node.ScheduledJobsStatsRequest
+import org.opensearch.common.settings.Settings
+import org.opensearch.commons.alerting.model.ScheduledJob
+
+class JobSchedulerDisabledIT : AlertingSingleNodeTestCase() {
+
+    // Set ALTERING_MULTI_TENANCY_ENABLED config as true
+    override fun nodeSettings(): Settings {
+        return Settings.builder()
+            .put(super.nodeSettings())
+            .put("plugins.alerting.multi_tenancy_enabled", true)
+            .build()
+    }
+
+    fun `test node starts successfully with multi tenancy enabled`() {
+        val clusterHealth = client().admin().cluster().prepareHealth().get()
+        assertNotNull("Cluster health should not be null", clusterHealth)
+    }
+
+    fun `test scheduled job index not created when multi tenancy enabled`() {
+        val clusterState = client().admin().cluster().prepareState().get().state
+        assertFalse(
+            "Scheduled job index should not exist when multi tenancy is enabled",
+            clusterState.routingTable.hasIndex(ScheduledJob.SCHEDULED_JOBS_INDEX)
+        )
+    }
+
+    fun `test lock index not created when multi tenancy enabled`() {
+        val clusterState = client().admin().cluster().prepareState().get().state
+        assertFalse(
+            "Lock index should not exist when sweeper is disabled",
+            clusterState.routingTable.hasIndex(".opensearch-alerting-config-lock")
+        )
+    }
+
+    fun `test no jobs scheduled when multi tenancy enabled`() {
+        val statsRequest = ScheduledJobsStatsRequest(arrayOf()).all()
+        val statsResponse = client().execute(ScheduledJobsStatsAction.INSTANCE, statsRequest).get()
+
+        assertNotNull("Stats response should not be null", statsResponse)
+        for (nodeStats in statsResponse.nodes) {
+            assertEquals(
+                "Node should have zero scheduled jobs when sweeper is disabled",
+                0,
+                nodeStats.jobInfos?.size ?: 0
+            )
+        }
+    }
+}

--- a/core/src/main/kotlin/org/opensearch/alerting/core/JobSweeper.kt
+++ b/core/src/main/kotlin/org/opensearch/alerting/core/JobSweeper.kt
@@ -25,6 +25,7 @@ import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.lifecycle.LifecycleListener
 import org.opensearch.common.logging.Loggers
 import org.opensearch.common.lucene.uid.Versions
+import org.opensearch.common.settings.Setting
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.util.concurrent.OpenSearchExecutors
@@ -76,7 +77,8 @@ class JobSweeper(
     private val threadPool: ThreadPool,
     private val xContentRegistry: NamedXContentRegistry,
     private val scheduler: JobScheduler,
-    private val sweepableJobTypes: List<String>
+    private val sweepableJobTypes: List<String>,
+    private val multiTenancyEnabledSetting: Setting<Boolean>
 ) : ClusterStateListener, IndexingOperationListener, LifecycleListener() {
     private val logger = LogManager.getLogger(javaClass)
 
@@ -95,6 +97,7 @@ class JobSweeper(
     @Volatile private var sweepBackoffMillis = SWEEP_BACKOFF_MILLIS.get(settings)
     @Volatile private var sweepBackoffRetryCount = SWEEP_BACKOFF_RETRY_COUNT.get(settings)
     @Volatile private var sweepSearchBackoff = BackoffPolicy.exponentialBackoff(sweepBackoffMillis, sweepBackoffRetryCount)
+    @Volatile private var multiTenancyEnabled = multiTenancyEnabledSetting.get(settings)
 
     init {
         clusterService.addListener(this)
@@ -119,6 +122,8 @@ class JobSweeper(
         }
         clusterService.clusterSettings.addSettingsUpdateConsumer(SWEEP_PAGE_SIZE) { sweepPageSize = it }
         clusterService.clusterSettings.addSettingsUpdateConsumer(REQUEST_TIMEOUT) { requestTimeout = it }
+        // Note: multiTenancyEnabledSetting is NodeScope and Final and immutable after node startup. Should this
+        // setting become Dynamic in future, register an update consumer here to toggle the sweeper via disable()/enable()
     }
 
     override fun afterStart() {
@@ -202,6 +207,7 @@ class JobSweeper(
     }
 
     fun enable() {
+        if (multiTenancyEnabled) return
         // initialize background sweep
         initBackgroundSweep()
         // set sweeperEnabled flag to true to make the listeners aware of this setting
@@ -221,6 +227,7 @@ class JobSweeper(
     public fun isSweepingEnabled(): Boolean {
         // Although it is a single link check, keeping it as a separate function, so we
         // can abstract out logic of finding out whether to proceed or not
+        if (multiTenancyEnabled) return false
         return sweeperEnabled == true
     }
 


### PR DESCRIPTION
When multi_tenancy_enabled is true, the internal job scheduling pipeline (JobSweeper, JobScheduler) is disabled since scheduling is handled externally. The sweeper is still instantiated to satisfy Guice dependency injection but isSweepingEnabled() returns false, making all scheduling operations no-op.

### Description
Disables the internal job scheduling pipeline (JobSweeper, JobScheduler) when multi_tenancy_enabled is true. When `plugins.alerting.multi_tenancy_enabled` is true , scheduling is handled externally. The sweeper is still instantiated to satisfy Guice dependency injection but isSweepingEnabled() returns false, making all scheduling operations no-op.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
