### PR TITLE
feat: Add MonitorJobPoller, ExternalSchedulerService, and SQS-based external monitor scheduling

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -179,6 +179,16 @@ dependencies {
 
     implementation "org.opensearch:opensearch-remote-metadata-sdk:${opensearch_build}"
 
+    implementation "software.amazon.awssdk:sqs:2.30.18"
+    implementation "software.amazon.awssdk:scheduler:2.30.18"
+    implementation "software.amazon.awssdk:sts:2.30.18"
+    implementation "software.amazon.awssdk:auth:2.30.18"
+    implementation "software.amazon.awssdk:identity-spi:2.30.18"
+    implementation "software.amazon.awssdk:aws-core:2.30.18"
+    implementation "software.amazon.awssdk:sdk-core:2.30.18"
+    implementation "software.amazon.awssdk:utils:2.30.18"
+    implementation "software.amazon.awssdk:regions:2.30.18"
+
     testImplementation "org.antlr:antlr4-runtime:${versions.antlr4}"
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
     testImplementation "org.mockito:mockito-core:${versions.mockito}"

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -382,8 +382,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             AlertingSettings.JOB_QUEUE_NAME.get(settings) ?: ""
         )
 
-        ExternalSchedulerService.region = REMOTE_METADATA_REGION.get(settings)
-        ExternalSchedulerService.messageGroupKeyName = AlertingSettings.JOB_QUEUE_MESSAGE_GROUP_KEY_NAME.get(settings) ?: ""
+        ExternalSchedulerService.initialize(settings)
 
         return listOf(
             sweeper,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -53,6 +53,8 @@ import org.opensearch.alerting.resthandler.RestSearchEmailGroupAction
 import org.opensearch.alerting.resthandler.RestSearchMonitorAction
 import org.opensearch.alerting.script.TriggerScript
 import org.opensearch.alerting.service.DeleteMonitorService
+import org.opensearch.alerting.service.ExternalSchedulerService
+import org.opensearch.alerting.service.MonitorJobPoller
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.settings.AlertingSettings.Companion.DOC_LEVEL_MONITOR_SHARD_FETCH_SIZE
 import org.opensearch.alerting.settings.AlertingSettings.Companion.MULTI_TENANCY_ENABLED
@@ -114,6 +116,7 @@ import org.opensearch.commons.alerting.model.ScheduledJob.Companion.SCHEDULED_JO
 import org.opensearch.commons.alerting.model.SearchInput
 import org.opensearch.commons.alerting.model.Workflow
 import org.opensearch.commons.alerting.model.remote.monitors.RemoteMonitorTrigger
+import org.opensearch.commons.utils.scheduler.JobQueueAccountIdProvider
 import org.opensearch.core.action.ActionResponse
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry
 import org.opensearch.core.common.io.stream.StreamInput
@@ -369,6 +372,19 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
 
         DeleteMonitorService.initialize(client, lockService)
 
+        val providerType = AlertingSettings.JOB_QUEUE_ACCOUNT_PROVIDER_TYPE.get(settings)
+        val monitorJobPoller = MonitorJobPoller(
+            xContentRegistry,
+            client,
+            MULTI_TENANCY_ENABLED.get(settings),
+            if (providerType.isNotEmpty()) JobQueueAccountIdProvider.find(providerType, settings) else null,
+            REMOTE_METADATA_REGION.get(settings) ?: "",
+            AlertingSettings.JOB_QUEUE_NAME.get(settings) ?: ""
+        )
+
+        ExternalSchedulerService.region = REMOTE_METADATA_REGION.get(settings)
+        ExternalSchedulerService.messageGroupKeyName = AlertingSettings.JOB_QUEUE_MESSAGE_GROUP_KEY_NAME.get(settings) ?: ""
+
         return listOf(
             sweeper,
             scheduler,
@@ -380,7 +396,8 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             lockService,
             alertService,
             triggerService,
-            sdkClient
+            sdkClient,
+            monitorJobPoller
         )
     }
 
@@ -471,7 +488,8 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             AlertingSettings.MULTI_TENANT_TRIGGER_EVAL_ENABLED,
             AlertingSettings.EXTERNAL_SCHEDULER_ENABLED,
             AlertingSettings.EXTERNAL_SCHEDULER_ACCOUNT_ID,
