### PR TITLE
Feature/use schedule job payload

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -53,6 +53,7 @@ import org.opensearch.common.inject.Inject
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
+import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.alerting.action.AlertingActions
@@ -62,13 +63,13 @@ import org.opensearch.commons.alerting.model.DocLevelMonitorInput
 import org.opensearch.commons.alerting.model.DocLevelMonitorInput.Companion.DOC_LEVEL_INPUT_FIELD
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.MonitorMetadata
+import org.opensearch.commons.alerting.model.ScheduleJobPayload
 import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.model.ScheduledJob.Companion.SCHEDULED_JOBS_INDEX
 import org.opensearch.commons.alerting.model.SearchInput
 import org.opensearch.commons.alerting.model.remote.monitors.RemoteDocLevelMonitorInput
 import org.opensearch.commons.alerting.model.remote.monitors.RemoteDocLevelMonitorInput.Companion.REMOTE_DOC_LEVEL_MONITOR_INPUT_FIELD
 import org.opensearch.commons.alerting.util.AlertingException
-import org.opensearch.commons.alerting.util.SchedulePayloadBuilder
 import org.opensearch.commons.alerting.util.isMonitorOfStandardType
 import org.opensearch.commons.authuser.User
 import org.opensearch.commons.utils.recreateObject
@@ -846,7 +847,7 @@ class TransportIndexMonitorAction @Inject constructor(
          */
         private fun createExternalSchedule(monitor: Monitor, tenantId: String?) {
             val routing = resolveRouting() ?: return
-            val targetInput = SchedulePayloadBuilder.buildTargetInput(monitor, ExternalSchedulerService.EB_SCHEDULED_TIME_PLACEHOLDER)
+            val targetInput = buildScheduleJobPayloadJson(monitor)
             ExternalSchedulerService.createSchedule(monitor, routing, targetInput)
         }
 
@@ -857,8 +858,26 @@ class TransportIndexMonitorAction @Inject constructor(
          */
         private fun updateExternalSchedule(monitor: Monitor, tenantId: String?) {
             val routing = resolveRouting() ?: return
-            val targetInput = SchedulePayloadBuilder.buildTargetInput(monitor, ExternalSchedulerService.EB_SCHEDULED_TIME_PLACEHOLDER)
+            val targetInput = buildScheduleJobPayloadJson(monitor)
             ExternalSchedulerService.updateSchedule(monitor, routing, targetInput)
+        }
+
+        /**
+         * Builds a JSON string matching [ScheduleJobPayload] schema for the EB schedule target input.
+         * Uses the EB placeholder for job_start_time which the scheduler replaces at invocation time
+         * with a real ISO-8601 timestamp that [ScheduleJobPayload.parse] can deserialize.
+         */
+        private fun buildScheduleJobPayloadJson(monitor: Monitor): String {
+            val monitorConfigBuilder = XContentFactory.jsonBuilder()
+            monitor.toXContent(monitorConfigBuilder, ToXContent.EMPTY_PARAMS)
+            val payload = ScheduleJobPayload(
+                monitorId = monitor.id,
+                jobStartTime = ExternalSchedulerService.EB_SCHEDULED_TIME_PLACEHOLDER,
+                monitorConfig = monitorConfigBuilder.toString()
+            )
+            val builder = XContentFactory.jsonBuilder()
+            payload.toXContent(builder, ToXContent.EMPTY_PARAMS)
+            return builder.toString()
         }
 
         private fun resolveRouting(): SchedulerRoutingResolver.Routing? = SchedulerRoutingResolver.resolve(

--- a/alerting/src/test/kotlin/org/opensearch/alerting/service/ExternalSchedulerServiceTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/service/ExternalSchedulerServiceTests.kt
@@ -6,10 +6,14 @@
 package org.opensearch.alerting.service
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.commons.alerting.model.IntervalSchedule
 import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.ScheduleJobPayload
 import org.opensearch.commons.alerting.model.SearchInput
+import org.opensearch.core.xcontent.ToXContent
 import org.opensearch.index.query.QueryBuilders
 import org.opensearch.search.builder.SearchSourceBuilder
 import java.time.Instant
@@ -36,6 +40,19 @@ class ExternalSchedulerServiceTests {
         )
     }
 
+    private fun buildPayloadJson(monitor: Monitor): String {
+        val configBuilder = XContentFactory.jsonBuilder()
+        monitor.toXContent(configBuilder, ToXContent.EMPTY_PARAMS)
+        val payload = ScheduleJobPayload(
+            monitorId = monitor.id,
+            jobStartTime = ExternalSchedulerService.EB_SCHEDULED_TIME_PLACEHOLDER,
+            monitorConfig = configBuilder.toString()
+        )
+        val builder = XContentFactory.jsonBuilder()
+        payload.toXContent(builder, ToXContent.EMPTY_PARAMS)
+        return builder.toString()
+    }
+
     @Test
     fun `scheduleName formats correctly`() {
         assertEquals("monitor-abc123", ExternalSchedulerService.scheduleName("abc123"))
@@ -43,14 +60,26 @@ class ExternalSchedulerServiceTests {
 
     @Test
     fun `createSchedule does not throw`() {
+        val monitor = testMonitor()
         val routing = SchedulerRoutingResolver.Routing("111111111111", "arn:aws:sqs:us-east-1:111:queue", "arn:aws:iam::111:role/test")
-        ExternalSchedulerService.createSchedule(testMonitor(), routing, "{}")
+        ExternalSchedulerService.createSchedule(monitor, routing, buildPayloadJson(monitor))
     }
 
     @Test
     fun `updateSchedule does not throw`() {
+        val monitor = testMonitor()
         val routing = SchedulerRoutingResolver.Routing("222222222222", "arn:aws:sqs:us-west-2:222:queue", "arn:aws:iam::222:role/test")
-        ExternalSchedulerService.updateSchedule(testMonitor(), routing, "{}")
+        ExternalSchedulerService.updateSchedule(monitor, routing, buildPayloadJson(monitor))
+    }
+
+    @Test
+    fun `payload json contains all ScheduleJobPayload fields`() {
+        val monitor = testMonitor()
+        val json = buildPayloadJson(monitor)
+        assertTrue(json.contains("\"${ScheduleJobPayload.MONITOR_ID_FIELD}\""))
+        assertTrue(json.contains("\"${ScheduleJobPayload.JOB_START_TIME_FIELD}\""))
+        assertTrue(json.contains("\"${ScheduleJobPayload.MONITOR_CONFIG_FIELD}\""))
+        assertTrue(json.contains(ExternalSchedulerService.EB_SCHEDULED_TIME_PLACEHOLDER))
     }
 
     @Test


### PR DESCRIPTION
### Description

This PR migrates the alerting plugin from SchedulePayloadBuilder.buildTargetInput() to the new ScheduleJobPayload POJO introduced in common-utils #943 for building SQS message payloads. The key change is that the target input JSON now includes monitorId as a top-level field alongside job_start_time and monitorConfig, matching the ScheduleJobPayload schema that the SQS consumer uses for deserialization via ScheduleJobPayload.parse(). Since the EB placeholder <aws.scheduler.scheduled-time> isn't a valid Instant at schedule-creation time, the producer side builds the JSON manually using ScheduleJobPayload field constants while keeping the placeholder as a raw string — EventBridge replaces it with a real ISO-8601 timestamp at invocation time. Unit tests are updated to use realistic payload JSON instead of empty {} stubs, and a new test validates that the generated payload contains all required ScheduleJobPayload fields.


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
