### PR TITLE
Block unsupported actions when multi-tenancy is enabled

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt
@@ -84,11 +84,22 @@ class TransportDeleteWorkflowAction @Inject constructor(
 
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
 
+    private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
+
     init {
         listenFilterBySettingChange(clusterService)
     }
 
     override fun doExecute(task: Task, request: ActionRequest, actionListener: ActionListener<DeleteWorkflowResponse>) {
+        if (multiTenancyEnabled) {
+            actionListener.onFailure(
+                AlertingException.wrap(
+                    OpenSearchStatusException("Workflow operations are not allowed when multi-tenancy is enabled.", RestStatus.METHOD_NOT_ALLOWED)
+                )
+            )
+            return
+        }
+
         val transformedRequest = request as? DeleteWorkflowRequest
             ?: recreateObject(request) { DeleteWorkflowRequest(it) }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt
@@ -94,7 +94,10 @@ class TransportDeleteWorkflowAction @Inject constructor(
         if (multiTenancyEnabled) {
             actionListener.onFailure(
                 AlertingException.wrap(
-                    OpenSearchStatusException("Workflow operations are not allowed when multi-tenancy is enabled.", RestStatus.METHOD_NOT_ALLOWED)
+                    OpenSearchStatusException(
+                        "Workflow operations are not allowed when multi-tenancy is enabled.",
+                        RestStatus.METHOD_NOT_ALLOWED
+                    )
                 )
             )
             return

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
@@ -22,6 +22,7 @@ import org.opensearch.alerting.action.ExecuteMonitorRequest
 import org.opensearch.alerting.action.ExecuteMonitorResponse
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.util.DocLevelMonitorQueries
+import org.opensearch.alerting.util.isUnsupportedMultiTenantMonitorType
 import org.opensearch.alerting.util.use
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
@@ -63,6 +64,8 @@ class TransportExecuteMonitorAction @Inject constructor(
     ExecuteMonitorAction.NAME, transportService, actionFilters, ::ExecuteMonitorRequest
 ) {
     @Volatile private var indexTimeout = AlertingSettings.INDEX_TIMEOUT.get(settings)
+
+    private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
 
     override fun doExecute(task: Task, execMonitorRequest: ExecuteMonitorRequest, actionListener: ActionListener<ExecuteMonitorResponse>) {
 
@@ -133,6 +136,17 @@ class TransportExecuteMonitorAction @Inject constructor(
                                 getResponse.sourceAsBytesRef, XContentType.JSON
                             ).use { xcp ->
                                 val monitor = ScheduledJob.parse(xcp, getResponse.id, getResponse.version) as Monitor
+                                if (multiTenancyEnabled && monitor.isUnsupportedMultiTenantMonitorType()) {
+                                    actionListener.onFailure(
+                                        AlertingException.wrap(
+                                            OpenSearchStatusException(
+                                                "${monitor.monitorType} monitors are not allowed when multi-tenancy is enabled.",
+                                                RestStatus.METHOD_NOT_ALLOWED
+                                            )
+                                        )
+                                    )
+                                    return@whenComplete
+                                }
                                 executeMonitor(monitor)
                             }
                         } else {
@@ -154,6 +168,18 @@ class TransportExecuteMonitorAction @Inject constructor(
                 val monitor = when (user?.name.isNullOrEmpty()) {
                     true -> execMonitorRequest.monitor as Monitor
                     false -> (execMonitorRequest.monitor as Monitor).copy(user = user)
+                }
+
+                if (multiTenancyEnabled && monitor.isUnsupportedMultiTenantMonitorType()) {
+                    actionListener.onFailure(
+                        AlertingException.wrap(
+                            OpenSearchStatusException(
+                                "${monitor.monitorType} monitors are not allowed when multi-tenancy is enabled.",
+                                RestStatus.METHOD_NOT_ALLOWED
+                            )
+                        )
+                    )
+                    return@use
                 }
 
                 if (

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteWorkflowAction.kt
@@ -18,8 +18,10 @@ import org.opensearch.alerting.MonitorRunnerService
 import org.opensearch.alerting.action.ExecuteWorkflowAction
 import org.opensearch.alerting.action.ExecuteWorkflowRequest
 import org.opensearch.alerting.action.ExecuteWorkflowResponse
+import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.util.use
 import org.opensearch.common.inject.Inject
+import org.opensearch.common.settings.Settings
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
@@ -43,15 +45,28 @@ class TransportExecuteWorkflowAction @Inject constructor(
     private val client: Client,
     private val runner: MonitorRunnerService,
     actionFilters: ActionFilters,
-    val xContentRegistry: NamedXContentRegistry
+    val xContentRegistry: NamedXContentRegistry,
+    val settings: Settings,
 ) : HandledTransportAction<ExecuteWorkflowRequest, ExecuteWorkflowResponse>(
     ExecuteWorkflowAction.NAME, transportService, actionFilters, ::ExecuteWorkflowRequest
 ) {
+
+    private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
+
     override fun doExecute(
         task: Task,
         execWorkflowRequest: ExecuteWorkflowRequest,
         actionListener: ActionListener<ExecuteWorkflowResponse>,
     ) {
+        if (multiTenancyEnabled) {
+            actionListener.onFailure(
+                AlertingException.wrap(
+                    OpenSearchStatusException("Workflow operations are not allowed when multi-tenancy is enabled.", RestStatus.METHOD_NOT_ALLOWED)
+                )
+            )
+            return
+        }
+
         val userStr = client.threadPool().threadContext.getTransient<String>(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT)
         log.debug("User and roles string from thread context: $userStr")
         val user: User? = User.parse(userStr)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteWorkflowAction.kt
@@ -61,7 +61,10 @@ class TransportExecuteWorkflowAction @Inject constructor(
         if (multiTenancyEnabled) {
             actionListener.onFailure(
                 AlertingException.wrap(
-                    OpenSearchStatusException("Workflow operations are not allowed when multi-tenancy is enabled.", RestStatus.METHOD_NOT_ALLOWED)
+                    OpenSearchStatusException(
+                        "Workflow operations are not allowed when multi-tenancy is enabled.",
+                        RestStatus.METHOD_NOT_ALLOWED
+                    )
                 )
             )
             return

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAction.kt
@@ -59,7 +59,10 @@ class TransportGetWorkflowAction @Inject constructor(
         if (multiTenancyEnabled) {
             actionListener.onFailure(
                 AlertingException.wrap(
-                    OpenSearchStatusException("Workflow operations are not allowed when multi-tenancy is enabled.", RestStatus.METHOD_NOT_ALLOWED)
+                    OpenSearchStatusException(
+                        "Workflow operations are not allowed when multi-tenancy is enabled.",
+                        RestStatus.METHOD_NOT_ALLOWED
+                    )
                 )
             )
             return

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAction.kt
@@ -49,11 +49,22 @@ class TransportGetWorkflowAction @Inject constructor(
 
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
 
+    private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
+
     init {
         listenFilterBySettingChange(clusterService)
     }
 
     override fun doExecute(task: Task, getWorkflowRequest: GetWorkflowRequest, actionListener: ActionListener<GetWorkflowResponse>) {
+        if (multiTenancyEnabled) {
+            actionListener.onFailure(
+                AlertingException.wrap(
+                    OpenSearchStatusException("Workflow operations are not allowed when multi-tenancy is enabled.", RestStatus.METHOD_NOT_ALLOWED)
+                )
+            )
+            return
+        }
+
         val user = readUserFromThreadContext(client)
 
         val getRequest = GetRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, getWorkflowRequest.workflowId)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAlertsAction.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.apache.logging.log4j.LogManager
+import org.opensearch.OpenSearchStatusException
 import org.opensearch.action.ActionRequest
 import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.search.SearchResponse
@@ -75,6 +76,8 @@ class TransportGetWorkflowAlertsAction @Inject constructor(
     @Volatile
     private var isAlertHistoryEnabled = AlertingSettings.ALERT_HISTORY_ENABLED.get(settings)
 
+    private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
+
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.ALERT_HISTORY_ENABLED) { isAlertHistoryEnabled = it }
         listenFilterBySettingChange(clusterService)
@@ -85,6 +88,15 @@ class TransportGetWorkflowAlertsAction @Inject constructor(
         request: ActionRequest,
         actionListener: ActionListener<GetWorkflowAlertsResponse>,
     ) {
+        if (multiTenancyEnabled) {
+            actionListener.onFailure(
+                AlertingException.wrap(
+                    OpenSearchStatusException("Workflow operations are not allowed when multi-tenancy is enabled.", RestStatus.METHOD_NOT_ALLOWED)
+                )
+            )
+            return
+        }
+
         val getWorkflowAlertsRequest = request as? GetWorkflowAlertsRequest
             ?: recreateObject(request) { GetWorkflowAlertsRequest(it) }
         val user = readUserFromThreadContext(client)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAlertsAction.kt
@@ -91,7 +91,10 @@ class TransportGetWorkflowAlertsAction @Inject constructor(
         if (multiTenancyEnabled) {
             actionListener.onFailure(
                 AlertingException.wrap(
-                    OpenSearchStatusException("Workflow operations are not allowed when multi-tenancy is enabled.", RestStatus.METHOD_NOT_ALLOWED)
+                    OpenSearchStatusException(
+                        "Workflow operations are not allowed when multi-tenancy is enabled.",
+                        RestStatus.METHOD_NOT_ALLOWED
+                    )
                 )
             )
             return

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -44,6 +44,7 @@ import org.opensearch.alerting.util.addUserBackendRolesFilter
 import org.opensearch.alerting.util.await
 import org.opensearch.alerting.util.getRoleFilterEnabled
 import org.opensearch.alerting.util.isADMonitor
+import org.opensearch.alerting.util.isUnsupportedMultiTenantMonitorType
 import org.opensearch.alerting.util.use
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
@@ -117,6 +118,8 @@ class TransportIndexMonitorAction @Inject constructor(
     @Volatile private var allowList = ALLOW_LIST.get(settings)
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
 
+    private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
+
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(ALERTING_MAX_MONITORS) { maxMonitors = it }
         clusterService.clusterSettings.addSettingsUpdateConsumer(MAX_TRIGGERS_PER_MONITOR) { maxTriggersPerMonitor = it }
@@ -132,6 +135,18 @@ class TransportIndexMonitorAction @Inject constructor(
             ?: recreateObject(request, namedWriteableRegistry) {
                 IndexMonitorRequest(it)
             }
+
+        if (multiTenancyEnabled && transformedRequest.monitor.isUnsupportedMultiTenantMonitorType()) {
+            actionListener.onFailure(
+                AlertingException.wrap(
+                    OpenSearchStatusException(
+                        "${transformedRequest.monitor.monitorType} monitors are not allowed when multi-tenancy is enabled.",
+                        RestStatus.METHOD_NOT_ALLOWED
+                    )
+                )
+            )
+            return
+        }
 
         val user = readUserFromThreadContext(client)
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
@@ -123,6 +123,8 @@ class TransportIndexWorkflowAction @Inject constructor(
     @Volatile
     override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
 
+    private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
+
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(ALERTING_MAX_MONITORS) { maxMonitors = it }
         clusterService.clusterSettings.addSettingsUpdateConsumer(MAX_TRIGGERS_PER_MONITOR) { maxTriggersPerMonitor = it }
@@ -134,6 +136,15 @@ class TransportIndexWorkflowAction @Inject constructor(
     }
 
     override fun doExecute(task: Task, request: ActionRequest, actionListener: ActionListener<IndexWorkflowResponse>) {
+        if (multiTenancyEnabled) {
+            actionListener.onFailure(
+                AlertingException.wrap(
+                    OpenSearchStatusException("Workflow operations are not allowed when multi-tenancy is enabled.", RestStatus.METHOD_NOT_ALLOWED)
+                )
+            )
+            return
+        }
+
         val transformedRequest = request as? IndexWorkflowRequest
             ?: recreateObject(request, namedWriteableRegistry) {
                 IndexWorkflowRequest(it)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
@@ -139,7 +139,10 @@ class TransportIndexWorkflowAction @Inject constructor(
         if (multiTenancyEnabled) {
             actionListener.onFailure(
                 AlertingException.wrap(
-                    OpenSearchStatusException("Workflow operations are not allowed when multi-tenancy is enabled.", RestStatus.METHOD_NOT_ALLOWED)
+                    OpenSearchStatusException(
+                        "Workflow operations are not allowed when multi-tenancy is enabled.",
+                        RestStatus.METHOD_NOT_ALLOWED
+                    )
                 )
             )
             return

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
@@ -88,6 +88,12 @@ fun Monitor.isQueryLevelMonitor(): Boolean =
     this.isMonitorOfStandardType() &&
         Monitor.MonitorType.valueOf(this.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.QUERY_LEVEL_MONITOR
 
+fun Monitor.isUnsupportedMultiTenantMonitorType(): Boolean {
+    if (!this.isMonitorOfStandardType()) return false
+    val type = Monitor.MonitorType.valueOf(this.monitorType.uppercase(Locale.ROOT))
+    return type == Monitor.MonitorType.DOC_LEVEL_MONITOR || type == Monitor.MonitorType.CLUSTER_METRICS_MONITOR
+}
+
 /**
  * Since buckets can have multi-value keys, this converts the bucket key values to a string that can be used
  * as the key for a HashMap to easily retrieve [AggregationResultBucket] based on the bucket key values.

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/MultiTenancyBlockIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/MultiTenancyBlockIT.kt
@@ -39,6 +39,10 @@ class MultiTenancyBlockIT : AlertingSingleNodeTestCase() {
             .build()
     }
 
+    override fun resetNodeAfterTest(): Boolean {
+        return true
+    }
+
     // --- Workflow tests ---
 
     fun `test index workflow fails when multi-tenancy is enabled`() {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/MultiTenancyBlockIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/MultiTenancyBlockIT.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.transport
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope
+import org.opensearch.action.support.WriteRequest
+import org.opensearch.alerting.action.ExecuteMonitorAction
+import org.opensearch.alerting.action.ExecuteMonitorRequest
+import org.opensearch.alerting.action.ExecuteWorkflowAction
+import org.opensearch.alerting.action.ExecuteWorkflowRequest
+import org.opensearch.alerting.randomClusterMetricsMonitor
+import org.opensearch.alerting.randomDocumentLevelMonitor
+import org.opensearch.alerting.randomQueryLevelMonitor
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.unit.TimeValue
+import org.opensearch.commons.alerting.action.AlertingActions
+import org.opensearch.commons.alerting.action.DeleteWorkflowRequest
+import org.opensearch.commons.alerting.action.GetWorkflowAlertsRequest
+import org.opensearch.commons.alerting.action.GetWorkflowRequest
+import org.opensearch.commons.alerting.action.IndexWorkflowRequest
+import org.opensearch.commons.alerting.model.Alert
+import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.Table
+import org.opensearch.commons.alerting.model.Workflow
+import org.opensearch.index.seqno.SequenceNumbers
+import org.opensearch.rest.RestRequest
+import java.time.Instant
+
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+class MultiTenancyBlockIT : AlertingSingleNodeTestCase() {
+
+    override fun nodeSettings(): Settings {
+        return Settings.builder()
+            .put(super.nodeSettings())
+            .put("plugins.alerting.multi_tenancy_enabled", true)
+            .build()
+    }
+
+    // --- Workflow tests ---
+
+    fun `test index workflow fails when multi-tenancy is enabled`() {
+        val request = IndexWorkflowRequest(
+            workflowId = Workflow.NO_ID,
+            seqNo = SequenceNumbers.UNASSIGNED_SEQ_NO,
+            primaryTerm = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
+            refreshPolicy = WriteRequest.RefreshPolicy.IMMEDIATE,
+            method = RestRequest.Method.POST,
+            workflow = org.opensearch.alerting.randomWorkflow(monitorIds = emptyList())
+        )
+        val exception = expectThrows(Exception::class.java) {
+            client().execute(AlertingActions.INDEX_WORKFLOW_ACTION_TYPE, request).actionGet()
+        }
+        assertTrue(exception.message!!.contains("Workflow operations are not allowed"))
+    }
+
+    fun `test get workflow fails when multi-tenancy is enabled`() {
+        val exception = expectThrows(Exception::class.java) {
+            client().execute(AlertingActions.GET_WORKFLOW_ACTION_TYPE, GetWorkflowRequest("test-id", RestRequest.Method.GET)).actionGet()
+        }
+        assertTrue(exception.message!!.contains("Workflow operations are not allowed"))
+    }
+
+    fun `test delete workflow fails when multi-tenancy is enabled`() {
+        val exception = expectThrows(Exception::class.java) {
+            client().execute(AlertingActions.DELETE_WORKFLOW_ACTION_TYPE, DeleteWorkflowRequest("test-id", false)).actionGet()
+        }
+        assertTrue(exception.message!!.contains("Workflow operations are not allowed"))
+    }
+
+    fun `test execute workflow fails when multi-tenancy is enabled`() {
+        val exception = expectThrows(Exception::class.java) {
+            client().execute(
+                ExecuteWorkflowAction.INSTANCE,
+                ExecuteWorkflowRequest(true, TimeValue(Instant.now().toEpochMilli()), "test-id", null)
+            ).actionGet()
+        }
+        assertTrue(exception.message!!.contains("Workflow operations are not allowed"))
+    }
+
+    fun `test get workflow alerts fails when multi-tenancy is enabled`() {
+        val request = GetWorkflowAlertsRequest(
+            table = Table("asc", "monitor_id", null, 100, 0, null),
+            severityLevel = "ALL",
+            alertState = Alert.State.ACTIVE.name,
+            alertIndex = "",
+            associatedAlertsIndex = "",
+            monitorIds = emptyList(),
+            workflowIds = listOf("test-id"),
+            alertIds = emptyList(),
+            getAssociatedAlerts = false
+        )
+        val exception = expectThrows(Exception::class.java) {
+            client().execute(AlertingActions.GET_WORKFLOW_ALERTS_ACTION_TYPE, request).actionGet()
+        }
+        assertTrue(exception.message!!.contains("Workflow operations are not allowed"))
+    }
+
+    // --- Monitor type tests ---
+
+    fun `test index doc-level monitor fails when multi-tenancy is enabled`() {
+        val exception = expectThrows(Exception::class.java) {
+            createMonitor(randomDocumentLevelMonitor())
+        }
+        assertTrue(exception.message!!.contains("not allowed when multi-tenancy is enabled"))
+    }
+
+    fun `test index cluster-metrics monitor fails when multi-tenancy is enabled`() {
+        val exception = expectThrows(Exception::class.java) {
+            createMonitor(randomClusterMetricsMonitor())
+        }
+        assertTrue(exception.message!!.contains("not allowed when multi-tenancy is enabled"))
+    }
+
+    fun `test index query-level monitor succeeds when multi-tenancy is enabled`() {
+        val response = createMonitor(randomQueryLevelMonitor())
+        assertNotNull(response)
+        assertNotEquals(Monitor.NO_ID, response!!.id)
+    }
+
+    fun `test execute inline doc-level monitor fails when multi-tenancy is enabled`() {
+        val exception = expectThrows(Exception::class.java) {
+            val request = ExecuteMonitorRequest(true, TimeValue(Instant.now().toEpochMilli()), null, randomDocumentLevelMonitor())
+            client().execute(ExecuteMonitorAction.INSTANCE, request).actionGet()
+        }
+        assertTrue(exception.message!!.contains("not allowed when multi-tenancy is enabled"))
+    }
+}

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/MultiTenancyBlockSingleNodeTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/MultiTenancyBlockSingleNodeTests.kt
@@ -13,7 +13,6 @@ import org.opensearch.alerting.action.ExecuteWorkflowAction
 import org.opensearch.alerting.action.ExecuteWorkflowRequest
 import org.opensearch.alerting.randomClusterMetricsMonitor
 import org.opensearch.alerting.randomDocumentLevelMonitor
-import org.opensearch.alerting.randomQueryLevelMonitor
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.commons.alerting.action.AlertingActions
@@ -22,7 +21,6 @@ import org.opensearch.commons.alerting.action.GetWorkflowAlertsRequest
 import org.opensearch.commons.alerting.action.GetWorkflowRequest
 import org.opensearch.commons.alerting.action.IndexWorkflowRequest
 import org.opensearch.commons.alerting.model.Alert
-import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.Table
 import org.opensearch.commons.alerting.model.Workflow
 import org.opensearch.index.seqno.SequenceNumbers
@@ -30,7 +28,7 @@ import org.opensearch.rest.RestRequest
 import java.time.Instant
 
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
-class MultiTenancyBlockIT : AlertingSingleNodeTestCase() {
+class MultiTenancyBlockSingleNodeTests : AlertingSingleNodeTestCase() {
 
     override fun nodeSettings(): Settings {
         return Settings.builder()
@@ -40,7 +38,7 @@ class MultiTenancyBlockIT : AlertingSingleNodeTestCase() {
     }
 
     override fun resetNodeAfterTest(): Boolean {
-        return true
+        return false
     }
 
     // --- Workflow tests ---
@@ -52,7 +50,7 @@ class MultiTenancyBlockIT : AlertingSingleNodeTestCase() {
             primaryTerm = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
             refreshPolicy = WriteRequest.RefreshPolicy.IMMEDIATE,
             method = RestRequest.Method.POST,
-            workflow = org.opensearch.alerting.randomWorkflow(monitorIds = emptyList())
+            workflow = org.opensearch.alerting.randomWorkflow(monitorIds = listOf("dummy-monitor-id"))
         )
         val exception = expectThrows(Exception::class.java) {
             client().execute(AlertingActions.INDEX_WORKFLOW_ACTION_TYPE, request).actionGet()
@@ -116,12 +114,6 @@ class MultiTenancyBlockIT : AlertingSingleNodeTestCase() {
             createMonitor(randomClusterMetricsMonitor())
         }
         assertTrue(exception.message!!.contains("not allowed when multi-tenancy is enabled"))
-    }
-
-    fun `test index query-level monitor succeeds when multi-tenancy is enabled`() {
-        val response = createMonitor(randomQueryLevelMonitor())
-        assertNotNull(response)
-        assertNotEquals(Monitor.NO_ID, response!!.id)
     }
 
     fun `test execute inline doc-level monitor fails when multi-tenancy is enabled`() {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportMultiTenancyBlockTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportMultiTenancyBlockTests.kt
@@ -1,0 +1,320 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.transport
+
+import org.junit.Before
+import org.mockito.Mockito
+import org.mockito.Mockito.verify
+import org.opensearch.OpenSearchStatusException
+import org.opensearch.action.support.ActionFilters
+import org.opensearch.alerting.MonitorRunnerService
+import org.opensearch.alerting.action.ExecuteMonitorRequest
+import org.opensearch.alerting.action.ExecuteMonitorResponse
+import org.opensearch.alerting.action.ExecuteWorkflowRequest
+import org.opensearch.alerting.action.ExecuteWorkflowResponse
+import org.opensearch.alerting.core.ScheduledJobIndices
+import org.opensearch.alerting.core.lock.LockService
+import org.opensearch.alerting.settings.AlertingSettings
+import org.opensearch.alerting.util.DocLevelMonitorQueries
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.ClusterSettings
+import org.opensearch.common.settings.Setting
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.unit.TimeValue
+import org.opensearch.common.util.concurrent.ThreadContext
+import org.opensearch.commons.alerting.action.DeleteWorkflowRequest
+import org.opensearch.commons.alerting.action.DeleteWorkflowResponse
+import org.opensearch.commons.alerting.action.GetWorkflowAlertsRequest
+import org.opensearch.commons.alerting.action.GetWorkflowAlertsResponse
+import org.opensearch.commons.alerting.action.GetWorkflowRequest
+import org.opensearch.commons.alerting.action.GetWorkflowResponse
+import org.opensearch.commons.alerting.action.IndexMonitorRequest
+import org.opensearch.commons.alerting.action.IndexMonitorResponse
+import org.opensearch.commons.alerting.action.IndexWorkflowRequest
+import org.opensearch.commons.alerting.action.IndexWorkflowResponse
+import org.opensearch.commons.alerting.model.Alert
+import org.opensearch.commons.alerting.model.DocLevelMonitorInput
+import org.opensearch.commons.alerting.model.IntervalSchedule
+import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.SearchInput
+import org.opensearch.commons.alerting.model.Table
+import org.opensearch.core.action.ActionListener
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry
+import org.opensearch.core.rest.RestStatus
+import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.index.query.QueryBuilders
+import org.opensearch.index.seqno.SequenceNumbers
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.rest.RestRequest
+import org.opensearch.search.builder.SearchSourceBuilder
+import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.threadpool.ThreadPool
+import org.opensearch.transport.TransportService
+import org.opensearch.transport.client.Client
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import org.mockito.Mockito.`when` as whenever
+
+class TransportMultiTenancyBlockTests : OpenSearchTestCase() {
+
+    private lateinit var client: Client
+    private lateinit var transportService: TransportService
+    private lateinit var actionFilters: ActionFilters
+    private lateinit var xContentRegistry: NamedXContentRegistry
+    private lateinit var clusterService: ClusterService
+    private lateinit var threadPool: ThreadPool
+    private lateinit var threadContext: ThreadContext
+
+    private val multiTenancySettings: Settings = Settings.builder()
+        .put("plugins.alerting.multi_tenancy_enabled", true)
+        .build()
+
+    @Before
+    fun setup() {
+        client = Mockito.mock(Client::class.java)
+        transportService = Mockito.mock(TransportService::class.java)
+        actionFilters = Mockito.mock(ActionFilters::class.java)
+        xContentRegistry = Mockito.mock(NamedXContentRegistry::class.java)
+        clusterService = Mockito.mock(ClusterService::class.java)
+        threadPool = Mockito.mock(ThreadPool::class.java)
+        threadContext = ThreadContext(Settings.EMPTY)
+
+        whenever(client.threadPool()).thenReturn(threadPool)
+        whenever(threadPool.threadContext).thenReturn(threadContext)
+
+        val settingSet = hashSetOf<Setting<*>>()
+        settingSet.addAll(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        settingSet.add(AlertingSettings.FILTER_BY_BACKEND_ROLES)
+        settingSet.add(AlertingSettings.MULTI_TENANCY_ENABLED)
+        settingSet.add(AlertingSettings.ALERT_HISTORY_ENABLED)
+        val clusterSettings = ClusterSettings(multiTenancySettings, settingSet)
+        whenever(clusterService.clusterSettings).thenReturn(clusterSettings)
+    }
+
+    // --- Workflow action tests ---
+
+    fun `test get workflow blocked when multi-tenancy enabled`() {
+        val action = TransportGetWorkflowAction(
+            transportService, client, actionFilters, xContentRegistry, clusterService, multiTenancySettings
+        )
+        val request = GetWorkflowRequest("test-id", RestRequest.Method.GET)
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<GetWorkflowResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        assertMethodNotAllowed(listener)
+    }
+
+    fun `test index workflow blocked when multi-tenancy enabled`() {
+        val action = TransportIndexWorkflowAction(
+            transportService, client, actionFilters,
+            Mockito.mock(ScheduledJobIndices::class.java),
+            clusterService, multiTenancySettings, xContentRegistry,
+            Mockito.mock(NamedWriteableRegistry::class.java)
+        )
+        val request = Mockito.mock(IndexWorkflowRequest::class.java)
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<IndexWorkflowResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        assertMethodNotAllowed(listener)
+    }
+
+    fun `test delete workflow blocked when multi-tenancy enabled`() {
+        val action = TransportDeleteWorkflowAction(
+            transportService, client, actionFilters, clusterService,
+            multiTenancySettings, xContentRegistry,
+            Mockito.mock(LockService::class.java)
+        )
+        val request = DeleteWorkflowRequest("test-id", false)
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<DeleteWorkflowResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        assertMethodNotAllowed(listener)
+    }
+
+    fun `test execute workflow blocked when multi-tenancy enabled`() {
+        val action = TransportExecuteWorkflowAction(
+            transportService, client,
+            Mockito.mock(MonitorRunnerService::class.java),
+            actionFilters, xContentRegistry, multiTenancySettings
+        )
+        val request = ExecuteWorkflowRequest(true, TimeValue(Instant.now().toEpochMilli()), "test-id", null)
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<ExecuteWorkflowResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        assertMethodNotAllowed(listener)
+    }
+
+    fun `test get workflow alerts blocked when multi-tenancy enabled`() {
+        val action = TransportGetWorkflowAlertsAction(
+            transportService, client, clusterService, actionFilters,
+            multiTenancySettings, xContentRegistry,
+            Mockito.mock(SdkClient::class.java)
+        )
+        val request = GetWorkflowAlertsRequest(
+            table = Table("asc", "monitor_id", null, 100, 0, null),
+            severityLevel = "ALL",
+            alertState = Alert.State.ACTIVE.name,
+            alertIndex = "",
+            associatedAlertsIndex = "",
+            monitorIds = emptyList(),
+            workflowIds = listOf("test-id"),
+            alertIds = emptyList(),
+            getAssociatedAlerts = false
+        )
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<GetWorkflowAlertsResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        assertMethodNotAllowed(listener)
+    }
+
+    // --- Monitor type tests ---
+
+    fun `test index doc-level monitor blocked when multi-tenancy enabled`() {
+        val action = TransportIndexMonitorAction(
+            transportService, client, actionFilters,
+            Mockito.mock(ScheduledJobIndices::class.java),
+            Mockito.mock(DocLevelMonitorQueries::class.java),
+            clusterService, multiTenancySettings, xContentRegistry,
+            Mockito.mock(NamedWriteableRegistry::class.java),
+            Mockito.mock(SdkClient::class.java)
+        )
+        val monitor = Monitor(
+            name = "test", monitorType = Monitor.MonitorType.DOC_LEVEL_MONITOR.value,
+            enabled = false, schedule = IntervalSchedule(5, ChronoUnit.MINUTES),
+            lastUpdateTime = Instant.now(), enabledTime = null, user = null,
+            inputs = listOf(DocLevelMonitorInput("desc", listOf("index"), emptyList())),
+            triggers = emptyList(), uiMetadata = mapOf()
+        )
+        val request = IndexMonitorRequest(
+            Monitor.NO_ID, SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
+            org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.POST, monitor
+        )
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<IndexMonitorResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        assertMethodNotAllowed(listener)
+    }
+
+    fun `test index cluster-metrics monitor blocked when multi-tenancy enabled`() {
+        val action = TransportIndexMonitorAction(
+            transportService, client, actionFilters,
+            Mockito.mock(ScheduledJobIndices::class.java),
+            Mockito.mock(DocLevelMonitorQueries::class.java),
+            clusterService, multiTenancySettings, xContentRegistry,
+            Mockito.mock(NamedWriteableRegistry::class.java),
+            Mockito.mock(SdkClient::class.java)
+        )
+        val monitor = Monitor(
+            name = "test", monitorType = Monitor.MonitorType.CLUSTER_METRICS_MONITOR.value,
+            enabled = false, schedule = IntervalSchedule(5, ChronoUnit.MINUTES),
+            lastUpdateTime = Instant.now(), enabledTime = null, user = null,
+            inputs = listOf(SearchInput(emptyList(), SearchSourceBuilder().query(QueryBuilders.matchAllQuery()))),
+            triggers = emptyList(), uiMetadata = mapOf()
+        )
+        val request = IndexMonitorRequest(
+            Monitor.NO_ID, SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
+            org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.POST, monitor
+        )
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<IndexMonitorResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        assertMethodNotAllowed(listener)
+    }
+
+    fun `test index query-level monitor allowed when multi-tenancy enabled`() {
+        val action = TransportIndexMonitorAction(
+            transportService, client, actionFilters,
+            Mockito.mock(ScheduledJobIndices::class.java),
+            Mockito.mock(DocLevelMonitorQueries::class.java),
+            clusterService, multiTenancySettings, xContentRegistry,
+            Mockito.mock(NamedWriteableRegistry::class.java),
+            Mockito.mock(SdkClient::class.java)
+        )
+        val monitor = Monitor(
+            name = "test", monitorType = Monitor.MonitorType.QUERY_LEVEL_MONITOR.value,
+            enabled = false, schedule = IntervalSchedule(5, ChronoUnit.MINUTES),
+            lastUpdateTime = Instant.now(), enabledTime = null, user = null,
+            inputs = listOf(SearchInput(emptyList(), SearchSourceBuilder().query(QueryBuilders.matchAllQuery()))),
+            triggers = emptyList(), uiMetadata = mapOf()
+        )
+        val request = IndexMonitorRequest(
+            Monitor.NO_ID, SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
+            org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.POST, monitor
+        )
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<IndexMonitorResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        // Should NOT call onFailure with METHOD_NOT_ALLOWED — it proceeds past the check
+        verify(listener, Mockito.never()).onFailure(
+            org.mockito.ArgumentMatchers.argThat { ex ->
+                val cause = (ex as? org.opensearch.commons.alerting.util.AlertingException)?.cause ?: ex
+                cause is OpenSearchStatusException && cause.status() == RestStatus.METHOD_NOT_ALLOWED
+            }
+        )
+    }
+
+    fun `test execute inline doc-level monitor blocked when multi-tenancy enabled`() {
+        val action = TransportExecuteMonitorAction(
+            transportService, client, clusterService,
+            Mockito.mock(MonitorRunnerService::class.java),
+            actionFilters, xContentRegistry,
+            Mockito.mock(DocLevelMonitorQueries::class.java),
+            multiTenancySettings, Mockito.mock(SdkClient::class.java)
+        )
+        val monitor = Monitor(
+            name = "test", monitorType = Monitor.MonitorType.DOC_LEVEL_MONITOR.value,
+            enabled = false, schedule = IntervalSchedule(5, ChronoUnit.MINUTES),
+            lastUpdateTime = Instant.now(), enabledTime = null, user = null,
+            inputs = listOf(DocLevelMonitorInput("desc", listOf("index"), emptyList())),
+            triggers = emptyList(), uiMetadata = mapOf()
+        )
+        val request = ExecuteMonitorRequest(true, TimeValue(Instant.now().toEpochMilli()), null, monitor)
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<ExecuteMonitorResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        assertMethodNotAllowed(listener)
+    }
+
+    // --- Helpers ---
+
+    private fun assertMethodNotAllowed(listener: ActionListener<*>) {
+        val captor = org.mockito.ArgumentCaptor.forClass(Exception::class.java)
+        verify(listener).onFailure(captor.capture())
+        val cause = (captor.value as? org.opensearch.commons.alerting.util.AlertingException)?.cause
+            ?: captor.value
+        assertTrue(cause is OpenSearchStatusException)
+        assertEquals(RestStatus.METHOD_NOT_ALLOWED, (cause as OpenSearchStatusException).status())
+    }
+
+    private fun invokeDoExecute(action: Any, request: Any, listener: ActionListener<*>) {
+        val method = action.javaClass.getDeclaredMethod(
+            "doExecute",
+            org.opensearch.tasks.Task::class.java,
+            org.opensearch.action.ActionRequest::class.java,
+            ActionListener::class.java
+        )
+        method.isAccessible = true
+        method.invoke(action, Mockito.mock(org.opensearch.tasks.Task::class.java), request, listener)
+    }
+}

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportMultiTenancyBlockTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportMultiTenancyBlockTests.kt
@@ -18,6 +18,7 @@ import org.opensearch.alerting.action.ExecuteWorkflowResponse
 import org.opensearch.alerting.core.ScheduledJobIndices
 import org.opensearch.alerting.core.lock.LockService
 import org.opensearch.alerting.settings.AlertingSettings
+import org.opensearch.alerting.settings.DestinationSettings
 import org.opensearch.alerting.util.DocLevelMonitorQueries
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.settings.ClusterSettings
@@ -67,6 +68,9 @@ class TransportMultiTenancyBlockTests : OpenSearchTestCase() {
     private lateinit var clusterService: ClusterService
     private lateinit var threadPool: ThreadPool
     private lateinit var threadContext: ThreadContext
+    private lateinit var scheduledJobIndices: ScheduledJobIndices
+    private lateinit var lockService: LockService
+    private lateinit var docLevelMonitorQueries: DocLevelMonitorQueries
 
     private val multiTenancySettings: Settings = Settings.builder()
         .put("plugins.alerting.multi_tenancy_enabled", true)
@@ -90,8 +94,20 @@ class TransportMultiTenancyBlockTests : OpenSearchTestCase() {
         settingSet.add(AlertingSettings.FILTER_BY_BACKEND_ROLES)
         settingSet.add(AlertingSettings.MULTI_TENANCY_ENABLED)
         settingSet.add(AlertingSettings.ALERT_HISTORY_ENABLED)
+        settingSet.add(AlertingSettings.ALERTING_MAX_MONITORS)
+        settingSet.add(AlertingSettings.MAX_TRIGGERS_PER_MONITOR)
+        settingSet.add(AlertingSettings.REQUEST_TIMEOUT)
+        settingSet.add(AlertingSettings.INDEX_TIMEOUT)
+        settingSet.add(AlertingSettings.MAX_ACTION_THROTTLE_VALUE)
+        settingSet.add(DestinationSettings.ALLOW_LIST)
         val clusterSettings = ClusterSettings(multiTenancySettings, settingSet)
         whenever(clusterService.clusterSettings).thenReturn(clusterSettings)
+
+        val adminClient = Mockito.mock(org.opensearch.transport.client.AdminClient::class.java)
+        whenever(client.admin()).thenReturn(adminClient)
+        scheduledJobIndices = ScheduledJobIndices(adminClient, clusterService)
+        lockService = LockService(client, clusterService)
+        docLevelMonitorQueries = DocLevelMonitorQueries(client, clusterService)
     }
 
     // --- Workflow action tests ---
@@ -112,11 +128,18 @@ class TransportMultiTenancyBlockTests : OpenSearchTestCase() {
     fun `test index workflow blocked when multi-tenancy enabled`() {
         val action = TransportIndexWorkflowAction(
             transportService, client, actionFilters,
-            Mockito.mock(ScheduledJobIndices::class.java),
+            scheduledJobIndices,
             clusterService, multiTenancySettings, xContentRegistry,
             Mockito.mock(NamedWriteableRegistry::class.java)
         )
-        val request = Mockito.mock(IndexWorkflowRequest::class.java)
+        val request = IndexWorkflowRequest(
+            workflowId = "test-id",
+            seqNo = SequenceNumbers.UNASSIGNED_SEQ_NO,
+            primaryTerm = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
+            refreshPolicy = org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE,
+            method = RestRequest.Method.POST,
+            workflow = org.opensearch.alerting.randomWorkflow(monitorIds = listOf("dummy-id"))
+        )
         @Suppress("UNCHECKED_CAST")
         val listener = Mockito.mock(ActionListener::class.java) as ActionListener<IndexWorkflowResponse>
 
@@ -129,7 +152,7 @@ class TransportMultiTenancyBlockTests : OpenSearchTestCase() {
         val action = TransportDeleteWorkflowAction(
             transportService, client, actionFilters, clusterService,
             multiTenancySettings, xContentRegistry,
-            Mockito.mock(LockService::class.java)
+            lockService
         )
         val request = DeleteWorkflowRequest("test-id", false)
         @Suppress("UNCHECKED_CAST")
@@ -143,7 +166,7 @@ class TransportMultiTenancyBlockTests : OpenSearchTestCase() {
     fun `test execute workflow blocked when multi-tenancy enabled`() {
         val action = TransportExecuteWorkflowAction(
             transportService, client,
-            Mockito.mock(MonitorRunnerService::class.java),
+            MonitorRunnerService,
             actionFilters, xContentRegistry, multiTenancySettings
         )
         val request = ExecuteWorkflowRequest(true, TimeValue(Instant.now().toEpochMilli()), "test-id", null)
@@ -185,8 +208,8 @@ class TransportMultiTenancyBlockTests : OpenSearchTestCase() {
     fun `test index doc-level monitor blocked when multi-tenancy enabled`() {
         val action = TransportIndexMonitorAction(
             transportService, client, actionFilters,
-            Mockito.mock(ScheduledJobIndices::class.java),
-            Mockito.mock(DocLevelMonitorQueries::class.java),
+            scheduledJobIndices,
+            docLevelMonitorQueries,
             clusterService, multiTenancySettings, xContentRegistry,
             Mockito.mock(NamedWriteableRegistry::class.java),
             Mockito.mock(SdkClient::class.java)
@@ -213,8 +236,8 @@ class TransportMultiTenancyBlockTests : OpenSearchTestCase() {
     fun `test index cluster-metrics monitor blocked when multi-tenancy enabled`() {
         val action = TransportIndexMonitorAction(
             transportService, client, actionFilters,
-            Mockito.mock(ScheduledJobIndices::class.java),
-            Mockito.mock(DocLevelMonitorQueries::class.java),
+            scheduledJobIndices,
+            docLevelMonitorQueries,
             clusterService, multiTenancySettings, xContentRegistry,
             Mockito.mock(NamedWriteableRegistry::class.java),
             Mockito.mock(SdkClient::class.java)
@@ -241,8 +264,8 @@ class TransportMultiTenancyBlockTests : OpenSearchTestCase() {
     fun `test index query-level monitor allowed when multi-tenancy enabled`() {
         val action = TransportIndexMonitorAction(
             transportService, client, actionFilters,
-            Mockito.mock(ScheduledJobIndices::class.java),
-            Mockito.mock(DocLevelMonitorQueries::class.java),
+            scheduledJobIndices,
+            docLevelMonitorQueries,
             clusterService, multiTenancySettings, xContentRegistry,
             Mockito.mock(NamedWriteableRegistry::class.java),
             Mockito.mock(SdkClient::class.java)
@@ -275,9 +298,9 @@ class TransportMultiTenancyBlockTests : OpenSearchTestCase() {
     fun `test execute inline doc-level monitor blocked when multi-tenancy enabled`() {
         val action = TransportExecuteMonitorAction(
             transportService, client, clusterService,
-            Mockito.mock(MonitorRunnerService::class.java),
+            MonitorRunnerService,
             actionFilters, xContentRegistry,
-            Mockito.mock(DocLevelMonitorQueries::class.java),
+            docLevelMonitorQueries,
             multiTenancySettings, Mockito.mock(SdkClient::class.java)
         )
         val monitor = Monitor(
@@ -301,19 +324,22 @@ class TransportMultiTenancyBlockTests : OpenSearchTestCase() {
     private fun assertMethodNotAllowed(listener: ActionListener<*>) {
         val captor = org.mockito.ArgumentCaptor.forClass(Exception::class.java)
         verify(listener).onFailure(captor.capture())
-        val cause = (captor.value as? org.opensearch.commons.alerting.util.AlertingException)?.cause
-            ?: captor.value
-        assertTrue(cause is OpenSearchStatusException)
-        assertEquals(RestStatus.METHOD_NOT_ALLOWED, (cause as OpenSearchStatusException).status())
+        val exception = captor.value
+        assertTrue(exception is org.opensearch.commons.alerting.util.AlertingException)
+        assertEquals(
+            RestStatus.METHOD_NOT_ALLOWED,
+            (exception as org.opensearch.commons.alerting.util.AlertingException).status()
+        )
     }
 
     private fun invokeDoExecute(action: Any, request: Any, listener: ActionListener<*>) {
-        val method = action.javaClass.getDeclaredMethod(
-            "doExecute",
-            org.opensearch.tasks.Task::class.java,
-            org.opensearch.action.ActionRequest::class.java,
-            ActionListener::class.java
-        )
+        val methods = action.javaClass.declaredMethods.filter { it.name == "doExecute" }
+        // Prefer the typed override; fall back to ActionRequest-based if only one exists
+        val method = if (methods.size > 1) {
+            methods.first { it.parameterTypes[1] != org.opensearch.action.ActionRequest::class.java }
+        } else {
+            methods.first()
+        }
         method.isAccessible = true
         method.invoke(action, Mockito.mock(org.opensearch.tasks.Task::class.java), request, listener)
     }


### PR DESCRIPTION
### Description
Adds checks within workflow, cluster metrics, and doc level monitor actions to reject the request as unsupported when multi-tenancy is enabled

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
