### PR TITLE
Use toXContentWithUser for SQS payload monitor serialization

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -869,7 +869,7 @@ class TransportIndexMonitorAction @Inject constructor(
          */
         private fun buildScheduleJobPayloadJson(monitor: Monitor): String {
             val monitorConfigBuilder = XContentFactory.jsonBuilder()
-            monitor.toXContent(monitorConfigBuilder, ToXContent.EMPTY_PARAMS)
+            monitor.toXContentWithUser(monitorConfigBuilder, ToXContent.EMPTY_PARAMS)
             val payload = ScheduleJobPayload(
                 monitorId = monitor.id,
                 jobStartTime = ExternalSchedulerService.EB_SCHEDULED_TIME_PLACEHOLDER,

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -1626,4 +1626,42 @@ class MonitorRestApiIT : AlertingRestTestCase() {
             client().updateSettings("plugins.alerting.monitor.max_triggers", 10)
         }
     }
+
+    @Suppress("UNCHECKED_CAST")
+    fun `test metadata field is not exposed in get monitor response`() {
+        // Create a monitor with metadata using toXContentWithUser (secure=false) so metadata is persisted
+        val monitor = randomQueryLevelMonitor().copy(
+            metadata = mapOf("appId" to "test-app", "workspaceId" to "ws-123")
+        )
+        val createResponse = client().makeRequest(
+            "POST", "$ALERTING_BASE_URI?refresh=true", emptyMap(),
+            monitor.toHttpEntityWithUser()
+        )
+        assertEquals("Create monitor failed", RestStatus.CREATED, createResponse.restStatus())
+        val createMap = createParser(XContentType.JSON.xContent(), createResponse.entity.content).map()
+        val monitorId = createMap["_id"] as String
+        val createMonitorMap = createMap["monitor"] as Map<String, Any>
+        assertFalse("Metadata should not be in create response", createMonitorMap.containsKey("metadata"))
+
+        // GET monitor — metadata should not be exposed
+        val getResponse = client().makeRequest("GET", "$ALERTING_BASE_URI/$monitorId", emptyMap())
+        assertEquals("Get monitor failed", RestStatus.OK, getResponse.restStatus())
+        val getMap = createParser(XContentType.JSON.xContent(), getResponse.entity.content).map()
+        val getMonitorMap = getMap["monitor"] as Map<String, Any>
+        assertFalse("Metadata should not be in get response", getMonitorMap.containsKey("metadata"))
+
+        // Search monitor — metadata should not be exposed
+        val search = SearchSourceBuilder().query(QueryBuilders.termQuery("_id", monitorId)).toString()
+        val searchResponse = client().makeRequest(
+            "GET", "$ALERTING_BASE_URI/_search", emptyMap(),
+            StringEntity(search, ContentType.APPLICATION_JSON)
+        )
+        assertEquals("Search monitor failed", RestStatus.OK, searchResponse.restStatus())
+        val searchMap = createParser(XContentType.JSON.xContent(), searchResponse.entity.content).map()
+        val hits = searchMap["hits"] as Map<String, Any>
+        val hitsList = hits["hits"] as List<Map<String, Any>>
+        assertFalse("Search should return results", hitsList.isEmpty())
+        val source = hitsList[0]["_source"] as Map<String, Any>
+        assertFalse("Metadata should not be in search response", source.containsKey("metadata"))
+    }
 }


### PR DESCRIPTION
* Switch buildScheduleJobPayloadJson from `toXContent()` to `toXContentWithUser()` so the SQS payload includes metadata and user context. The SQS payload is internal (not customer-facing), so it should use secure=false to include all fields needed by the consumer. This is a companion change to the common-utils fix that hides metadata from REST API responses.

* toXContentWithUser() call also includes the user field in the SQS payload

Depends on: opensearch-project/common-utils#XXX

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