-            AlertingSettings.EXTERNAL_SCHEDULER_QUEUE_ARN,
+            AlertingSettings.JOB_QUEUE_NAME,
+            AlertingSettings.JOB_QUEUE_MESSAGE_GROUP_KEY_NAME,
             AlertingSettings.EXTERNAL_SCHEDULER_ROLE_ARN,
             AlertingSettings.JOB_QUEUE_ACCOUNT_ID,
             AlertingSettings.JOB_QUEUE_ACCOUNT_PROVIDER_TYPE

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/AssumeRoleCredentialsCache.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/AssumeRoleCredentialsCache.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.service
+
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.awssdk.services.sts.StsClient
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Caches [AwsCredentialsProvider] instances per account ID, using
+ * [StsAssumeRoleCredentialsProvider] for automatic credential refresh on expiry.
+ */
+class AssumeRoleCredentialsCache(
+    private val stsClient: StsClient,
+    private val roleArnFormat: String,
+    private val sessionPrefix: String = "alerting"
+) {
+    private val cache = ConcurrentHashMap<String, AwsCredentialsProvider>()
+
+    fun getCredentialsProvider(accountId: String): AwsCredentialsProvider {
+        return cache.computeIfAbsent(accountId) {
+            StsAssumeRoleCredentialsProvider.builder()
+                .stsClient(stsClient)
+                .refreshRequest(
+                    AssumeRoleRequest.builder()
+                        .roleArn(String.format(roleArnFormat, accountId))
+                        .roleSessionName("$sessionPrefix-$accountId")
+                        .build()
+                )
+                .build()
+        }
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/ExternalSchedulerService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/ExternalSchedulerService.kt
@@ -8,12 +8,27 @@ package org.opensearch.alerting.service
 import org.apache.logging.log4j.LogManager
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.util.ScheduleTranslator
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.scheduler.SchedulerClient
+import software.amazon.awssdk.services.scheduler.model.ActionAfterCompletion
+import software.amazon.awssdk.services.scheduler.model.FlexibleTimeWindow
+import software.amazon.awssdk.services.scheduler.model.FlexibleTimeWindowMode
+import software.amazon.awssdk.services.scheduler.model.ResourceNotFoundException
+import software.amazon.awssdk.services.scheduler.model.ScheduleState
+import software.amazon.awssdk.services.scheduler.model.Target
+import software.amazon.awssdk.services.sts.StsClient
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest
 
 /**
  * Manages external EventBridge schedules for monitor execution.
  *
  * Called from TransportIndexMonitorAction (create/update) and
  * TransportDeleteMonitorAction (delete) during monitor CRUD.
+ *
+ * [stsClient] must be set before any schedule operations are invoked.
+ * It is not created in the open-source plugin — the closed-source layer injects it.
  */
 object ExternalSchedulerService {
 
@@ -26,10 +41,18 @@ object ExternalSchedulerService {
 
     /**
      * Transient ThreadContext key used to override the default `account_id` plugin setting
-     * on a per-request basis. Other routing fields (queue_arn, role_arn) come from plugin
+     * on a per-request basis. Other routing fields (queue_name, role_arn) come from plugin
      * settings only and are not overridable via ThreadContext.
      */
-    const val SCHEDULER_ACCOUNT_ID_KEY = "scheduler.account_id"
+    const val SCHEDULER_ACCOUNT_ID_KEY = "x-scheduler-account-id"
+
+    @Volatile
+    var stsClient: StsClient? = null
+
+    @Volatile
+    var region: String? = null
+
+    var messageGroupKeyName: String = ""
 
     fun scheduleName(monitorId: String): String = "$SCHEDULE_NAME_PREFIX$monitorId"
 
@@ -38,12 +61,24 @@ object ExternalSchedulerService {
      */
     fun createSchedule(monitor: Monitor, routing: SchedulerRoutingResolver.Routing, targetInput: String) {
         val (scheduleExpression, timezone) = ScheduleTranslator.toEventBridgeExpression(monitor.schedule)
+        val name = scheduleName(monitor.id)
+        val queueUrl = buildQueueUrl(routing)
         log.info(
-            "Creating EB schedule ${scheduleName(monitor.id)} in account ${routing.accountId} " +
+            "Creating EB schedule $name in account ${routing.accountId} " +
                 "expr=$scheduleExpression tz=$timezone enabled=${monitor.enabled} " +
-                "queue=${routing.queueArn} role=${routing.roleArn} inputBytes=${targetInput.length}"
+                "queue=$queueUrl role=${routing.roleArn} inputBytes=${targetInput.length}"
         )
-        // TODO: SchedulerClient.createSchedule() with AssumeRole into scheduler account
+        withSchedulerClient(routing) { client ->
+            client.createSchedule {
+                it.name(name)
+                    .scheduleExpression(scheduleExpression)
+                    .scheduleExpressionTimezone(timezone?.toString() ?: "UTC")
+                    .state(if (monitor.enabled) ScheduleState.ENABLED else ScheduleState.DISABLED)
+                    .actionAfterCompletion(ActionAfterCompletion.NONE)
+                    .flexibleTimeWindow(FlexibleTimeWindow.builder().mode(FlexibleTimeWindowMode.OFF).build())
+                    .target(buildTarget(queueUrl, routing, targetInput, monitor))
+            }
+        }
     }
 
     /**
@@ -51,22 +86,105 @@ object ExternalSchedulerService {
      */
     fun updateSchedule(monitor: Monitor, routing: SchedulerRoutingResolver.Routing, targetInput: String) {
         val (scheduleExpression, timezone) = ScheduleTranslator.toEventBridgeExpression(monitor.schedule)
+        val name = scheduleName(monitor.id)
+        val queueUrl = buildQueueUrl(routing)
         log.info(
-            "Updating EB schedule ${scheduleName(monitor.id)} in account ${routing.accountId} " +
+            "Updating EB schedule $name in account ${routing.accountId} " +
                 "expr=$scheduleExpression tz=$timezone enabled=${monitor.enabled} " +
-                "queue=${routing.queueArn} role=${routing.roleArn} inputBytes=${targetInput.length}"
+                "queue=$queueUrl role=${routing.roleArn} inputBytes=${targetInput.length}"
         )
-        // TODO: SchedulerClient.updateSchedule() with AssumeRole into scheduler account
+        withSchedulerClient(routing) { client ->
+            client.updateSchedule {
+                it.name(name)
+                    .scheduleExpression(scheduleExpression)
+                    .scheduleExpressionTimezone(timezone?.toString() ?: "UTC")
+                    .state(if (monitor.enabled) ScheduleState.ENABLED else ScheduleState.DISABLED)
+                    .actionAfterCompletion(ActionAfterCompletion.NONE)
+                    .flexibleTimeWindow(FlexibleTimeWindow.builder().mode(FlexibleTimeWindowMode.OFF).build())
+                    .target(buildTarget(queueUrl, routing, targetInput, monitor))
+            }
+        }
     }
 
     /**
      * Deletes an EventBridge schedule. Idempotent — if not found, proceeds silently.
      */
     fun deleteSchedule(monitorId: String, routing: SchedulerRoutingResolver.Routing) {
-        log.info(
-            "Deleting EB schedule ${scheduleName(monitorId)} from account ${routing.accountId} " +
-                "role=${routing.roleArn}"
+        val name = scheduleName(monitorId)
+        log.info("Deleting EB schedule $name from account ${routing.accountId} role=${routing.roleArn}")
+        withSchedulerClient(routing) { client ->
+            try {
+                client.deleteSchedule { it.name(name) }
+            } catch (e: ResourceNotFoundException) {
+                log.info("Schedule $name not found in account ${routing.accountId}, nothing to delete")
+            }
+        }
+    }
+
+    /** Universal target ARN for SQS SendMessage via EventBridge Scheduler. */
+    const val SQS_SEND_MESSAGE_ARN = "arn:aws:scheduler:::aws-sdk:sqs:sendMessage"
+
+    private fun buildTarget(
+        queueUrl: String,
+        routing: SchedulerRoutingResolver.Routing,
+        targetInput: String,
+        monitor: Monitor
+    ): Target {
+        val universalInput = buildUniversalInput(queueUrl, targetInput, monitor)
+        return Target.builder()
+            .arn(SQS_SEND_MESSAGE_ARN)
+            .roleArn(routing.roleArn)
+            .input(universalInput)
+            .build()
+    }
+
+    /**
+     * Builds the Input JSON for the universal target `sqs:sendMessage`.
+     * Includes MessageGroupId from monitor metadata when configured, enabling
+     * SQS fair queuing on standard queues.
+     */
+    private fun buildUniversalInput(queueUrl: String, messageBody: String, monitor: Monitor): String {
+        val escaped = messageBody.replace("\\", "\\\\").replace("\"", "\\\"")
+        val sb = StringBuilder()
+        sb.append("{\"QueueUrl\":\"").append(queueUrl).append("\",")
+        sb.append("\"MessageBody\":\"").append(escaped).append("\"")
+        val keyName = messageGroupKeyName
+        if (keyName.isNotEmpty()) {
+            val groupId = monitor.metadata?.get(keyName)
+            if (!groupId.isNullOrEmpty()) {
+                sb.append(",\"MessageGroupId\":\"").append(groupId).append("\"")
+            }
+        }
+        sb.append("}")
+        return sb.toString()
+    }
+    private fun buildQueueUrl(routing: SchedulerRoutingResolver.Routing): String {
+        val resolvedRegion = requireNotNull(region) { "region must be set" }
+        return "https://sqs.$resolvedRegion.amazonaws.com/${routing.accountId}/${routing.queueName}"
+    }
+
+    private fun <T> withSchedulerClient(routing: SchedulerRoutingResolver.Routing, block: (SchedulerClient) -> T): T {
+        val sts = requireNotNull(stsClient) { "stsClient must be set before invoking schedule operations" }
+        val resolvedRegion = requireNotNull(region) { "region must be set" }
+        val assumeRoleResponse = sts.assumeRole(
+            AssumeRoleRequest.builder()
+                .roleArn(routing.roleArn)
+                .roleSessionName("alerting-scheduler-${routing.accountId}")
+                .build()
         )
-        // TODO: SchedulerClient.deleteSchedule() with AssumeRole into scheduler account
+        val credentials = assumeRoleResponse.credentials()
+        val schedulerClient = SchedulerClient.builder()
+            .region(Region.of(resolvedRegion))
+            .credentialsProvider(
+                StaticCredentialsProvider.create(
+                    AwsSessionCredentials.create(
+                        credentials.accessKeyId(),
+                        credentials.secretAccessKey(),
+                        credentials.sessionToken()
+                    )
+                )
+            )
+            .build()
+        return schedulerClient.use(block)
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/ExternalSchedulerService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/ExternalSchedulerService.kt
@@ -6,10 +6,11 @@
 package org.opensearch.alerting.service
 
 import org.apache.logging.log4j.LogManager
+import org.opensearch.alerting.settings.AlertingSettings
+import org.opensearch.alerting.settings.AlertingSettings.Companion.REMOTE_METADATA_REGION
+import org.opensearch.common.settings.Settings
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.util.ScheduleTranslator
-import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.scheduler.SchedulerClient
 import software.amazon.awssdk.services.scheduler.model.ActionAfterCompletion
@@ -18,8 +19,7 @@ import software.amazon.awssdk.services.scheduler.model.FlexibleTimeWindowMode
 import software.amazon.awssdk.services.scheduler.model.ResourceNotFoundException
 import software.amazon.awssdk.services.scheduler.model.ScheduleState
 import software.amazon.awssdk.services.scheduler.model.Target
-import software.amazon.awssdk.services.sts.StsClient
-import software.amazon.awssdk.services.sts.model.AssumeRoleRequest
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Manages external EventBridge schedules for monitor execution.
@@ -27,8 +27,7 @@ import software.amazon.awssdk.services.sts.model.AssumeRoleRequest
  * Called from TransportIndexMonitorAction (create/update) and
  * TransportDeleteMonitorAction (delete) during monitor CRUD.
  *
- * [stsClient] must be set before any schedule operations are invoked.
- * It is not created in the open-source plugin — the closed-source layer injects it.
+ * [credentialsCache] must be set before any schedule operations are invoked.
  */
 object ExternalSchedulerService {
 
@@ -47,12 +46,17 @@ object ExternalSchedulerService {
     const val SCHEDULER_ACCOUNT_ID_KEY = "x-scheduler-account-id"
 
     @Volatile
-    var stsClient: StsClient? = null
+    var credentialsCache: AssumeRoleCredentialsCache? = null
 
-    @Volatile
-    var region: String? = null
+    private var region: String? = null
+    private var messageGroupKeyName: String = ""
 
-    var messageGroupKeyName: String = ""
+    private val schedulerClients = ConcurrentHashMap<String, SchedulerClient>()
+
+    fun initialize(settings: Settings) {
+        region = AlertingSettings.REMOTE_METADATA_REGION.get(settings)
+        messageGroupKeyName = AlertingSettings.JOB_QUEUE_MESSAGE_GROUP_KEY_NAME.get(settings) ?: ""
+    }
 
     fun scheduleName(monitorId: String): String = "$SCHEDULE_NAME_PREFIX$monitorId"
 
@@ -68,16 +72,15 @@ object ExternalSchedulerService {
                 "expr=$scheduleExpression tz=$timezone enabled=${monitor.enabled} " +
                 "queue=$queueUrl role=${routing.roleArn} inputBytes=${targetInput.length}"
         )
-        withSchedulerClient(routing) { client ->
-            client.createSchedule {
-                it.name(name)
-                    .scheduleExpression(scheduleExpression)
-                    .scheduleExpressionTimezone(timezone?.toString() ?: "UTC")
-                    .state(if (monitor.enabled) ScheduleState.ENABLED else ScheduleState.DISABLED)
-                    .actionAfterCompletion(ActionAfterCompletion.NONE)
-                    .flexibleTimeWindow(FlexibleTimeWindow.builder().mode(FlexibleTimeWindowMode.OFF).build())
-                    .target(buildTarget(queueUrl, routing, targetInput, monitor))
-            }
+        val client = getSchedulerClient(routing)
+        client.createSchedule {
+            it.name(name)
+                .scheduleExpression(scheduleExpression)
+                .scheduleExpressionTimezone(timezone?.toString() ?: "UTC")
+                .state(if (monitor.enabled) ScheduleState.ENABLED else ScheduleState.DISABLED)
+                .actionAfterCompletion(ActionAfterCompletion.NONE)
+                .flexibleTimeWindow(FlexibleTimeWindow.builder().mode(FlexibleTimeWindowMode.OFF).build())
+                .target(buildTarget(queueUrl, routing, targetInput, monitor))
         }
     }
 
@@ -93,16 +96,15 @@ object ExternalSchedulerService {
                 "expr=$scheduleExpression tz=$timezone enabled=${monitor.enabled} " +
                 "queue=$queueUrl role=${routing.roleArn} inputBytes=${targetInput.length}"
         )
-        withSchedulerClient(routing) { client ->
-            client.updateSchedule {
-                it.name(name)
-                    .scheduleExpression(scheduleExpression)
-                    .scheduleExpressionTimezone(timezone?.toString() ?: "UTC")
-                    .state(if (monitor.enabled) ScheduleState.ENABLED else ScheduleState.DISABLED)
-                    .actionAfterCompletion(ActionAfterCompletion.NONE)
-                    .flexibleTimeWindow(FlexibleTimeWindow.builder().mode(FlexibleTimeWindowMode.OFF).build())
-                    .target(buildTarget(queueUrl, routing, targetInput, monitor))
-            }
+        val client = getSchedulerClient(routing)
+        client.updateSchedule {
+            it.name(name)
+                .scheduleExpression(scheduleExpression)
+                .scheduleExpressionTimezone(timezone?.toString() ?: "UTC")
+                .state(if (monitor.enabled) ScheduleState.ENABLED else ScheduleState.DISABLED)
+                .actionAfterCompletion(ActionAfterCompletion.NONE)
+                .flexibleTimeWindow(FlexibleTimeWindow.builder().mode(FlexibleTimeWindowMode.OFF).build())
+                .target(buildTarget(queueUrl, routing, targetInput, monitor))
         }
     }
 
@@ -112,17 +114,16 @@ object ExternalSchedulerService {
     fun deleteSchedule(monitorId: String, routing: SchedulerRoutingResolver.Routing) {
         val name = scheduleName(monitorId)
         log.info("Deleting EB schedule $name from account ${routing.accountId} role=${routing.roleArn}")
-        withSchedulerClient(routing) { client ->
-            try {
-                client.deleteSchedule { it.name(name) }
-            } catch (e: ResourceNotFoundException) {
-                log.info("Schedule $name not found in account ${routing.accountId}, nothing to delete")
-            }
+        val client = getSchedulerClient(routing)
+        try {
+            client.deleteSchedule { it.name(name) }
+        } catch (e: ResourceNotFoundException) {
+            log.info("Schedule $name not found in account ${routing.accountId}, nothing to delete")
         }
     }
 
     /** Universal target ARN for SQS SendMessage via EventBridge Scheduler. */
-    const val SQS_SEND_MESSAGE_ARN = "arn:aws:scheduler:::aws-sdk:sqs:sendMessage"
+    const val EB_SQS_UNIVERSAL_TARGET_ARN = "arn:aws:scheduler:::aws-sdk:sqs:sendMessage"
 
     private fun buildTarget(
         queueUrl: String,
@@ -132,7 +133,7 @@ object ExternalSchedulerService {
     ): Target {
         val universalInput = buildUniversalInput(queueUrl, targetInput, monitor)
         return Target.builder()
-            .arn(SQS_SEND_MESSAGE_ARN)
+            .arn(EB_SQS_UNIVERSAL_TARGET_ARN)
             .roleArn(routing.roleArn)
             .input(universalInput)
             .build()
@@ -163,28 +164,14 @@ object ExternalSchedulerService {
         return "https://sqs.$resolvedRegion.amazonaws.com/${routing.accountId}/${routing.queueName}"
     }
 
-    private fun <T> withSchedulerClient(routing: SchedulerRoutingResolver.Routing, block: (SchedulerClient) -> T): T {
-        val sts = requireNotNull(stsClient) { "stsClient must be set before invoking schedule operations" }
+    private fun getSchedulerClient(routing: SchedulerRoutingResolver.Routing): SchedulerClient {
+        val cache = requireNotNull(credentialsCache) { "credentialsCache must be set before invoking schedule operations" }
         val resolvedRegion = requireNotNull(region) { "region must be set" }
-        val assumeRoleResponse = sts.assumeRole(
-            AssumeRoleRequest.builder()
-                .roleArn(routing.roleArn)
-                .roleSessionName("alerting-scheduler-${routing.accountId}")
+        return schedulerClients.computeIfAbsent(routing.accountId) {
+            SchedulerClient.builder()
+                .region(Region.of(resolvedRegion))
+                .credentialsProvider(cache.getCredentialsProvider(routing.accountId))
                 .build()
-        )
-        val credentials = assumeRoleResponse.credentials()
-        val schedulerClient = SchedulerClient.builder()
-            .region(Region.of(resolvedRegion))
-            .credentialsProvider(
-                StaticCredentialsProvider.create(
-                    AwsSessionCredentials.create(
-                        credentials.accessKeyId(),
-                        credentials.secretAccessKey(),
-                        credentials.sessionToken()
-                    )
-                )
-            )
-            .build()
-        return schedulerClient.use(block)
+        }
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
@@ -8,6 +8,7 @@ package org.opensearch.alerting.service
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.apache.logging.log4j.LogManager
@@ -99,7 +100,10 @@ class MonitorJobPoller(
                 val queueUrl = cachedQueueUrls[queueIndex.getAndIncrement() % cachedQueueUrls.size]
 
                 val messages = receiveMessages(sqs, queueUrl)
-                if (messages.isEmpty()) continue
+                if (messages.isEmpty()) {
+                    delay(POLL_INTERVAL_MS)
+                    continue
+                }
 
                 val message = messages[0]
                 try {
@@ -178,5 +182,6 @@ class MonitorJobPoller(
 
     companion object {
         const val POLLER_THREAD_COUNT = 10
+        const val POLL_INTERVAL_MS = 1000L
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
@@ -1,0 +1,182 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.service
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import org.apache.logging.log4j.LogManager
+import org.opensearch.alerting.action.ExecuteMonitorAction
+import org.opensearch.alerting.action.ExecuteMonitorRequest
+import org.opensearch.alerting.action.ExecuteMonitorResponse
+import org.opensearch.alerting.opensearchapi.suspendUntil
+import org.opensearch.common.lifecycle.AbstractLifecycleComponent
+import org.opensearch.common.unit.TimeValue
+import org.opensearch.common.xcontent.LoggingDeprecationHandler
+import org.opensearch.common.xcontent.XContentType
+import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.ScheduleJobPayload
+import org.opensearch.commons.alerting.util.AlertingException
+import org.opensearch.commons.utils.scheduler.JobQueueAccountIdProvider
+import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.transport.client.Client
+import software.amazon.awssdk.services.sqs.SqsClient
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest
+import software.amazon.awssdk.services.sqs.model.Message
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Polls SQS queues for monitor execution messages and dispatches them
+ * to TransportExecuteMonitorAction. Runs a fixed number of coroutines
+ * that round-robin across queue URLs constructed from account IDs, region,
+ * and queue name.
+ *
+ * Coroutines are only launched when [enabled] is true (multi-tenant deployment mode).
+ * [sqsClient] must be set before workers begin polling.
+ */
+class MonitorJobPoller(
+    private val xContentRegistry: NamedXContentRegistry,
+    private val client: Client,
+    private val enabled: Boolean,
+    private val accountIdProvider: JobQueueAccountIdProvider?,
+    private val region: String,
+    private val queueName: String
+) : AbstractLifecycleComponent() {
+
+    private val logger = LogManager.getLogger(MonitorJobPoller::class.java)
+    private val supervisorJob = SupervisorJob()
+    private val scope = CoroutineScope(Dispatchers.IO + supervisorJob)
+
+    @Volatile
+    var sqsClient: SqsClient? = null
+
+    override fun doStart() {
+        if (!enabled) {
+            logger.info("MonitorJobPoller disabled, not starting poll workers")
+            return
+        }
+        val provider = requireNotNull(accountIdProvider) { "accountIdProvider must be set before starting" }
+        val sqs = requireNotNull(sqsClient) { "sqsClient must be set before starting" }
+
+        logger.info("Starting MonitorJobPoller with $POLLER_THREAD_COUNT workers")
+        repeat(POLLER_THREAD_COUNT) { scope.launch { pollLoop(provider, sqs, region, queueName) } }
+    }
+
+    override fun doStop() {
+        logger.info("Stopping MonitorJobPoller")
+        supervisorJob.cancel()
+    }
+
+    override fun doClose() {}
+
+    private suspend fun pollLoop(
+        provider: JobQueueAccountIdProvider,
+        sqs: SqsClient,
+        region: String,
+        queueName: String
+    ) {
+        val queueIndex = AtomicInteger(0)
+        var cachedQueueUrls: List<String> = emptyList()
+        var cachedAccountIds: List<String> = emptyList()
+
+        while (scope.isActive) {
+            try {
+                val accountIds = provider.getAccountIds()
+                if (accountIds.isEmpty()) continue
+
+                if (accountIds != cachedAccountIds) {
+                    cachedAccountIds = accountIds
+                    cachedQueueUrls = accountIds.map { "https://sqs.$region.amazonaws.com/$it/$queueName" }
+                }
+
+                val queueUrl = cachedQueueUrls[queueIndex.getAndIncrement() % cachedQueueUrls.size]
+
+                val messages = receiveMessages(sqs, queueUrl)
+                if (messages.isEmpty()) continue
+
+                val message = messages[0]
+                try {
+                    logger.info(
+                        "Received message {} from queue {}",
+                        message.messageId(), queueUrl
+                    )
+                    val payload = parseMessage(message.body())
+                    val monitor = payload.toMonitor(xContentRegistry)
+                    val jobStartTime = Instant.parse(payload.jobStartTime)
+                    logger.info(
+                        "Parsed monitor [{}] type [{}] jobStartTime [{}]",
+                        monitor.id, monitor.monitorType, jobStartTime
+                    )
+                    executeMonitor(monitor, jobStartTime)
+                    deleteMessage(sqs, queueUrl, message)
+                } catch (e: Exception) {
+                    logger.error(
+                        "Failed to process job queue message {} from queue {}",
+                        message.messageId(), queueUrl, e
+                    )
+                    // Don't delete — visibility timeout expires, SQS redelivers
+                }
+            } catch (e: Exception) {
+                logger.error("Error in MonitorJobPoller worker", e)
+            }
+        }
+    }
+
+    private suspend fun executeMonitor(monitor: Monitor, jobStartTime: Instant) {
+        val request = ExecuteMonitorRequest(
+            dryrun = false,
+            requestEnd = TimeValue(jobStartTime.toEpochMilli()),
+            monitorId = monitor.id,
+            monitor = monitor,
+            requestStart = null
+        )
+        try {
+            client.suspendUntil<Client, ExecuteMonitorResponse> {
+                client.execute(ExecuteMonitorAction.INSTANCE, request, it)
+            }
+        } catch (e: Exception) {
+            throw AlertingException.wrap(e)
+        }
+    }
+
+    internal fun receiveMessages(sqs: SqsClient, queueUrl: String): List<Message> {
+        val request = ReceiveMessageRequest.builder()
+            .queueUrl(queueUrl)
+            .maxNumberOfMessages(1)
+            .waitTimeSeconds(0)
+            .build()
+        return sqs.receiveMessage(request).messages()
+    }
+
+    internal fun deleteMessage(sqs: SqsClient, queueUrl: String, message: Message) {
+        val request = DeleteMessageRequest.builder()
+            .queueUrl(queueUrl)
+            .receiptHandle(message.receiptHandle())
+            .build()
+        sqs.deleteMessage(request)
+    }
+
+    internal fun parseMessage(body: String): ScheduleJobPayload {
+        try {
+            return XContentType.JSON.xContent()
+                .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, body)
+                .use { parser ->
+                    parser.nextToken()
+                    ScheduleJobPayload.parse(parser)
+                }
+        } catch (e: Exception) {
+            throw AlertingException.wrap(e)
+        }
+    }
+
+    companion object {
+        const val POLLER_THREAD_COUNT = 10
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/SchedulerRoutingResolver.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/SchedulerRoutingResolver.kt
@@ -16,21 +16,21 @@ package org.opensearch.alerting.service
 object SchedulerRoutingResolver {
 
     /** Routing info for external scheduler operations. */
-    data class Routing(val accountId: String, val queueArn: String, val roleArn: String)
+    data class Routing(val accountId: String, val queueName: String, val roleArn: String)
 
     fun resolve(
         settingsAccountId: String,
-        settingsQueueArn: String,
+        settingsQueueName: String,
         settingsRoleArn: String,
         threadContextAccountIdOverride: String?
     ): Routing? {
         val accountId = pickAccountId(settingsAccountId, threadContextAccountIdOverride) ?: return null
-        val queueArn = settingsQueueArn.takeIf { it.isNotBlank() } ?: return null
+        val queueName = settingsQueueName.takeIf { it.isNotBlank() } ?: return null
         val roleArn = settingsRoleArn.takeIf { it.isNotBlank() } ?: return null
-        return Routing(accountId, queueArn, roleArn)
+        return Routing(accountId, queueName, roleArn)
     }
 
-    /** Delete only needs accountId + roleArn; queueArn is set to empty. */
+    /** Delete only needs accountId + roleArn; queueName is set to empty. */
     fun resolveForDelete(
         settingsAccountId: String,
         settingsRoleArn: String,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
@@ -374,12 +374,6 @@ class AlertingSettings {
             Setting.Property.NodeScope, Setting.Property.Dynamic
         )
 
-        /** SQS queue ARN that EventBridge schedules dispatch monitor executions to. */
-        val EXTERNAL_SCHEDULER_QUEUE_ARN = Setting.simpleString(
-            "plugins.alerting.external_scheduler.queue_arn",
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-        )
-
         /** IAM role ARN that EventBridge assumes to send messages to the target SQS queue. */
         val EXTERNAL_SCHEDULER_ROLE_ARN = Setting.simpleString(
             "plugins.alerting.external_scheduler.role_arn",
@@ -397,6 +391,18 @@ class AlertingSettings {
             "plugins.alerting.job_queue_account_provider_type",
             "plugin_setting",
             Setting.Property.NodeScope, Setting.Property.Final
+        )
+
+        /** Name of the SQS queue to poll for monitor execution messages. */
+        val JOB_QUEUE_NAME = Setting.simpleString(
+            "plugins.alerting.job_queue_name",
+            Setting.Property.NodeScope, Setting.Property.Dynamic
+        )
+
+        /** Key name in monitor metadata whose value is used as the SQS MessageGroupId for fair queuing. */
+        val JOB_QUEUE_MESSAGE_GROUP_KEY_NAME = Setting.simpleString(
+            "plugins.alerting.job_queue_message_group_key_name",
+            Setting.Property.NodeScope, Setting.Property.Dynamic
         )
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
@@ -382,26 +382,26 @@ class AlertingSettings {
 
         /** AWS account ID that hosts the job queues available for polling. */
         val JOB_QUEUE_ACCOUNT_ID = Setting.simpleString(
-            "plugins.alerting.job_queue_account_id",
+            "plugins.alerting.external_scheduler.job_queue_account_id",
             Setting.Property.NodeScope, Setting.Property.Dynamic
         )
 
         /** Provider type used to resolve job queue account IDs (e.g. "plugin_setting"). */
         val JOB_QUEUE_ACCOUNT_PROVIDER_TYPE = Setting.simpleString(
-            "plugins.alerting.job_queue_account_provider_type",
+            "plugins.alerting.external_scheduler.job_queue_account_provider_type",
             "plugin_setting",
             Setting.Property.NodeScope, Setting.Property.Final
         )
 
         /** Name of the SQS queue to poll for monitor execution messages. */
         val JOB_QUEUE_NAME = Setting.simpleString(
-            "plugins.alerting.job_queue_name",
+            "plugins.alerting.external_scheduler.job_queue_name",
             Setting.Property.NodeScope, Setting.Property.Dynamic
         )
 
         /** Key name in monitor metadata whose value is used as the SQS MessageGroupId for fair queuing. */
         val JOB_QUEUE_MESSAGE_GROUP_KEY_NAME = Setting.simpleString(
-            "plugins.alerting.job_queue_message_group_key_name",
+            "plugins.alerting.external_scheduler.job_queue_message_group_key_name",
             Setting.Property.NodeScope, Setting.Property.Dynamic
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
@@ -105,7 +105,7 @@ class TransportExecuteMonitorAction @Inject constructor(
                 }
             }
 
-            if (execMonitorRequest.monitorId != null) {
+            if (execMonitorRequest.monitorId != null && execMonitorRequest.monitor == null) {
                 val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
                 val getRequest = GetDataObjectRequest.builder()
                     .index(ScheduledJob.SCHEDULED_JOBS_INDEX)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -123,7 +123,7 @@ class TransportIndexMonitorAction @Inject constructor(
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
     @Volatile private var externalSchedulerEnabled = AlertingSettings.EXTERNAL_SCHEDULER_ENABLED.get(settings)
     @Volatile private var externalSchedulerAccountId = AlertingSettings.EXTERNAL_SCHEDULER_ACCOUNT_ID.get(settings)
-    @Volatile private var externalSchedulerQueueArn = AlertingSettings.EXTERNAL_SCHEDULER_QUEUE_ARN.get(settings)
+    @Volatile private var jobQueueName = AlertingSettings.JOB_QUEUE_NAME.get(settings)
     @Volatile private var externalSchedulerRoleArn = AlertingSettings.EXTERNAL_SCHEDULER_ROLE_ARN.get(settings)
 
     private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
@@ -141,8 +141,8 @@ class TransportIndexMonitorAction @Inject constructor(
         clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.EXTERNAL_SCHEDULER_ACCOUNT_ID) {
             externalSchedulerAccountId = it
         }
-        clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.EXTERNAL_SCHEDULER_QUEUE_ARN) {
-            externalSchedulerQueueArn = it
+        clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.JOB_QUEUE_NAME) {
+            jobQueueName = it
         }
         clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.EXTERNAL_SCHEDULER_ROLE_ARN) {
             externalSchedulerRoleArn = it
@@ -882,7 +882,7 @@ class TransportIndexMonitorAction @Inject constructor(
 
         private fun resolveRouting(): SchedulerRoutingResolver.Routing? = SchedulerRoutingResolver.resolve(
             settingsAccountId = externalSchedulerAccountId,
-            settingsQueueArn = externalSchedulerQueueArn,
+            settingsQueueName = jobQueueName,
             settingsRoleArn = externalSchedulerRoleArn,
             threadContextAccountIdOverride = client.threadPool().threadContext
                 .getTransient<String>(ExternalSchedulerService.SCHEDULER_ACCOUNT_ID_KEY)

--- a/alerting/src/test/kotlin/org/opensearch/alerting/service/ExternalSchedulerServiceTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/service/ExternalSchedulerServiceTests.kt
@@ -69,29 +69,35 @@ class ExternalSchedulerServiceTests {
     }
 
     @Test
-    fun `createSchedule throws when stsClient not set`() {
-        ExternalSchedulerService.stsClient = null
-        ExternalSchedulerService.region = "us-west-2"
+    fun `createSchedule throws when credentialsCache not set`() {
+        ExternalSchedulerService.credentialsCache = null
+        ExternalSchedulerService.initialize(
+            org.opensearch.common.settings.Settings.builder()
+                .put("plugins.alerting.remote_metadata_region", "us-west-2").build()
+        )
         val monitor = testMonitor()
         val routing = SchedulerRoutingResolver.Routing("111111111111", "queue", "arn:aws:iam::111:role/test")
         try {
             ExternalSchedulerService.createSchedule(monitor, routing, buildPayloadJson(monitor))
             throw AssertionError("Expected IllegalArgumentException")
         } catch (e: IllegalArgumentException) {
-            assertTrue(e.message!!.contains("stsClient"))
+            assertTrue(e.message!!.contains("credentialsCache"))
         }
     }
 
     @Test
-    fun `deleteSchedule throws when stsClient not set`() {
-        ExternalSchedulerService.stsClient = null
-        ExternalSchedulerService.region = "us-west-2"
+    fun `deleteSchedule throws when credentialsCache not set`() {
+        ExternalSchedulerService.credentialsCache = null
+        ExternalSchedulerService.initialize(
+            org.opensearch.common.settings.Settings.builder()
+                .put("plugins.alerting.remote_metadata_region", "us-west-2").build()
+        )
         val routing = SchedulerRoutingResolver.Routing("333333333333", "queue", "arn:aws:iam::333:role/test")
         try {
             ExternalSchedulerService.deleteSchedule("mon-3", routing)
             throw AssertionError("Expected IllegalArgumentException")
         } catch (e: IllegalArgumentException) {
-            assertTrue(e.message!!.contains("stsClient"))
+            assertTrue(e.message!!.contains("credentialsCache"))
         }
     }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/service/ExternalSchedulerServiceTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/service/ExternalSchedulerServiceTests.kt
@@ -59,20 +59,6 @@ class ExternalSchedulerServiceTests {
     }
 
     @Test
-    fun `createSchedule does not throw`() {
-        val monitor = testMonitor()
-        val routing = SchedulerRoutingResolver.Routing("111111111111", "arn:aws:sqs:us-east-1:111:queue", "arn:aws:iam::111:role/test")
-        ExternalSchedulerService.createSchedule(monitor, routing, buildPayloadJson(monitor))
-    }
-
-    @Test
-    fun `updateSchedule does not throw`() {
-        val monitor = testMonitor()
-        val routing = SchedulerRoutingResolver.Routing("222222222222", "arn:aws:sqs:us-west-2:222:queue", "arn:aws:iam::222:role/test")
-        ExternalSchedulerService.updateSchedule(monitor, routing, buildPayloadJson(monitor))
-    }
-
-    @Test
     fun `payload json contains all ScheduleJobPayload fields`() {
         val monitor = testMonitor()
         val json = buildPayloadJson(monitor)
@@ -83,8 +69,29 @@ class ExternalSchedulerServiceTests {
     }
 
     @Test
-    fun `deleteSchedule accepts all required params`() {
-        val routing = SchedulerRoutingResolver.Routing("333333333333", "", "arn:aws:iam::333:role/eb-role")
-        ExternalSchedulerService.deleteSchedule("mon-3", routing)
+    fun `createSchedule throws when stsClient not set`() {
+        ExternalSchedulerService.stsClient = null
+        ExternalSchedulerService.region = "us-west-2"
+        val monitor = testMonitor()
+        val routing = SchedulerRoutingResolver.Routing("111111111111", "queue", "arn:aws:iam::111:role/test")
+        try {
+            ExternalSchedulerService.createSchedule(monitor, routing, buildPayloadJson(monitor))
+            throw AssertionError("Expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(e.message!!.contains("stsClient"))
+        }
+    }
+
+    @Test
+    fun `deleteSchedule throws when stsClient not set`() {
+        ExternalSchedulerService.stsClient = null
+        ExternalSchedulerService.region = "us-west-2"
+        val routing = SchedulerRoutingResolver.Routing("333333333333", "queue", "arn:aws:iam::333:role/test")
+        try {
+            ExternalSchedulerService.deleteSchedule("mon-3", routing)
+            throw AssertionError("Expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(e.message!!.contains("stsClient"))
+        }
     }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/service/MonitorJobPollerTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/service/MonitorJobPollerTests.kt
@@ -33,7 +33,8 @@ import java.util.concurrent.atomic.AtomicReference
 class MonitorJobPollerTests : OpenSearchTestCase() {
 
     class CoroutineThreadFilter : ThreadFilter {
-        override fun reject(t: Thread): Boolean = t.name.startsWith("DefaultDispatcher-worker")
+        override fun reject(t: Thread): Boolean =
+            t.name.startsWith("DefaultDispatcher-worker") || t.name == "kotlinx.coroutines.DefaultExecutor"
     }
 
     private fun testXContentRegistry(): NamedXContentRegistry {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/service/MonitorJobPollerTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/service/MonitorJobPollerTests.kt
@@ -1,0 +1,337 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.service
+
+import com.carrotsearch.randomizedtesting.ThreadFilter
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters
+import org.mockito.Mockito.mock
+import org.opensearch.common.settings.Settings
+import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.SearchInput
+import org.opensearch.commons.utils.scheduler.JobQueueAccountIdProvider
+import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.search.SearchModule
+import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.transport.client.Client
+import software.amazon.awssdk.services.sqs.SqsClient
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest
+import software.amazon.awssdk.services.sqs.model.DeleteMessageResponse
+import software.amazon.awssdk.services.sqs.model.Message
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse
+import software.amazon.awssdk.services.sqs.model.SqsException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+@ThreadLeakFilters(filters = [MonitorJobPollerTests.CoroutineThreadFilter::class])
+class MonitorJobPollerTests : OpenSearchTestCase() {
+
+    class CoroutineThreadFilter : ThreadFilter {
+        override fun reject(t: Thread): Boolean = t.name.startsWith("DefaultDispatcher-worker")
+    }
+
+    private fun testXContentRegistry(): NamedXContentRegistry {
+        return NamedXContentRegistry(
+            mutableListOf(
+                Monitor.XCONTENT_REGISTRY,
+                SearchInput.XCONTENT_REGISTRY
+            ) + SearchModule(Settings.EMPTY, emptyList()).namedXContents
+        )
+    }
+
+    private fun mockClient(): Client = mock(Client::class.java)
+
+    private fun testAccountIdProvider(accountId: String = "123"): JobQueueAccountIdProvider {
+        return object : JobQueueAccountIdProvider {
+            override fun getType() = "test"
+            override fun initialize(settings: org.opensearch.common.settings.Settings) {}
+            override fun getAccountIds() = listOf(accountId)
+        }
+    }
+
+    private fun validMessageBody(): String {
+        val monitorConfig = "{\"type\":\"monitor\",\"name\":\"test\"," +
+            "\"monitor_type\":\"query_level_monitor\",\"enabled\":true," +
+            "\"schedule\":{\"period\":{\"interval\":5,\"unit\":\"MINUTES\"}}," +
+            "\"inputs\":[{\"search\":{\"indices\":[\"idx\"]," +
+            "\"query\":{\"query\":{\"match_all\":{}}}}}]," +
+            "\"triggers\":[],\"enabled_time\":1712750000000," +
+            "\"last_update_time\":1712750000000}"
+        val escaped = monitorConfig.replace("\"", "\\\"")
+        return "{\"job_start_time\":\"2026-04-10T10:05:00Z\"," +
+            "\"monitorId\":\"abc\",\"monitorConfig\":\"$escaped\"}"
+    }
+
+    private fun createPoller(
+        sqsClient: FakeSqsClient = FakeSqsClient(),
+        enabled: Boolean = true
+    ): MonitorJobPoller {
+        return MonitorJobPoller(
+            testXContentRegistry(), mockClient(), enabled,
+            testAccountIdProvider(), "us-west-2", "test-queue"
+        ).also { it.sqsClient = sqsClient }
+    }
+
+    /**
+     * Fake SqsClient for testing — avoids Mockito issues with Java 21 module system.
+     */
+    private class FakeSqsClient(
+        private val onReceive: (ReceiveMessageRequest) -> ReceiveMessageResponse = {
+            ReceiveMessageResponse.builder().messages(emptyList()).build()
+        },
+        private val onDelete: (DeleteMessageRequest) -> DeleteMessageResponse = {
+            DeleteMessageResponse.builder().build()
+        }
+    ) : SqsClient {
+        val closed = AtomicBoolean(false)
+        override fun serviceName(): String = "sqs"
+        override fun close() { closed.set(true) }
+        override fun receiveMessage(req: ReceiveMessageRequest): ReceiveMessageResponse = onReceive(req)
+        override fun deleteMessage(req: DeleteMessageRequest): DeleteMessageResponse = onDelete(req)
+    }
+
+    fun `test start creates threads when enabled and stop interrupts them`() {
+        val sqsClient = FakeSqsClient()
+        val poller = MonitorJobPoller(
+            testXContentRegistry(), mockClient(), true,
+            testAccountIdProvider(), "us-west-2", "test-queue"
+        ).also { it.sqsClient = sqsClient }
+        poller.start()
+        Thread.sleep(100)
+        poller.stop()
+        poller.close()
+    }
+
+    fun `test start does not create threads when disabled`() {
+        val latch = CountDownLatch(1)
+        val sqsClient = FakeSqsClient(
+            onReceive = {
+                latch.countDown()
+                ReceiveMessageResponse.builder().messages(emptyList()).build()
+            }
+        )
+        val poller = MonitorJobPoller(
+            testXContentRegistry(), mockClient(), false,
+            null, "", ""
+        )
+        poller.start()
+        // Should NOT poll since disabled
+        assertFalse("Should not have polled", latch.await(500, TimeUnit.MILLISECONDS))
+        poller.stop()
+        poller.close()
+    }
+
+    fun `test start throws when provider not set`() {
+        val poller = MonitorJobPoller(
+            testXContentRegistry(), mockClient(), true,
+            null, "us-west-2", "test-queue"
+        )
+        expectThrows(Exception::class.java) {
+            poller.start()
+        }
+        poller.close()
+    }
+
+    fun `test worker polls when provider is set`() {
+        val latch = CountDownLatch(1)
+        val sqsClient = FakeSqsClient(
+            onReceive = {
+                latch.countDown()
+                ReceiveMessageResponse.builder().messages(emptyList()).build()
+            }
+        )
+        val poller = createPoller(sqsClient)
+        poller.start()
+        assertTrue("Should have polled", latch.await(5, TimeUnit.SECONDS))
+        poller.stop()
+        poller.close()
+    }
+
+    fun `test worker continues on provider exception`() {
+        var callCount = 0
+        val latch = CountDownLatch(2)
+        val errorProvider = object : JobQueueAccountIdProvider {
+            override fun getType() = "test"
+            override fun initialize(settings: org.opensearch.common.settings.Settings) {}
+            override fun getAccountIds(): List<String> {
+                callCount++
+                latch.countDown()
+                if (callCount == 1) throw RuntimeException("test error")
+                return listOf("123")
+            }
+        }
+        val poller = MonitorJobPoller(
+            testXContentRegistry(), mockClient(), true,
+            errorProvider, "us-west-2", "test-queue"
+        ).also { it.sqsClient = FakeSqsClient() }
+        poller.start()
+        assertTrue("Worker should have polled twice", latch.await(5, TimeUnit.SECONDS))
+        poller.stop()
+        poller.close()
+    }
+
+    fun `test worker handles empty account ids`() {
+        val latch = CountDownLatch(3)
+        val emptyProvider = object : JobQueueAccountIdProvider {
+            override fun getType() = "test"
+            override fun initialize(settings: org.opensearch.common.settings.Settings) {}
+            override fun getAccountIds(): List<String> {
+                latch.countDown()
+                return emptyList()
+            }
+        }
+        val poller = MonitorJobPoller(
+            testXContentRegistry(), mockClient(), true,
+            emptyProvider, "us-west-2", "test-queue"
+        ).also { it.sqsClient = FakeSqsClient() }
+        poller.start()
+        assertTrue("Worker should have polled multiple times", latch.await(5, TimeUnit.SECONDS))
+        poller.stop()
+        poller.close()
+    }
+
+    fun `test receive message with correct parameters`() {
+        val receivedRequest = AtomicReference<ReceiveMessageRequest>()
+        val latch = CountDownLatch(1)
+        val delivered = AtomicBoolean(false)
+        val sqsClient = FakeSqsClient(
+            onReceive = { req ->
+                if (!delivered.getAndSet(true)) {
+                    receivedRequest.set(req)
+                    latch.countDown()
+                    ReceiveMessageResponse.builder().messages(
+                        Message.builder().messageId("msg-1")
+                            .receiptHandle("r-1")
+                            .body(validMessageBody()).build()
+                    ).build()
+                } else {
+                    ReceiveMessageResponse.builder().messages(emptyList()).build()
+                }
+            }
+        )
+        val poller = createPoller(sqsClient)
+        poller.start()
+        assertTrue("Should have received", latch.await(5, TimeUnit.SECONDS))
+        poller.stop()
+        poller.close()
+
+        val req = receivedRequest.get()
+        assertEquals(1, req.maxNumberOfMessages())
+        assertEquals(0, req.waitTimeSeconds())
+        assertEquals(
+            "https://sqs.us-west-2.amazonaws.com/123/test-queue",
+            req.queueUrl()
+        )
+    }
+
+    fun `test delete message uses receipt handle`() {
+        val deletedRequest = AtomicReference<DeleteMessageRequest>()
+        val sqsClient = FakeSqsClient(
+            onDelete = { req ->
+                deletedRequest.set(req)
+                DeleteMessageResponse.builder().build()
+            }
+        )
+        val poller = createPoller(sqsClient)
+        val message = Message.builder()
+            .messageId("msg-1")
+            .receiptHandle("receipt-handle-abc")
+            .body(validMessageBody())
+            .build()
+
+        poller.deleteMessage(
+            sqsClient,
+            "https://sqs.us-west-2.amazonaws.com/123/test-queue",
+            message
+        )
+
+        assertEquals("receipt-handle-abc", deletedRequest.get().receiptHandle())
+        assertEquals(
+            "https://sqs.us-west-2.amazonaws.com/123/test-queue",
+            deletedRequest.get().queueUrl()
+        )
+        poller.close()
+    }
+
+    fun `test sqs exception during receive does not kill worker`() {
+        val callCount = AtomicInteger(0)
+        val latch = CountDownLatch(2)
+        val sqsClient = FakeSqsClient(
+            onReceive = {
+                val count = callCount.incrementAndGet()
+                latch.countDown()
+                if (count == 1) {
+                    throw SqsException.builder().message("throttled").build()
+                }
+                ReceiveMessageResponse.builder().messages(emptyList()).build()
+            }
+        )
+        val poller = createPoller(sqsClient)
+        poller.start()
+        assertTrue("Worker should survive SQS exception", latch.await(5, TimeUnit.SECONDS))
+        poller.stop()
+        poller.close()
+    }
+
+    fun `test empty receive does not call delete`() {
+        val deleteCount = AtomicInteger(0)
+        val receiveLatch = CountDownLatch(3)
+        val sqsClient = FakeSqsClient(
+            onReceive = {
+                receiveLatch.countDown()
+                ReceiveMessageResponse.builder().messages(emptyList()).build()
+            },
+            onDelete = {
+                deleteCount.incrementAndGet()
+                DeleteMessageResponse.builder().build()
+            }
+        )
+        val poller = createPoller(sqsClient)
+        poller.start()
+        assertTrue("Should poll multiple times", receiveLatch.await(5, TimeUnit.SECONDS))
+        poller.stop()
+        poller.close()
+        assertEquals("Delete should not be called", 0, deleteCount.get())
+    }
+
+    fun `test parseMessage extracts monitor and jobStartTime`() {
+        val poller = createPoller()
+
+        val monitorConfig = "{\"type\":\"monitor\",\"name\":\"test-monitor\"," +
+            "\"monitor_type\":\"query_level_monitor\",\"enabled\":true," +
+            "\"schedule\":{\"period\":{\"interval\":5,\"unit\":\"MINUTES\"}}," +
+            "\"inputs\":[{\"search\":{\"indices\":[\"my-index\"]," +
+            "\"query\":{\"query\":{\"match_all\":{}}}}}]," +
+            "\"triggers\":[],\"enabled_time\":1712750000000," +
+            "\"last_update_time\":1712750000000}"
+        val escaped = monitorConfig.replace("\"", "\\\"")
+        val body = "{\"job_start_time\":\"2026-04-10T10:05:00Z\"," +
+            "\"monitorId\":\"abc123\",\"monitorConfig\":\"$escaped\"}"
+
+        val payload = poller.parseMessage(body)
+        val monitor = payload.toMonitor(testXContentRegistry())
+
+        assertEquals("abc123", payload.monitorId)
+        assertEquals("2026-04-10T10:05:00Z", payload.jobStartTime)
+        assertEquals("test-monitor", monitor.name)
+        assertEquals("query_level_monitor", monitor.monitorType)
+        poller.close()
+    }
+
+    fun `test parseMessage throws on missing monitorConfig`() {
+        val poller = createPoller()
+        val body = "{\"job_start_time\":\"2026-04-10T10:05:00Z\"," +
+            "\"monitorId\":\"abc123\"}"
+
+        expectThrows(Exception::class.java) {
+            poller.parseMessage(body)
+        }
+        poller.close()
+    }
+}

--- a/alerting/src/test/kotlin/org/opensearch/alerting/service/SchedulerRoutingResolverTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/service/SchedulerRoutingResolverTests.kt
@@ -21,7 +21,7 @@ class SchedulerRoutingResolverTests {
     @Test fun `resolve uses plugin settings when no override`() {
         val r = SchedulerRoutingResolver.resolve(acct, queue, role, threadContextAccountIdOverride = null)!!
         assertEquals(acct, r.accountId)
-        assertEquals(queue, r.queueArn)
+        assertEquals(queue, r.queueName)
         assertEquals(role, r.roleArn)
     }
 
@@ -45,7 +45,7 @@ class SchedulerRoutingResolverTests {
         assertEquals(override, r.accountId)
     }
 
-    @Test fun `resolve returns null when queueArn blank`() {
+    @Test fun `resolve returns null when queueName blank`() {
         assertNull(SchedulerRoutingResolver.resolve(acct, "", role, threadContextAccountIdOverride = null))
     }
 
@@ -74,8 +74,8 @@ class SchedulerRoutingResolverTests {
         assertNull(SchedulerRoutingResolver.resolveForDelete(acct, "", threadContextAccountIdOverride = null))
     }
 
-    @Test fun `resolveForDelete does not require queueArn`() {
-        // No queueArn parameter at all — setup covers delete path independent of create/update
+    @Test fun `resolveForDelete does not require queueName`() {
+        // No queueName parameter at all — setup covers delete path independent of create/update
         val r = SchedulerRoutingResolver.resolveForDelete(acct, role, threadContextAccountIdOverride = null)
         assertEquals(acct, r?.accountId)
     }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/settings/JobQueueAccountSettingsTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/settings/JobQueueAccountSettingsTests.kt
@@ -45,14 +45,14 @@ class JobQueueAccountSettingsTests : OpenSearchTestCase() {
 
     fun `test job_queue_account_id reads configured value`() {
         val settings = Settings.builder()
-            .put("plugins.alerting.job_queue_account_id", "123456789012")
+            .put("plugins.alerting.external_scheduler.job_queue_account_id", "123456789012")
             .build()
         assertEquals("123456789012", AlertingSettings.JOB_QUEUE_ACCOUNT_ID.get(settings))
     }
 
     fun `test job_queue_account_provider_type reads configured value`() {
         val settings = Settings.builder()
-            .put("plugins.alerting.job_queue_account_provider_type", "custom_provider")
+            .put("plugins.alerting.external_scheduler.job_queue_account_provider_type", "custom_provider")
             .build()
         assertEquals("custom_provider", AlertingSettings.JOB_QUEUE_ACCOUNT_PROVIDER_TYPE.get(settings))
     }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/AlertingSingleNodeTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/AlertingSingleNodeTestCase.kt
@@ -98,7 +98,7 @@ abstract class AlertingSingleNodeTestCase : OpenSearchSingleNodeTestCase() {
     }
 
     protected fun executeMonitor(monitor: Monitor, id: String?, dryRun: Boolean = true): ExecuteMonitorResponse? {
-        val request = ExecuteMonitorRequest(dryRun, TimeValue(Instant.now().toEpochMilli()), id, monitor)
+        val request = ExecuteMonitorRequest(dryRun, TimeValue(Instant.now().toEpochMilli()), id, if (id != null) null else monitor)
         return client().execute(ExecuteMonitorAction.INSTANCE, request).get()
     }
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorActionTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorActionTests.kt
@@ -65,7 +65,7 @@ class TransportIndexMonitorActionTests : OpenSearchTestCase() {
         settingSet.add(DestinationSettings.ALLOW_LIST)
         settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ENABLED)
         settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ACCOUNT_ID)
-        settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_QUEUE_ARN)
+        settingSet.add(AlertingSettings.JOB_QUEUE_NAME)
         settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ROLE_ARN)
         return ClusterSettings(settings, settingSet)
     }
@@ -126,7 +126,7 @@ class TransportIndexMonitorActionTests : OpenSearchTestCase() {
     fun `test scheduler settings are registered as dynamic`() {
         assertTrue(AlertingSettings.EXTERNAL_SCHEDULER_ENABLED.isDynamic)
         assertTrue(AlertingSettings.EXTERNAL_SCHEDULER_ACCOUNT_ID.isDynamic)
-        assertTrue(AlertingSettings.EXTERNAL_SCHEDULER_QUEUE_ARN.isDynamic)
+        assertTrue(AlertingSettings.JOB_QUEUE_NAME.isDynamic)
         assertTrue(AlertingSettings.EXTERNAL_SCHEDULER_ROLE_ARN.isDynamic)
     }
 
@@ -137,7 +137,7 @@ class TransportIndexMonitorActionTests : OpenSearchTestCase() {
 
     fun `test scheduler string settings default to empty`() {
         assertEquals("", AlertingSettings.EXTERNAL_SCHEDULER_ACCOUNT_ID.get(Settings.EMPTY))
-        assertEquals("", AlertingSettings.EXTERNAL_SCHEDULER_QUEUE_ARN.get(Settings.EMPTY))
+        assertEquals("", AlertingSettings.JOB_QUEUE_NAME.get(Settings.EMPTY))
         assertEquals("", AlertingSettings.EXTERNAL_SCHEDULER_ROLE_ARN.get(Settings.EMPTY))
     }
 }


### PR DESCRIPTION

- JobQueueUrlsProvider: interface for queue URL discovery
- MonitorJobPoller: AbstractLifecycleComponent with coroutine-based
  poll workers, round-robin queue selection. Workers only launched
  when enabled (MULTI_TENANCY_ENABLED). Idles until jobQueueUrlsProvider
  and sqsClient are set.
- Queue integration: receiveMessage (max=1, waitTime=0, visibility=90),
  deleteMessage on success, exception resilience
- Message parsing: extracts Monitor object and jobStartTime from
  SchedulePayloadBuilder format
- Execution: uses suspendUntil with ExecuteMonitorAction, inline Monitor
  (skips metadata store fetch when monitor object is provided)
- TransportExecuteMonitorAction: prioritize inline monitor over
  monitorId fetch when both are present
- Plugin integration: MonitorJobPoller created in createComponents,
  returned as lifecycle component
- AWS SDK v2 SQS compile dependencies
- Unit tests (12 tests)


### E2E Test 1: ExternalSchedulerService — Create/Update/Delete Schedule (Universal Target)


Creating schedule for monitor e2e-1777266565689...
Creating EB schedule monitor-e2e-1777266565689 in account 333654771707
 expr=rate(5 minutes) enabled=true
 queue=https://sqs.us-west-2.amazonaws.com/333654771707/alerting-poller-test
 role=arn:aws:iam::333654771707:role/allow-eventbridge-to-sqs
Created: monitor-e2e-1777266565689
Universal target ARN ✓
QueueUrl ✓  MessageBody ✓  MessageGroupId=test-app-e2e ✓  EB placeholder ✓

Waiting for EB to fire (up to 3 min)...
Received message (1252 bytes)
Payload: monitorId=e2e-1777266565689 jobStartTime=2026-04-27T05:09:26Z ✓

Updating schedule (disable monitor)...
Schedule state after update: DISABLED ✓

Deleting schedule...
Schedule deleted ✓
Idempotent delete ✓

=== E2E CREATE/UPDATE/DELETE TEST PASSED ===

### E2E Test 2: MonitorJobPoller — SQS → Execute Monitor → Alert Created


Created monitor: xstdzZ0BIfTj63wpIKhF
Sent SQS message: monitorId=xstdzZ0BIfTj63wpIKhF jobStartTime=2026-04-27T05:15:25.813Z

Starting MonitorJobPoller with 10 workers
Received message 132bc1e3-d750-4bff-9112-7964407d2c36
 from queue https://sqs.us-west-2.amazonaws.com/333654771707/alerting-poller-test
Parsed monitor [xstdzZ0BIfTj63wpIKhF] type [query_level_monitor] jobStartTime [2026-04-27T05:15:25.813Z]
Executing monitor from API - id: xstdzZ0BIfTj63wpIKhF, type: query_level_monitor
 periodStart: 2026-04-27T05:10:25.813Z, periodEnd: 2026-04-27T05:15:25.813Z, dryrun: false

Poller stopped
SQS queue empty ✓
Alerts created: 1 ✓
Monitor execution verified ✓

=== POLLER E2E TEST PASSED ===
