### PR TITLE
Disable email, findings, and chained alert actions when multi-tenancy…

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeChainedAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeChainedAlertAction.kt
@@ -80,6 +80,8 @@ class TransportAcknowledgeChainedAlertAction @Inject constructor(
     @Volatile
     private var isAlertHistoryEnabled = AlertingSettings.ALERT_HISTORY_ENABLED.get(settings)
 
+    private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
+
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.ALERT_HISTORY_ENABLED) { isAlertHistoryEnabled = it }
     }
@@ -89,6 +91,18 @@ class TransportAcknowledgeChainedAlertAction @Inject constructor(
         AcknowledgeChainedAlertRequest: ActionRequest,
         actionListener: ActionListener<AcknowledgeAlertResponse>,
     ) {
+        if (multiTenancyEnabled) {
+            actionListener.onFailure(
+                AlertingException.wrap(
+                    OpenSearchStatusException(
+                        "Chained alert operations are not allowed when multi-tenancy is enabled.",
+                        RestStatus.METHOD_NOT_ALLOWED
+                    )
+                )
+            )
+            return
+        }
+
         val request = AcknowledgeChainedAlertRequest as? AcknowledgeChainedAlertRequest
             ?: recreateObject(AcknowledgeChainedAlertRequest) { AcknowledgeChainedAlertRequest(it) }
         client.threadPool().threadContext.stashContext().use {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetDestinationsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetDestinationsAction.kt
@@ -6,6 +6,7 @@
 package org.opensearch.alerting.transport
 
 import org.apache.logging.log4j.LogManager
+import org.opensearch.OpenSearchStatusException
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.alerting.AlertingPlugin
@@ -60,6 +61,8 @@ class TransportGetDestinationsAction @Inject constructor(
 
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
 
+    private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
+
     init {
         listenFilterBySettingChange(clusterService)
     }
@@ -69,6 +72,18 @@ class TransportGetDestinationsAction @Inject constructor(
         getDestinationsRequest: GetDestinationsRequest,
         actionListener: ActionListener<GetDestinationsResponse>
     ) {
+        if (multiTenancyEnabled) {
+            actionListener.onFailure(
+                AlertingException.wrap(
+                    OpenSearchStatusException(
+                        "Destination operations are not allowed when multi-tenancy is enabled.",
+                        RestStatus.METHOD_NOT_ALLOWED
+                    )
+                )
+            )
+            return
+        }
+
         val user = readUserFromThreadContext(client)
         val tableProp = getDestinationsRequest.table
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetEmailAccountAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetEmailAccountAction.kt
@@ -15,6 +15,7 @@ import org.opensearch.alerting.action.GetEmailAccountAction
 import org.opensearch.alerting.action.GetEmailAccountRequest
 import org.opensearch.alerting.action.GetEmailAccountResponse
 import org.opensearch.alerting.model.destination.email.EmailAccount
+import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.settings.DestinationSettings.Companion.ALLOW_LIST
 import org.opensearch.alerting.util.DestinationType
 import org.opensearch.alerting.util.use
@@ -48,6 +49,8 @@ class TransportGetEmailAccountAction @Inject constructor(
 
     @Volatile private var allowList = ALLOW_LIST.get(settings)
 
+    private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
+
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(ALLOW_LIST) { allowList = it }
     }
@@ -57,6 +60,18 @@ class TransportGetEmailAccountAction @Inject constructor(
         getEmailAccountRequest: GetEmailAccountRequest,
         actionListener: ActionListener<GetEmailAccountResponse>
     ) {
+
+        if (multiTenancyEnabled) {
+            actionListener.onFailure(
+                AlertingException.wrap(
+                    OpenSearchStatusException(
+                        "Email account operations are not allowed when multi-tenancy is enabled.",
+                        RestStatus.METHOD_NOT_ALLOWED
+                    )
+                )
+            )
+            return
+        }
 
         if (!allowList.contains(DestinationType.EMAIL.value)) {
             actionListener.onFailure(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetEmailGroupAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetEmailGroupAction.kt
@@ -15,6 +15,7 @@ import org.opensearch.alerting.action.GetEmailGroupAction
 import org.opensearch.alerting.action.GetEmailGroupRequest
 import org.opensearch.alerting.action.GetEmailGroupResponse
 import org.opensearch.alerting.model.destination.email.EmailGroup
+import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.settings.DestinationSettings.Companion.ALLOW_LIST
 import org.opensearch.alerting.util.DestinationType
 import org.opensearch.alerting.util.use
@@ -48,6 +49,8 @@ class TransportGetEmailGroupAction @Inject constructor(
 
     @Volatile private var allowList = ALLOW_LIST.get(settings)
 
+    private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
+
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(ALLOW_LIST) { allowList = it }
     }
@@ -57,6 +60,18 @@ class TransportGetEmailGroupAction @Inject constructor(
         getEmailGroupRequest: GetEmailGroupRequest,
         actionListener: ActionListener<GetEmailGroupResponse>
     ) {
+
+        if (multiTenancyEnabled) {
+            actionListener.onFailure(
+                AlertingException.wrap(
+                    OpenSearchStatusException(
+                        "Email group operations are not allowed when multi-tenancy is enabled.",
+                        RestStatus.METHOD_NOT_ALLOWED
+                    )
+                )
+            )
+            return
+        }
 
         if (!allowList.contains(DestinationType.EMAIL.value)) {
             actionListener.onFailure(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetFindingsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetFindingsAction.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.apache.logging.log4j.LogManager
 import org.apache.lucene.search.join.ScoreMode
+import org.opensearch.OpenSearchStatusException
 import org.opensearch.action.ActionRequest
 import org.opensearch.action.get.MultiGetRequest
 import org.opensearch.action.get.MultiGetResponse
@@ -40,6 +41,7 @@ import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.common.Strings
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry
+import org.opensearch.core.rest.RestStatus
 import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.core.xcontent.XContentParser
 import org.opensearch.core.xcontent.XContentParserUtils
@@ -72,6 +74,8 @@ class TransportGetFindingsSearchAction @Inject constructor(
 
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
 
+    private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
+
     init {
         listenFilterBySettingChange(clusterService)
     }
@@ -81,6 +85,18 @@ class TransportGetFindingsSearchAction @Inject constructor(
         request: ActionRequest,
         actionListener: ActionListener<GetFindingsResponse>
     ) {
+        if (multiTenancyEnabled) {
+            actionListener.onFailure(
+                AlertingException.wrap(
+                    OpenSearchStatusException(
+                        "Findings operations are not allowed when multi-tenancy is enabled.",
+                        RestStatus.METHOD_NOT_ALLOWED
+                    )
+                )
+            )
+            return
+        }
+
         val getFindingsRequest = request as? GetFindingsRequest
             ?: recreateObject(request, namedWriteableRegistry) { GetFindingsRequest(it) }
         val tableProp = getFindingsRequest.table

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetRemoteIndexesAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetRemoteIndexesAction.kt
@@ -64,6 +64,8 @@ class TransportGetRemoteIndexesAction @Inject constructor(
 
     @Volatile private var remoteMonitoringEnabled = CROSS_CLUSTER_MONITORING_ENABLED.get(settings)
 
+    private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
+
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(CROSS_CLUSTER_MONITORING_ENABLED) { remoteMonitoringEnabled = it }
         listenFilterBySettingChange(clusterService)
@@ -74,6 +76,18 @@ class TransportGetRemoteIndexesAction @Inject constructor(
         request: GetRemoteIndexesRequest,
         actionListener: ActionListener<GetRemoteIndexesResponse>
     ) {
+        if (multiTenancyEnabled) {
+            actionListener.onFailure(
+                AlertingException.wrap(
+                    OpenSearchStatusException(
+                        "Remote index operations are not allowed when multi-tenancy is enabled.",
+                        RestStatus.METHOD_NOT_ALLOWED
+                    )
+                )
+            )
+            return
+        }
+
         log.debug("Remote monitoring enabled: {}", remoteMonitoringEnabled)
         if (!remoteMonitoringEnabled) {
             actionListener.onFailure(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchEmailAccountAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchEmailAccountAction.kt
@@ -11,6 +11,7 @@ import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.alerting.action.SearchEmailAccountAction
+import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.settings.DestinationSettings.Companion.ALLOW_LIST
 import org.opensearch.alerting.util.DestinationType
 import org.opensearch.alerting.util.use
@@ -36,11 +37,25 @@ class TransportSearchEmailAccountAction @Inject constructor(
 
     @Volatile private var allowList = ALLOW_LIST.get(settings)
 
+    private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
+
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(ALLOW_LIST) { allowList = it }
     }
 
     override fun doExecute(task: Task, searchRequest: SearchRequest, actionListener: ActionListener<SearchResponse>) {
+
+        if (multiTenancyEnabled) {
+            actionListener.onFailure(
+                AlertingException.wrap(
+                    OpenSearchStatusException(
+                        "Email account operations are not allowed when multi-tenancy is enabled.",
+                        RestStatus.METHOD_NOT_ALLOWED
+                    )
+                )
+            )
+            return
+        }
 
         if (!allowList.contains(DestinationType.EMAIL.value)) {
             actionListener.onFailure(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchEmailGroupAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchEmailGroupAction.kt
@@ -11,6 +11,7 @@ import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.alerting.action.SearchEmailGroupAction
+import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.settings.DestinationSettings.Companion.ALLOW_LIST
 import org.opensearch.alerting.util.DestinationType
 import org.opensearch.alerting.util.use
@@ -36,11 +37,25 @@ class TransportSearchEmailGroupAction @Inject constructor(
 
     @Volatile private var allowList = ALLOW_LIST.get(settings)
 
+    private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
+
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(ALLOW_LIST) { allowList = it }
     }
 
     override fun doExecute(task: Task, searchRequest: SearchRequest, actionListener: ActionListener<SearchResponse>) {
+
+        if (multiTenancyEnabled) {
+            actionListener.onFailure(
+                AlertingException.wrap(
+                    OpenSearchStatusException(
+                        "Email group operations are not allowed when multi-tenancy is enabled.",
+                        RestStatus.METHOD_NOT_ALLOWED
+                    )
+                )
+            )
+            return
+        }
 
         if (!allowList.contains(DestinationType.EMAIL.value)) {
             actionListener.onFailure(

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/MultiTenancyBlockSingleNodeTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/MultiTenancyBlockSingleNodeTests.kt
@@ -6,11 +6,22 @@
 package org.opensearch.alerting.transport
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope
+import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.support.WriteRequest
 import org.opensearch.alerting.action.ExecuteMonitorAction
 import org.opensearch.alerting.action.ExecuteMonitorRequest
 import org.opensearch.alerting.action.ExecuteWorkflowAction
 import org.opensearch.alerting.action.ExecuteWorkflowRequest
+import org.opensearch.alerting.action.GetDestinationsAction
+import org.opensearch.alerting.action.GetDestinationsRequest
+import org.opensearch.alerting.action.GetEmailAccountAction
+import org.opensearch.alerting.action.GetEmailAccountRequest
+import org.opensearch.alerting.action.GetEmailGroupAction
+import org.opensearch.alerting.action.GetEmailGroupRequest
+import org.opensearch.alerting.action.GetRemoteIndexesAction
+import org.opensearch.alerting.action.GetRemoteIndexesRequest
+import org.opensearch.alerting.action.SearchEmailAccountAction
+import org.opensearch.alerting.action.SearchEmailGroupAction
 import org.opensearch.alerting.randomClusterMetricsMonitor
 import org.opensearch.alerting.randomDocumentLevelMonitor
 import org.opensearch.common.settings.Settings
@@ -120,6 +131,84 @@ class MultiTenancyBlockSingleNodeTests : AlertingSingleNodeTestCase() {
         val exception = expectThrows(Exception::class.java) {
             val request = ExecuteMonitorRequest(true, TimeValue(Instant.now().toEpochMilli()), null, randomDocumentLevelMonitor())
             client().execute(ExecuteMonitorAction.INSTANCE, request).actionGet()
+        }
+        assertTrue(exception.message!!.contains("not allowed when multi-tenancy is enabled"))
+    }
+
+    // --- Notification-related action tests ---
+
+    fun `test search email account fails when multi-tenancy is enabled`() {
+        val exception = expectThrows(Exception::class.java) {
+            client().execute(SearchEmailAccountAction.INSTANCE, SearchRequest()).actionGet()
+        }
+        assertTrue(exception.message!!.contains("not allowed when multi-tenancy is enabled"))
+    }
+
+    fun `test get email account fails when multi-tenancy is enabled`() {
+        val exception = expectThrows(Exception::class.java) {
+            client().execute(
+                GetEmailAccountAction.INSTANCE,
+                GetEmailAccountRequest("test-id", 1L, RestRequest.Method.GET, null)
+            ).actionGet()
+        }
+        assertTrue(exception.message!!.contains("not allowed when multi-tenancy is enabled"))
+    }
+
+    fun `test search email group fails when multi-tenancy is enabled`() {
+        val exception = expectThrows(Exception::class.java) {
+            client().execute(SearchEmailGroupAction.INSTANCE, SearchRequest()).actionGet()
+        }
+        assertTrue(exception.message!!.contains("not allowed when multi-tenancy is enabled"))
+    }
+
+    fun `test get email group fails when multi-tenancy is enabled`() {
+        val exception = expectThrows(Exception::class.java) {
+            client().execute(
+                GetEmailGroupAction.INSTANCE,
+                GetEmailGroupRequest("test-id", 1L, RestRequest.Method.GET, null)
+            ).actionGet()
+        }
+        assertTrue(exception.message!!.contains("not allowed when multi-tenancy is enabled"))
+    }
+
+    fun `test get destinations fails when multi-tenancy is enabled`() {
+        val exception = expectThrows(Exception::class.java) {
+            client().execute(
+                GetDestinationsAction.INSTANCE,
+                GetDestinationsRequest(null, 1L, null, Table("asc", "destination.name", null, 20, 0, null), "ALL")
+            ).actionGet()
+        }
+        assertTrue(exception.message!!.contains("not allowed when multi-tenancy is enabled"))
+    }
+
+    // --- Additional blocked action tests ---
+
+    fun `test acknowledge chained alerts fails when multi-tenancy is enabled`() {
+        val exception = expectThrows(Exception::class.java) {
+            client().execute(
+                AlertingActions.ACKNOWLEDGE_CHAINED_ALERTS_ACTION_TYPE,
+                org.opensearch.commons.alerting.action.AcknowledgeChainedAlertRequest("test-wf-id", listOf("alert-1"))
+            ).actionGet()
+        }
+        assertTrue(exception.message!!.contains("not allowed when multi-tenancy is enabled"))
+    }
+
+    fun `test get findings fails when multi-tenancy is enabled`() {
+        val exception = expectThrows(Exception::class.java) {
+            client().execute(
+                AlertingActions.GET_FINDINGS_ACTION_TYPE,
+                org.opensearch.commons.alerting.action.GetFindingsRequest(null, Table("asc", "timestamp", null, 20, 0, null), null, null, null)
+            ).actionGet()
+        }
+        assertTrue(exception.message!!.contains("not allowed when multi-tenancy is enabled"))
+    }
+
+    fun `test get remote indexes fails when multi-tenancy is enabled`() {
+        val exception = expectThrows(Exception::class.java) {
+            client().execute(
+                GetRemoteIndexesAction.INSTANCE,
+                GetRemoteIndexesRequest(listOf("cluster:index*"), false)
+            ).actionGet()
         }
         assertTrue(exception.message!!.contains("not allowed when multi-tenancy is enabled"))
     }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/MultiTenancyBlockSingleNodeTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/MultiTenancyBlockSingleNodeTests.kt
@@ -197,7 +197,10 @@ class MultiTenancyBlockSingleNodeTests : AlertingSingleNodeTestCase() {
         val exception = expectThrows(Exception::class.java) {
             client().execute(
                 AlertingActions.GET_FINDINGS_ACTION_TYPE,
-                org.opensearch.commons.alerting.action.GetFindingsRequest(null, Table("asc", "timestamp", null, 20, 0, null), null, null, null)
+                org.opensearch.commons.alerting.action.GetFindingsRequest(
+                    null, Table("asc", "timestamp", null, 20, 0, null),
+                    null, null, null
+                )
             ).actionGet()
         }
         assertTrue(exception.message!!.contains("not allowed when multi-tenancy is enabled"))

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportMultiTenancyBlockTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportMultiTenancyBlockTests.kt
@@ -9,12 +9,22 @@ import org.junit.Before
 import org.mockito.Mockito
 import org.mockito.Mockito.verify
 import org.opensearch.OpenSearchStatusException
+import org.opensearch.action.search.SearchRequest
+import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.alerting.MonitorRunnerService
 import org.opensearch.alerting.action.ExecuteMonitorRequest
 import org.opensearch.alerting.action.ExecuteMonitorResponse
 import org.opensearch.alerting.action.ExecuteWorkflowRequest
 import org.opensearch.alerting.action.ExecuteWorkflowResponse
+import org.opensearch.alerting.action.GetDestinationsRequest
+import org.opensearch.alerting.action.GetDestinationsResponse
+import org.opensearch.alerting.action.GetEmailAccountRequest
+import org.opensearch.alerting.action.GetEmailAccountResponse
+import org.opensearch.alerting.action.GetEmailGroupRequest
+import org.opensearch.alerting.action.GetEmailGroupResponse
+import org.opensearch.alerting.action.GetRemoteIndexesRequest
+import org.opensearch.alerting.action.GetRemoteIndexesResponse
 import org.opensearch.alerting.core.ScheduledJobIndices
 import org.opensearch.alerting.core.lock.LockService
 import org.opensearch.alerting.settings.AlertingSettings
@@ -100,6 +110,7 @@ class TransportMultiTenancyBlockTests : OpenSearchTestCase() {
         settingSet.add(AlertingSettings.INDEX_TIMEOUT)
         settingSet.add(AlertingSettings.MAX_ACTION_THROTTLE_VALUE)
         settingSet.add(DestinationSettings.ALLOW_LIST)
+        settingSet.add(AlertingSettings.CROSS_CLUSTER_MONITORING_ENABLED)
         val clusterSettings = ClusterSettings(multiTenancySettings, settingSet)
         whenever(clusterService.clusterSettings).thenReturn(clusterSettings)
 
@@ -313,6 +324,127 @@ class TransportMultiTenancyBlockTests : OpenSearchTestCase() {
         val request = ExecuteMonitorRequest(true, TimeValue(Instant.now().toEpochMilli()), null, monitor)
         @Suppress("UNCHECKED_CAST")
         val listener = Mockito.mock(ActionListener::class.java) as ActionListener<ExecuteMonitorResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        assertMethodNotAllowed(listener)
+    }
+
+    // --- Notification-related action tests ---
+
+    fun `test search email account blocked when multi-tenancy enabled`() {
+        val action = TransportSearchEmailAccountAction(
+            transportService, client, actionFilters, clusterService, multiTenancySettings
+        )
+        val request = SearchRequest()
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<SearchResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        assertMethodNotAllowed(listener)
+    }
+
+    fun `test get email account blocked when multi-tenancy enabled`() {
+        val action = TransportGetEmailAccountAction(
+            transportService, client, actionFilters, clusterService, multiTenancySettings, xContentRegistry
+        )
+        val request = GetEmailAccountRequest("test-id", 1L, RestRequest.Method.GET, null)
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<GetEmailAccountResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        assertMethodNotAllowed(listener)
+    }
+
+    fun `test search email group blocked when multi-tenancy enabled`() {
+        val action = TransportSearchEmailGroupAction(
+            transportService, client, actionFilters, clusterService, multiTenancySettings
+        )
+        val request = SearchRequest()
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<SearchResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        assertMethodNotAllowed(listener)
+    }
+
+    fun `test get email group blocked when multi-tenancy enabled`() {
+        val action = TransportGetEmailGroupAction(
+            transportService, client, actionFilters, clusterService, multiTenancySettings, xContentRegistry
+        )
+        val request = GetEmailGroupRequest("test-id", 1L, RestRequest.Method.GET, null)
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<GetEmailGroupResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        assertMethodNotAllowed(listener)
+    }
+
+    fun `test get destinations blocked when multi-tenancy enabled`() {
+        val action = TransportGetDestinationsAction(
+            transportService, client, clusterService, actionFilters,
+            multiTenancySettings, xContentRegistry,
+            Mockito.mock(SdkClient::class.java)
+        )
+        val request = GetDestinationsRequest(
+            null, 1L, null,
+            Table("asc", "destination.name", null, 20, 0, null),
+            "ALL"
+        )
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<GetDestinationsResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        assertMethodNotAllowed(listener)
+    }
+
+    // --- Additional blocked action tests ---
+
+    fun `test acknowledge chained alerts blocked when multi-tenancy enabled`() {
+        val action = TransportAcknowledgeChainedAlertAction(
+            transportService, client, clusterService, actionFilters,
+            multiTenancySettings, xContentRegistry,
+            Mockito.mock(SdkClient::class.java)
+        )
+        val request = org.opensearch.commons.alerting.action.AcknowledgeChainedAlertRequest("test-wf-id", listOf("alert-1"))
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<org.opensearch.commons.alerting.action.AcknowledgeAlertResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        assertMethodNotAllowed(listener)
+    }
+
+    fun `test get findings blocked when multi-tenancy enabled`() {
+        val action = TransportGetFindingsSearchAction(
+            transportService, client, clusterService, actionFilters,
+            multiTenancySettings, xContentRegistry,
+            Mockito.mock(NamedWriteableRegistry::class.java)
+        )
+        val request = org.opensearch.commons.alerting.action.GetFindingsRequest(
+            null, Table("asc", "timestamp", null, 20, 0, null), null, null, null
+        )
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<org.opensearch.commons.alerting.action.GetFindingsResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        assertMethodNotAllowed(listener)
+    }
+
+    fun `test get remote indexes blocked when multi-tenancy enabled`() {
+        val action = TransportGetRemoteIndexesAction(
+            transportService, client, actionFilters, xContentRegistry,
+            clusterService, multiTenancySettings
+        )
+        val request = GetRemoteIndexesRequest(listOf("cluster:index*"), false)
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<GetRemoteIndexesResponse>
 
         invokeDoExecute(action, request, listener)
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportMultiTenancyBlockTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportMultiTenancyBlockTests.kt
@@ -36,8 +36,12 @@ import org.opensearch.common.settings.Setting
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.util.concurrent.ThreadContext
+import org.opensearch.commons.alerting.action.AcknowledgeAlertResponse
+import org.opensearch.commons.alerting.action.AcknowledgeChainedAlertRequest
 import org.opensearch.commons.alerting.action.DeleteWorkflowRequest
 import org.opensearch.commons.alerting.action.DeleteWorkflowResponse
+import org.opensearch.commons.alerting.action.GetFindingsRequest
+import org.opensearch.commons.alerting.action.GetFindingsResponse
 import org.opensearch.commons.alerting.action.GetWorkflowAlertsRequest
 import org.opensearch.commons.alerting.action.GetWorkflowAlertsResponse
 import org.opensearch.commons.alerting.action.GetWorkflowRequest
@@ -411,9 +415,10 @@ class TransportMultiTenancyBlockTests : OpenSearchTestCase() {
             multiTenancySettings, xContentRegistry,
             Mockito.mock(SdkClient::class.java)
         )
-        val request = org.opensearch.commons.alerting.action.AcknowledgeChainedAlertRequest("test-wf-id", listOf("alert-1"))
+        val request = AcknowledgeChainedAlertRequest("test-wf-id", listOf("alert-1"))
         @Suppress("UNCHECKED_CAST")
-        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<org.opensearch.commons.alerting.action.AcknowledgeAlertResponse>
+        val listener = Mockito.mock(ActionListener::class.java)
+            as ActionListener<AcknowledgeAlertResponse>
 
         invokeDoExecute(action, request, listener)
 
@@ -426,11 +431,13 @@ class TransportMultiTenancyBlockTests : OpenSearchTestCase() {
             multiTenancySettings, xContentRegistry,
             Mockito.mock(NamedWriteableRegistry::class.java)
         )
-        val request = org.opensearch.commons.alerting.action.GetFindingsRequest(
-            null, Table("asc", "timestamp", null, 20, 0, null), null, null, null
+        val request = GetFindingsRequest(
+            null, Table("asc", "timestamp", null, 20, 0, null),
+            null, null, null
         )
         @Suppress("UNCHECKED_CAST")
-        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<org.opensearch.commons.alerting.action.GetFindingsResponse>
+        val listener = Mockito.mock(ActionListener::class.java)
+            as ActionListener<GetFindingsResponse>
 
         invokeDoExecute(action, request, listener)
 


### PR DESCRIPTION
… is enabled

### Description
Disables more actions that are not supported when multi-tenancy is enabled

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
