### PR TITLE
 Make MonitorJobPoller populate thread context for downstream request interception

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -379,7 +379,10 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             MULTI_TENANCY_ENABLED.get(settings),
             if (providerType.isNotEmpty()) JobQueueAccountIdProvider.find(providerType, settings) else null,
             REMOTE_METADATA_REGION.get(settings) ?: "",
-            AlertingSettings.JOB_QUEUE_NAME.get(settings) ?: ""
+            AlertingSettings.JOB_QUEUE_NAME.get(settings) ?: "",
+            AlertingSettings.JOB_QUEUE_TARGET_TYPE_TO_SERVICE_NAME.get(settings).let {
+                it.keySet().associateWith { key -> it.get(key) }
+            }
         )
 
         ExternalSchedulerService.initialize(settings)
@@ -491,7 +494,8 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             AlertingSettings.JOB_QUEUE_MESSAGE_GROUP_KEY_NAME,
             AlertingSettings.EXTERNAL_SCHEDULER_ROLE_ARN,
             AlertingSettings.JOB_QUEUE_ACCOUNT_ID,
-            AlertingSettings.JOB_QUEUE_ACCOUNT_PROVIDER_TYPE
+            AlertingSettings.JOB_QUEUE_ACCOUNT_PROVIDER_TYPE,
+            AlertingSettings.JOB_QUEUE_TARGET_TYPE_TO_SERVICE_NAME
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -380,7 +380,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             if (providerType.isNotEmpty()) JobQueueAccountIdProvider.find(providerType, settings) else null,
             REMOTE_METADATA_REGION.get(settings) ?: "",
             AlertingSettings.JOB_QUEUE_NAME.get(settings) ?: "",
-            AlertingSettings.JOB_QUEUE_TARGET_TYPE_TO_SERVICE_NAME.get(settings).let {
+            AlertingSettings.TARGET_TYPE_TO_SERVICE_NAME.get(settings).let {
                 it.keySet().associateWith { key -> it.get(key) }
             }
         )
@@ -495,7 +495,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             AlertingSettings.EXTERNAL_SCHEDULER_ROLE_ARN,
             AlertingSettings.JOB_QUEUE_ACCOUNT_ID,
             AlertingSettings.JOB_QUEUE_ACCOUNT_PROVIDER_TYPE,
-            AlertingSettings.JOB_QUEUE_TARGET_TYPE_TO_SERVICE_NAME
+            AlertingSettings.TARGET_TYPE_TO_SERVICE_NAME
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
@@ -5,6 +5,8 @@
 
 package org.opensearch.alerting.service
 
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -30,8 +32,6 @@ import software.amazon.awssdk.services.sqs.SqsClient
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest
 import software.amazon.awssdk.services.sqs.model.Message
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
-import java.time.Instant
-import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Polls SQS queues for monitor execution messages and dispatches them
@@ -65,6 +65,7 @@ class MonitorJobPoller(
         }
         val provider = requireNotNull(accountIdProvider) { "accountIdProvider must be set before starting" }
         val sqs = requireNotNull(sqsClient) { "sqsClient must be set before starting" }
+        require(region.isNotBlank()) { "region must be set before starting" }
 
         logger.info("Starting MonitorJobPoller with $POLLER_THREAD_COUNT workers")
         repeat(POLLER_THREAD_COUNT) { scope.launch { pollLoop(provider, sqs, region, queueName) } }
@@ -194,28 +195,41 @@ class MonitorJobPoller(
             )
         }
 
-        if (region.isBlank()) {
+        if (monitor.target!!.type.isBlank()) {
             throw AlertingException.wrap(
-                IllegalStateException("No region configured when populating thread context from job poller")
+                IllegalStateException("Monitor target received by Job Poller did not contain target type")
+            )
+        }
+
+        if (monitor.target!!.endpoint.isBlank()) {
+            throw AlertingException.wrap(
+                IllegalStateException("Monitor target received by Job Poller did not contain endpoint")
             )
         }
 
         val threadContext = client.threadPool().threadContext
 
-        // Request interception checks for this flag to know that because this is
-        // a scheduled background monitor execution, there will be
+        // Request interception checks for this flag to know that this is
+        // a scheduled background monitor execution, meaning there will be
         // no user credentials to make the search/ppl call to customer
         // data source with, and it must use service credentials
         threadContext.putHeader(IS_BACKGROUND_JOB_HEADER, "true")
 
-        // TODO: in long term, may need to generalize to aos data source type
-        threadContext.putHeader(SERVICE_NAME_HEADER, "aoss")
+        threadContext.putHeader(SERVICE_NAME_HEADER, mapTargetTypeToServiceName(monitor.target!!.type))
 
         // external customer data source endpoint, to run search/ppl against
         threadContext.putHeader(OPENSEARCH_ENDPOINT_HEADER, monitor.target!!.endpoint)
 
         // populated upstream in AlertingPlugin.kt with REMOTE_METADATA_REGION.get(settings)
         threadContext.putHeader(REGION_HEADER, region)
+    }
+
+    private fun mapTargetTypeToServiceName(targetType: String): String {
+        return when (targetType) {
+            "AOSS_COLLECTION" -> "aoss"
+            "AOS_DOMAIN" -> "es"
+            else -> throw AlertingException.wrap(IllegalStateException("Received unknown target type in Job Poller: " + targetType))
+        }
     }
 
     companion object {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
@@ -134,7 +134,7 @@ class MonitorJobPoller(
     }
 
     private suspend fun executeMonitor(monitor: Monitor, jobStartTime: Instant) {
-        // populate thread context for downstream Oasis interception the moment
+        // populate thread context for downstream request interception the moment
         // Monitor config is in hand
         populateThreadContext(monitor)
 
@@ -184,8 +184,8 @@ class MonitorJobPoller(
         }
     }
 
-    // populates thread context with KVs that Oasis will need
-    // when intercepting search or PPL calls to external customer
+    // populates thread context with KVs that downstream interception will
+    // need when intercepting search or PPL calls to external customer
     // data source
     internal fun populateThreadContext(monitor: Monitor) {
         if (monitor.target == null) {
@@ -202,7 +202,7 @@ class MonitorJobPoller(
 
         val threadContext = client.threadPool().threadContext
 
-        // Oasis checks for this flag to know that because this is
+        // Request interception checks for this flag to know that because this is
         // a scheduled background monitor execution, there will be
         // no user credentials to make the search/ppl call to customer
         // data source with, and it must use service credentials
@@ -222,7 +222,7 @@ class MonitorJobPoller(
         const val POLLER_THREAD_COUNT = 10
         const val POLL_INTERVAL_MS = 1000L
 
-        // thread context header keys for Oasis interception
+        // thread context header keys for request interception
         const val IS_BACKGROUND_JOB_HEADER = "alerting-is-background-job"
         const val SERVICE_NAME_HEADER = "aws-service-name"
         const val OPENSEARCH_ENDPOINT_HEADER = "opensearch-url"

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
@@ -226,9 +226,10 @@ class MonitorJobPoller(
 
     private fun mapTargetTypeToServiceName(targetType: String): String {
         return when (targetType) {
-            "AOSS_COLLECTION" -> "aoss"
-            "AOS_DOMAIN" -> "es"
-            else -> throw AlertingException.wrap(IllegalStateException("Received unknown target type in Job Poller: " + targetType))
+            AOSS_COLLECTION -> AOSS_SERVICE_NAME
+            AOS_DOMAIN -> AOS_SERVICE_NAME
+            // default target type of "local" is invalid and will throw exception
+            else -> throw AlertingException.wrap(IllegalStateException("Received invalid target type in Job Poller: " + targetType))
         }
     }
 
@@ -241,5 +242,13 @@ class MonitorJobPoller(
         const val SERVICE_NAME_HEADER = "aws-service-name"
         const val OPENSEARCH_ENDPOINT_HEADER = "opensearch-url"
         const val REGION_HEADER = "aws-region"
+
+        // target types
+        const val AOSS_COLLECTION = "AOSS_COLLECTION"
+        const val AOS_DOMAIN = "AOS_DOMAIN"
+
+        // service names
+        const val AOSS_SERVICE_NAME = "aoss"
+        const val AOS_SERVICE_NAME = "es"
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
@@ -242,7 +242,7 @@ class MonitorJobPoller(
 
         // thread context header keys for request interception
         const val OPERATION_NAME_HEADER = "x-amzn-oasis-operation"
-        const val IS_BACKGROUND_JOB_HEADER = "alerting-is-background-job"
+        const val IS_BACKGROUND_JOB_HEADER = "is-observability-bg-job"
         const val SERVICE_NAME_HEADER = "aws-service-name"
         const val OPENSEARCH_ENDPOINT_HEADER = "opensearch-url"
         const val REGION_HEADER = "aws-region"

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
@@ -22,6 +22,7 @@ import org.opensearch.common.xcontent.LoggingDeprecationHandler
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.ScheduleJobPayload
+import org.opensearch.commons.alerting.model.Target
 import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.commons.utils.scheduler.JobQueueAccountIdProvider
 import org.opensearch.core.xcontent.NamedXContentRegistry
@@ -137,7 +138,7 @@ class MonitorJobPoller(
     private suspend fun executeMonitor(monitor: Monitor, jobStartTime: Instant) {
         // populate thread context for downstream request interception the moment
         // Monitor config is in hand
-        populateThreadContext(monitor)
+        populateThreadContext(monitor.target)
 
         val request = ExecuteMonitorRequest(
             dryrun = false,
@@ -188,20 +189,20 @@ class MonitorJobPoller(
     // populates thread context with KVs that downstream interception will
     // need when intercepting search or PPL calls to external customer
     // data source
-    internal fun populateThreadContext(monitor: Monitor) {
-        if (monitor.target == null) {
+    internal fun populateThreadContext(target: Target?) {
+        if (target == null) {
             throw AlertingException.wrap(
                 IllegalStateException("Monitor received by Job Poller did not contain target")
             )
         }
 
-        if (monitor.target!!.type.isBlank()) {
+        if (target.type.isBlank()) {
             throw AlertingException.wrap(
                 IllegalStateException("Monitor target received by Job Poller did not contain target type")
             )
         }
 
-        if (monitor.target!!.endpoint.isBlank()) {
+        if (target.endpoint.isBlank()) {
             throw AlertingException.wrap(
                 IllegalStateException("Monitor target received by Job Poller did not contain endpoint")
             )
@@ -215,10 +216,10 @@ class MonitorJobPoller(
         // data source with, and it must use service credentials
         threadContext.putHeader(IS_BACKGROUND_JOB_HEADER, "true")
 
-        threadContext.putHeader(SERVICE_NAME_HEADER, mapTargetTypeToServiceName(monitor.target!!.type))
+        threadContext.putHeader(SERVICE_NAME_HEADER, mapTargetTypeToServiceName(target.type))
 
         // external customer data source endpoint, to run search/ppl against
-        threadContext.putHeader(OPENSEARCH_ENDPOINT_HEADER, monitor.target!!.endpoint)
+        threadContext.putHeader(OPENSEARCH_ENDPOINT_HEADER, target.endpoint)
 
         // populated upstream in AlertingPlugin.kt with REMOTE_METADATA_REGION.get(settings)
         threadContext.putHeader(REGION_HEADER, region)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
@@ -210,6 +210,8 @@ class MonitorJobPoller(
 
         val threadContext = client.threadPool().threadContext
 
+        threadContext.putHeader(OPERATION_NAME_HEADER, ALERTING_OP_TYPE)
+
         // Request interception checks for this flag to know that this is
         // a scheduled background monitor execution, meaning there will be
         // no user credentials to make the search/ppl call to customer
@@ -239,10 +241,14 @@ class MonitorJobPoller(
         const val POLL_INTERVAL_MS = 1000L
 
         // thread context header keys for request interception
+        const val OPERATION_NAME_HEADER = "x-amzn-oasis-operation"
         const val IS_BACKGROUND_JOB_HEADER = "alerting-is-background-job"
         const val SERVICE_NAME_HEADER = "aws-service-name"
         const val OPENSEARCH_ENDPOINT_HEADER = "opensearch-url"
         const val REGION_HEADER = "aws-region"
+
+        // operation type
+        const val ALERTING_OP_TYPE = "Alerting"
 
         // target types
         const val AOSS_COLLECTION = "AOSS_COLLECTION"

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
@@ -134,6 +134,10 @@ class MonitorJobPoller(
     }
 
     private suspend fun executeMonitor(monitor: Monitor, jobStartTime: Instant) {
+        // populate thread context for downstream Oasis interception the moment
+        // Monitor config is in hand
+        populateThreadContext(monitor)
+
         val request = ExecuteMonitorRequest(
             dryrun = false,
             requestEnd = TimeValue(jobStartTime.toEpochMilli()),
@@ -180,8 +184,48 @@ class MonitorJobPoller(
         }
     }
 
+    // populates thread context with KVs that Oasis will need
+    // when intercepting search or PPL calls to external customer
+    // data source
+    private fun populateThreadContext(monitor: Monitor) {
+        if (monitor.target == null) {
+            throw AlertingException.wrap(
+                IllegalStateException("Monitor received by Job Poller did not contain target")
+            )
+        }
+
+        if (region.isBlank()) {
+            throw AlertingException.wrap(
+                IllegalStateException("Monitor received by Job Poller did not contain target")
+            )
+        }
+
+        val threadContext = client.threadPool().threadContext
+
+        // Oasis checks for this flag to know that because this is
+        // a scheduled background monitor execution, there will be
+        // no user credentials to make the search/ppl call to customer
+        // data source with, and it must use service credentials
+        threadContext.putHeader(IS_BACKGROUND_JOB_HEADER, "true")
+
+        // TODO: in long term, may need to generalize to aos data source type
+        threadContext.putHeader(SERVICE_NAME_HEADER, "aoss")
+
+        // external customer data source endpoint, to run search/ppl against
+        threadContext.putHeader(OPENSEARCH_ENDPOINT_HEADER, monitor.target!!.endpoint)
+
+        // populated upstream in AlertingPlugin.kt with REMOTE_METADATA_REGION.get(settings)
+        threadContext.putHeader(REGION_HEADER, region)
+    }
+
     companion object {
         const val POLLER_THREAD_COUNT = 10
         const val POLL_INTERVAL_MS = 1000L
+
+        // thread context header keys for Oasis interception
+        const val IS_BACKGROUND_JOB_HEADER = "alerting-is-background-job"
+        const val SERVICE_NAME_HEADER = "aws-service-name"
+        const val OPENSEARCH_ENDPOINT_HEADER = "opensearch-url"
+        const val REGION_HEADER = "aws-region"
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
@@ -187,7 +187,7 @@ class MonitorJobPoller(
     // populates thread context with KVs that Oasis will need
     // when intercepting search or PPL calls to external customer
     // data source
-    private fun populateThreadContext(monitor: Monitor) {
+    internal fun populateThreadContext(monitor: Monitor) {
         if (monitor.target == null) {
             throw AlertingException.wrap(
                 IllegalStateException("Monitor received by Job Poller did not contain target")
@@ -196,7 +196,7 @@ class MonitorJobPoller(
 
         if (region.isBlank()) {
             throw AlertingException.wrap(
-                IllegalStateException("Monitor received by Job Poller did not contain target")
+                IllegalStateException("No region configured when populating thread context from job poller")
             )
         }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
@@ -5,8 +5,6 @@
 
 package org.opensearch.alerting.service
 
-import java.time.Instant
-import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -32,6 +30,8 @@ import software.amazon.awssdk.services.sqs.SqsClient
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest
 import software.amazon.awssdk.services.sqs.model.Message
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Polls SQS queues for monitor execution messages and dispatches them

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
@@ -49,7 +49,8 @@ class MonitorJobPoller(
     private val enabled: Boolean,
     private val accountIdProvider: JobQueueAccountIdProvider?,
     private val region: String,
-    private val queueName: String
+    private val queueName: String,
+    private val targetTypeToServiceName: Map<String, String>
 ) : AbstractLifecycleComponent() {
 
     private val logger = LogManager.getLogger(MonitorJobPoller::class.java)
@@ -210,8 +211,6 @@ class MonitorJobPoller(
 
         val threadContext = client.threadPool().threadContext
 
-        threadContext.putHeader(OPERATION_NAME_HEADER, ALERTING_OP_TYPE)
-
         // Request interception checks for this flag to know that this is
         // a scheduled background monitor execution, meaning there will be
         // no user credentials to make the search/ppl call to customer
@@ -228,12 +227,16 @@ class MonitorJobPoller(
     }
 
     private fun mapTargetTypeToServiceName(targetType: String): String {
-        return when (targetType) {
-            AOSS_COLLECTION -> AOSS_SERVICE_NAME
-            AOS_DOMAIN -> AOS_SERVICE_NAME
-            // default target type of "local" is invalid and will throw exception
-            else -> throw AlertingException.wrap(IllegalStateException("Received invalid target type in Job Poller: " + targetType))
+        if (!targetTypeToServiceName.containsKey(targetType)) {
+            throw AlertingException.wrap(
+                IllegalStateException(
+                    "Received invalid target type in Job Poller: " + targetType +
+                        ", expected one of: " + targetTypeToServiceName.keys
+                )
+            )
         }
+
+        return targetTypeToServiceName[targetType]!!
     }
 
     companion object {
@@ -241,21 +244,9 @@ class MonitorJobPoller(
         const val POLL_INTERVAL_MS = 1000L
 
         // thread context header keys for request interception
-        const val OPERATION_NAME_HEADER = "x-amzn-oasis-operation"
         const val IS_BACKGROUND_JOB_HEADER = "is-observability-bg-job"
         const val SERVICE_NAME_HEADER = "aws-service-name"
         const val OPENSEARCH_ENDPOINT_HEADER = "opensearch-url"
         const val REGION_HEADER = "aws-region"
-
-        // operation type
-        const val ALERTING_OP_TYPE = "Alerting"
-
-        // target types
-        const val AOSS_COLLECTION = "AOSS_COLLECTION"
-        const val AOS_DOMAIN = "AOS_DOMAIN"
-
-        // service names
-        const val AOSS_SERVICE_NAME = "aoss"
-        const val AOS_SERVICE_NAME = "es"
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
@@ -405,8 +405,10 @@ class AlertingSettings {
             Setting.Property.NodeScope, Setting.Property.Dynamic
         )
 
-        val JOB_QUEUE_TARGET_TYPE_TO_SERVICE_NAME = Setting.groupSetting(
-            "plugins.alerting.external_scheduler.type_to_service.",
+        /** Mappings from Monitor target type to opensearch service name, used in MonitorJobPoller
+         * to populate thread context with required Monitor target information */
+        val TARGET_TYPE_TO_SERVICE_NAME = Setting.groupSetting(
+            "plugins.alerting.monitor.target_type_to_service_name.",
             Setting.Property.NodeScope, Setting.Property.Dynamic
         )
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
@@ -404,5 +404,10 @@ class AlertingSettings {
             "plugins.alerting.external_scheduler.job_queue_message_group_key_name",
             Setting.Property.NodeScope, Setting.Property.Dynamic
         )
+
+        val JOB_QUEUE_TARGET_TYPE_TO_SERVICE_NAME = Setting.groupSetting(
+            "plugins.alerting.external_scheduler.type_to_service.",
+            Setting.Property.NodeScope, Setting.Property.Dynamic
+        )
     }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/service/MonitorJobPollerTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/service/MonitorJobPollerTests.kt
@@ -9,7 +9,11 @@ import com.carrotsearch.randomizedtesting.ThreadFilter
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import org.opensearch.alerting.randomQueryLevelMonitor
+import org.opensearch.alerting.service.MonitorJobPoller.Companion.ALERTING_OP_TYPE
+import org.opensearch.alerting.service.MonitorJobPoller.Companion.AOSS_COLLECTION
+import org.opensearch.alerting.service.MonitorJobPoller.Companion.AOSS_SERVICE_NAME
+import org.opensearch.alerting.service.MonitorJobPoller.Companion.AOS_DOMAIN
+import org.opensearch.alerting.service.MonitorJobPoller.Companion.AOS_SERVICE_NAME
 import org.opensearch.common.settings.Settings
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.SearchInput
@@ -135,6 +139,17 @@ class MonitorJobPollerTests : OpenSearchTestCase() {
         val poller = MonitorJobPoller(
             testXContentRegistry(), mockClient(), true,
             null, "us-west-2", "test-queue"
+        )
+        expectThrows(Exception::class.java) {
+            poller.start()
+        }
+        poller.close()
+    }
+
+    fun `test start throws when region not set`() {
+        val poller = MonitorJobPoller(
+            testXContentRegistry(), mockClient(), true,
+            testAccountIdProvider(), "", "test-queue"
         )
         expectThrows(Exception::class.java) {
             poller.start()
@@ -339,7 +354,7 @@ class MonitorJobPollerTests : OpenSearchTestCase() {
         poller.close()
     }
 
-    fun `test thread context populated correctly`() {
+    fun `test thread context populated correctly with aoss endpoint`() {
         val mockClient = mockClient()
         val mockThreadPool = mock(org.opensearch.threadpool.ThreadPool::class.java)
         val mockThreadContext = org.opensearch.common.util.concurrent.ThreadContext(Settings.EMPTY)
@@ -352,14 +367,58 @@ class MonitorJobPollerTests : OpenSearchTestCase() {
             testAccountIdProvider(), "us-east-1", "test-queue"
         )
 
-        val monitor = randomQueryLevelMonitor().copy(target = Target(endpoint = "https://test.aoss.amazonaws.com"))
+        val target = Target(type = AOSS_COLLECTION, endpoint = "https://test.aoss.amazonaws.com")
 
-        poller.populateThreadContext(monitor)
+        poller.populateThreadContext(target)
 
+        assertEquals(ALERTING_OP_TYPE, mockThreadContext.getHeader(MonitorJobPoller.OPERATION_NAME_HEADER))
         assertEquals("true", mockThreadContext.getHeader(MonitorJobPoller.IS_BACKGROUND_JOB_HEADER))
-        assertEquals("aoss", mockThreadContext.getHeader(MonitorJobPoller.SERVICE_NAME_HEADER))
+        assertEquals(AOSS_SERVICE_NAME, mockThreadContext.getHeader(MonitorJobPoller.SERVICE_NAME_HEADER))
         assertEquals("https://test.aoss.amazonaws.com", mockThreadContext.getHeader(MonitorJobPoller.OPENSEARCH_ENDPOINT_HEADER))
         assertEquals("us-east-1", mockThreadContext.getHeader(MonitorJobPoller.REGION_HEADER))
+
+        poller.close()
+    }
+
+    fun `test thread context populated correctly with aos endpoint`() {
+        val mockClient = mockClient()
+        val mockThreadPool = mock(org.opensearch.threadpool.ThreadPool::class.java)
+        val mockThreadContext = org.opensearch.common.util.concurrent.ThreadContext(Settings.EMPTY)
+
+        `when`(mockClient.threadPool()).thenReturn(mockThreadPool)
+        `when`(mockThreadPool.threadContext).thenReturn(mockThreadContext)
+
+        val poller = MonitorJobPoller(
+            testXContentRegistry(), mockClient, true,
+            testAccountIdProvider(), "us-east-1", "test-queue"
+        )
+
+        val target = Target(type = AOS_DOMAIN, endpoint = "https://test.es.amazonaws.com")
+
+        poller.populateThreadContext(target)
+
+        assertEquals(ALERTING_OP_TYPE, mockThreadContext.getHeader(MonitorJobPoller.OPERATION_NAME_HEADER))
+        assertEquals("true", mockThreadContext.getHeader(MonitorJobPoller.IS_BACKGROUND_JOB_HEADER))
+        assertEquals(AOS_SERVICE_NAME, mockThreadContext.getHeader(MonitorJobPoller.SERVICE_NAME_HEADER))
+        assertEquals("https://test.es.amazonaws.com", mockThreadContext.getHeader(MonitorJobPoller.OPENSEARCH_ENDPOINT_HEADER))
+        assertEquals("us-east-1", mockThreadContext.getHeader(MonitorJobPoller.REGION_HEADER))
+
+        poller.close()
+    }
+
+    fun `test thread context population rejects invalid target type`() {
+        val mockClient = mockClient()
+
+        val poller = MonitorJobPoller(
+            testXContentRegistry(), mockClient, true,
+            testAccountIdProvider(), "us-east-1", "test-queue"
+        )
+
+        val target = Target(type = "local", endpoint = "https://test.aoss.amazonaws.com")
+
+        expectThrows(Exception::class.java) {
+            poller.populateThreadContext(target)
+        }
 
         poller.close()
     }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/service/MonitorJobPollerTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/service/MonitorJobPollerTests.kt
@@ -9,11 +9,6 @@ import com.carrotsearch.randomizedtesting.ThreadFilter
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import org.opensearch.alerting.service.MonitorJobPoller.Companion.ALERTING_OP_TYPE
-import org.opensearch.alerting.service.MonitorJobPoller.Companion.AOSS_COLLECTION
-import org.opensearch.alerting.service.MonitorJobPoller.Companion.AOSS_SERVICE_NAME
-import org.opensearch.alerting.service.MonitorJobPoller.Companion.AOS_DOMAIN
-import org.opensearch.alerting.service.MonitorJobPoller.Companion.AOS_SERVICE_NAME
 import org.opensearch.common.settings.Settings
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.SearchInput
@@ -63,6 +58,13 @@ class MonitorJobPollerTests : OpenSearchTestCase() {
         }
     }
 
+    private fun mappingProvider(): Map<String, String> {
+        return mapOf(
+            "target_1" to "service_1",
+            "target_2" to "service_2"
+        )
+    }
+
     private fun validMessageBody(): String {
         val monitorConfig = "{\"type\":\"monitor\",\"name\":\"test\"," +
             "\"monitor_type\":\"query_level_monitor\",\"enabled\":true," +
@@ -82,7 +84,8 @@ class MonitorJobPollerTests : OpenSearchTestCase() {
     ): MonitorJobPoller {
         return MonitorJobPoller(
             testXContentRegistry(), mockClient(), enabled,
-            testAccountIdProvider(), "us-west-2", "test-queue"
+            testAccountIdProvider(), "us-west-2", "test-queue",
+            mappingProvider()
         ).also { it.sqsClient = sqsClient }
     }
 
@@ -108,7 +111,8 @@ class MonitorJobPollerTests : OpenSearchTestCase() {
         val sqsClient = FakeSqsClient()
         val poller = MonitorJobPoller(
             testXContentRegistry(), mockClient(), true,
-            testAccountIdProvider(), "us-west-2", "test-queue"
+            testAccountIdProvider(), "us-west-2", "test-queue",
+            mappingProvider()
         ).also { it.sqsClient = sqsClient }
         poller.start()
         Thread.sleep(100)
@@ -126,7 +130,7 @@ class MonitorJobPollerTests : OpenSearchTestCase() {
         )
         val poller = MonitorJobPoller(
             testXContentRegistry(), mockClient(), false,
-            null, "", ""
+            null, "", "", mappingProvider()
         )
         poller.start()
         // Should NOT poll since disabled
@@ -138,7 +142,7 @@ class MonitorJobPollerTests : OpenSearchTestCase() {
     fun `test start throws when provider not set`() {
         val poller = MonitorJobPoller(
             testXContentRegistry(), mockClient(), true,
-            null, "us-west-2", "test-queue"
+            null, "us-west-2", "test-queue", mappingProvider()
         )
         expectThrows(Exception::class.java) {
             poller.start()
@@ -149,7 +153,8 @@ class MonitorJobPollerTests : OpenSearchTestCase() {
     fun `test start throws when region not set`() {
         val poller = MonitorJobPoller(
             testXContentRegistry(), mockClient(), true,
-            testAccountIdProvider(), "", "test-queue"
+            testAccountIdProvider(), "", "test-queue",
+            mappingProvider()
         )
         expectThrows(Exception::class.java) {
             poller.start()
@@ -187,7 +192,8 @@ class MonitorJobPollerTests : OpenSearchTestCase() {
         }
         val poller = MonitorJobPoller(
             testXContentRegistry(), mockClient(), true,
-            errorProvider, "us-west-2", "test-queue"
+            errorProvider, "us-west-2", "test-queue",
+            mappingProvider()
         ).also { it.sqsClient = FakeSqsClient() }
         poller.start()
         assertTrue("Worker should have polled twice", latch.await(5, TimeUnit.SECONDS))
@@ -207,7 +213,8 @@ class MonitorJobPollerTests : OpenSearchTestCase() {
         }
         val poller = MonitorJobPoller(
             testXContentRegistry(), mockClient(), true,
-            emptyProvider, "us-west-2", "test-queue"
+            emptyProvider, "us-west-2", "test-queue",
+            mappingProvider()
         ).also { it.sqsClient = FakeSqsClient() }
         poller.start()
         assertTrue("Worker should have polled multiple times", latch.await(5, TimeUnit.SECONDS))
@@ -354,7 +361,7 @@ class MonitorJobPollerTests : OpenSearchTestCase() {
         poller.close()
     }
 
-    fun `test thread context populated correctly with aoss endpoint`() {
+    fun `test thread context populated correctly based on target type`() {
         val mockClient = mockClient()
         val mockThreadPool = mock(org.opensearch.threadpool.ThreadPool::class.java)
         val mockThreadContext = org.opensearch.common.util.concurrent.ThreadContext(Settings.EMPTY)
@@ -364,43 +371,18 @@ class MonitorJobPollerTests : OpenSearchTestCase() {
 
         val poller = MonitorJobPoller(
             testXContentRegistry(), mockClient, true,
-            testAccountIdProvider(), "us-east-1", "test-queue"
+            testAccountIdProvider(), "us-east-1", "test-queue",
+            mappingProvider()
         )
 
-        val target = Target(type = AOSS_COLLECTION, endpoint = "https://test.aoss.amazonaws.com")
+        val mockTargetType = mappingProvider().entries.first().key
+        val target = Target(type = mockTargetType, endpoint = "https://test.aoss.amazonaws.com")
 
         poller.populateThreadContext(target)
 
-        assertEquals(ALERTING_OP_TYPE, mockThreadContext.getHeader(MonitorJobPoller.OPERATION_NAME_HEADER))
         assertEquals("true", mockThreadContext.getHeader(MonitorJobPoller.IS_BACKGROUND_JOB_HEADER))
-        assertEquals(AOSS_SERVICE_NAME, mockThreadContext.getHeader(MonitorJobPoller.SERVICE_NAME_HEADER))
+        assertEquals(mappingProvider()[mockTargetType], mockThreadContext.getHeader(MonitorJobPoller.SERVICE_NAME_HEADER))
         assertEquals("https://test.aoss.amazonaws.com", mockThreadContext.getHeader(MonitorJobPoller.OPENSEARCH_ENDPOINT_HEADER))
-        assertEquals("us-east-1", mockThreadContext.getHeader(MonitorJobPoller.REGION_HEADER))
-
-        poller.close()
-    }
-
-    fun `test thread context populated correctly with aos endpoint`() {
-        val mockClient = mockClient()
-        val mockThreadPool = mock(org.opensearch.threadpool.ThreadPool::class.java)
-        val mockThreadContext = org.opensearch.common.util.concurrent.ThreadContext(Settings.EMPTY)
-
-        `when`(mockClient.threadPool()).thenReturn(mockThreadPool)
-        `when`(mockThreadPool.threadContext).thenReturn(mockThreadContext)
-
-        val poller = MonitorJobPoller(
-            testXContentRegistry(), mockClient, true,
-            testAccountIdProvider(), "us-east-1", "test-queue"
-        )
-
-        val target = Target(type = AOS_DOMAIN, endpoint = "https://test.es.amazonaws.com")
-
-        poller.populateThreadContext(target)
-
-        assertEquals(ALERTING_OP_TYPE, mockThreadContext.getHeader(MonitorJobPoller.OPERATION_NAME_HEADER))
-        assertEquals("true", mockThreadContext.getHeader(MonitorJobPoller.IS_BACKGROUND_JOB_HEADER))
-        assertEquals(AOS_SERVICE_NAME, mockThreadContext.getHeader(MonitorJobPoller.SERVICE_NAME_HEADER))
-        assertEquals("https://test.es.amazonaws.com", mockThreadContext.getHeader(MonitorJobPoller.OPENSEARCH_ENDPOINT_HEADER))
         assertEquals("us-east-1", mockThreadContext.getHeader(MonitorJobPoller.REGION_HEADER))
 
         poller.close()
@@ -411,10 +393,11 @@ class MonitorJobPollerTests : OpenSearchTestCase() {
 
         val poller = MonitorJobPoller(
             testXContentRegistry(), mockClient, true,
-            testAccountIdProvider(), "us-east-1", "test-queue"
+            testAccountIdProvider(), "us-east-1", "test-queue",
+            mappingProvider()
         )
 
-        val target = Target(type = "local", endpoint = "https://test.aoss.amazonaws.com")
+        val target = Target(type = "non_existent_type", endpoint = "https://test.aoss.amazonaws.com")
 
         expectThrows(Exception::class.java) {
             poller.populateThreadContext(target)

--- a/alerting/src/test/kotlin/org/opensearch/alerting/service/MonitorJobPollerTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/service/MonitorJobPollerTests.kt
@@ -8,9 +8,12 @@ package org.opensearch.alerting.service
 import com.carrotsearch.randomizedtesting.ThreadFilter
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.opensearch.alerting.randomQueryLevelMonitor
 import org.opensearch.common.settings.Settings
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.SearchInput
+import org.opensearch.commons.alerting.model.Target
 import org.opensearch.commons.utils.scheduler.JobQueueAccountIdProvider
 import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.search.SearchModule
@@ -333,6 +336,31 @@ class MonitorJobPollerTests : OpenSearchTestCase() {
         expectThrows(Exception::class.java) {
             poller.parseMessage(body)
         }
+        poller.close()
+    }
+
+    fun `test thread context populated correctly`() {
+        val mockClient = mockClient()
+        val mockThreadPool = mock(org.opensearch.threadpool.ThreadPool::class.java)
+        val mockThreadContext = org.opensearch.common.util.concurrent.ThreadContext(Settings.EMPTY)
+
+        `when`(mockClient.threadPool()).thenReturn(mockThreadPool)
+        `when`(mockThreadPool.threadContext).thenReturn(mockThreadContext)
+
+        val poller = MonitorJobPoller(
+            testXContentRegistry(), mockClient, true,
+            testAccountIdProvider(), "us-east-1", "test-queue"
+        )
+
+        val monitor = randomQueryLevelMonitor().copy(target = Target(endpoint = "https://test.aoss.amazonaws.com"))
+
+        poller.populateThreadContext(monitor)
+
+        assertEquals("true", mockThreadContext.getHeader(MonitorJobPoller.IS_BACKGROUND_JOB_HEADER))
+        assertEquals("aoss", mockThreadContext.getHeader(MonitorJobPoller.SERVICE_NAME_HEADER))
+        assertEquals("https://test.aoss.amazonaws.com", mockThreadContext.getHeader(MonitorJobPoller.OPENSEARCH_ENDPOINT_HEADER))
+        assertEquals("us-east-1", mockThreadContext.getHeader(MonitorJobPoller.REGION_HEADER))
+
         poller.close()
     }
 }


### PR DESCRIPTION
### Description
Job poller now populates the thread context with information about the external data source so downstream flows can properly intercept it and make Search and PPL calls to external data source.

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
