### PR TITLE
Disable job scheduler indices

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
@@ -183,6 +183,7 @@ class TransportExecuteMonitorAction @Inject constructor(
                 }
 
                 if (
+                    !multiTenancyEnabled &&
                     monitor.isMonitorOfStandardType() &&
                     Monitor.MonitorType.valueOf(monitor.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.DOC_LEVEL_MONITOR
                 ) {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
@@ -183,7 +183,6 @@ class TransportExecuteMonitorAction @Inject constructor(
                 }
 
                 if (
-                    !multiTenancyEnabled &&
                     monitor.isMonitorOfStandardType() &&
                     Monitor.MonitorType.valueOf(monitor.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.DOC_LEVEL_MONITOR
                 ) {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetMonitorAction.kt
@@ -72,6 +72,8 @@ class TransportGetMonitorAction @Inject constructor(
     @Volatile
     override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
 
+    private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
+
     init {
         listenFilterBySettingChange(clusterService)
     }
@@ -161,6 +163,8 @@ class TransportGetMonitorAction @Inject constructor(
     }
 
     private suspend fun getAssociatedWorkflows(id: String): List<AssociatedWorkflow> {
+        // Skip local scheduled-job index search when multi-tenancy is enabled.
+        if (multiTenancyEnabled) return emptyList()
         try {
             val associatedWorkflows = mutableListOf<AssociatedWorkflow>()
             val queryBuilder = QueryBuilders.nestedQuery(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -587,7 +587,8 @@ class TransportIndexMonitorAction @Inject constructor(
                 if (!multiTenancyEnabled) {
                     var metadata: MonitorMetadata?
                     try {
-                        var (monitorMetadata: MonitorMetadata, created: Boolean) = MonitorMetadataService.getOrCreateMetadata(request.monitor)
+                        var (monitorMetadata: MonitorMetadata, created: Boolean) =
+                            MonitorMetadataService.getOrCreateMetadata(request.monitor)
                         if (created == false) {
                             log.warn("Metadata doc id:${monitorMetadata.id} exists, but it shouldn't!")
                         }
@@ -801,10 +802,10 @@ class TransportIndexMonitorAction @Inject constructor(
                     // Recreate runContext if metadata exists
                     // Delete and insert all queries from/to queryIndex
 
-                    if (!created &&
-                        currentMonitor.isMonitorOfStandardType() &&
-                        Monitor.MonitorType.valueOf(currentMonitor.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.DOC_LEVEL_MONITOR
-                    ) {
+                    val isDocLevelMonitor = currentMonitor.isMonitorOfStandardType() &&
+                        Monitor.MonitorType.valueOf(currentMonitor.monitorType.uppercase(Locale.ROOT)) ==
+                        Monitor.MonitorType.DOC_LEVEL_MONITOR
+                    if (!created && isDocLevelMonitor) {
                         updatedMetadata = MonitorMetadataService.recreateRunContext(metadata, currentMonitor)
                         if (docLevelMonitorQueries.docLevelQueryIndexExists(currentMonitor.dataSources)) {
                             client.suspendUntil<Client, BulkByScrollResponse> {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -360,6 +360,12 @@ class TransportIndexMonitorAction @Inject constructor(
         }
 
         fun start() {
+            // When multi-tenancy is enabled, monitors are stored in remote metadata —
+            // skip local scheduled-job index creation and mapping updates.
+            if (multiTenancyEnabled) {
+                prepareMonitorIndexing()
+                return
+            }
             if (!scheduledJobIndices.scheduledJobIndexExists()) {
                 scheduledJobIndices.initScheduledJobIndex(object : ActionListener<CreateIndexResponse> {
                     override fun onResponse(response: CreateIndexResponse) {
@@ -428,6 +434,11 @@ class TransportIndexMonitorAction @Inject constructor(
             if (request.method == RestRequest.Method.PUT) {
                 scope.launch {
                     updateMonitor()
+                }
+            } else if (multiTenancyEnabled) {
+                // Skip local scheduled-job index search for monitor count when multi-tenancy is enabled.
+                scope.launch {
+                    indexMonitor()
                 }
             } else {
                 val query = QueryBuilders.boolQuery().filter(QueryBuilders.termQuery("${Monitor.MONITOR_TYPE}.type", Monitor.MONITOR_TYPE))

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -582,33 +582,36 @@ class TransportIndexMonitorAction @Inject constructor(
                 }
                 val indexResponse = putResponse.indexResponse()
                     ?: throw OpenSearchStatusException("No index response from SDK", RestStatus.INTERNAL_SERVER_ERROR)
-                var metadata: MonitorMetadata?
-                try { // delete monitor if metadata creation fails, log the right error and re-throw the error to fail listener
-                    request.monitor = request.monitor.copy(id = indexResponse.id)
-                    var (monitorMetadata: MonitorMetadata, created: Boolean) = MonitorMetadataService.getOrCreateMetadata(request.monitor)
-                    if (created == false) {
-                        log.warn("Metadata doc id:${monitorMetadata.id} exists, but it shouldn't!")
+                request.monitor = request.monitor.copy(id = indexResponse.id)
+
+                if (!multiTenancyEnabled) {
+                    var metadata: MonitorMetadata?
+                    try {
+                        var (monitorMetadata: MonitorMetadata, created: Boolean) = MonitorMetadataService.getOrCreateMetadata(request.monitor)
+                        if (created == false) {
+                            log.warn("Metadata doc id:${monitorMetadata.id} exists, but it shouldn't!")
+                        }
+                        metadata = monitorMetadata
+                    } catch (t: Exception) {
+                        log.error("failed to create metadata for monitor ${indexResponse.id}. deleting monitor")
+                        cleanupMonitorAfterPartialFailure(request.monitor, indexResponse)
+                        throw t
                     }
-                    metadata = monitorMetadata
-                } catch (t: Exception) {
-                    log.error("failed to create metadata for monitor ${indexResponse.id}. deleting monitor")
-                    cleanupMonitorAfterPartialFailure(request.monitor, indexResponse)
-                    throw t
-                }
-                try {
-                    if (
-                        request.monitor.isMonitorOfStandardType() &&
-                        Monitor.MonitorType.valueOf(request.monitor.monitorType.uppercase(Locale.ROOT)) ==
-                        Monitor.MonitorType.DOC_LEVEL_MONITOR
-                    ) {
-                        indexDocLevelMonitorQueries(request.monitor, indexResponse.id, metadata, request.refreshPolicy)
+                    try {
+                        if (
+                            request.monitor.isMonitorOfStandardType() &&
+                            Monitor.MonitorType.valueOf(request.monitor.monitorType.uppercase(Locale.ROOT)) ==
+                            Monitor.MonitorType.DOC_LEVEL_MONITOR
+                        ) {
+                            indexDocLevelMonitorQueries(request.monitor, indexResponse.id, metadata, request.refreshPolicy)
+                        }
+                        // When inserting queries in queryIndex we could update sourceToQueryIndexMapping
+                        MonitorMetadataService.upsertMetadata(metadata, updating = true)
+                    } catch (t: Exception) {
+                        log.error("failed to index doc level queries monitor ${indexResponse.id}. deleting monitor", t)
+                        cleanupMonitorAfterPartialFailure(request.monitor, indexResponse)
+                        throw t
                     }
-                    // When inserting queries in queryIndex we could update sourceToQueryIndexMapping
-                    MonitorMetadataService.upsertMetadata(metadata, updating = true)
-                } catch (t: Exception) {
-                    log.error("failed to index doc level queries monitor ${indexResponse.id}. deleting monitor", t)
-                    cleanupMonitorAfterPartialFailure(request.monitor, indexResponse)
-                    throw t
                 }
 
                 // Create external schedule for monitor execution
@@ -788,35 +791,37 @@ class TransportIndexMonitorAction @Inject constructor(
                     isDocLevelMonitorRestarted = true
                 }
 
-                var updatedMetadata: MonitorMetadata
-                val (metadata, created) = MonitorMetadataService.getOrCreateMetadata(
-                    request.monitor,
-                    forceCreateLastRunContext = isDocLevelMonitorRestarted
-                )
-
-                // Recreate runContext if metadata exists
-                // Delete and insert all queries from/to queryIndex
-
-                if (!created &&
-                    currentMonitor.isMonitorOfStandardType() &&
-                    Monitor.MonitorType.valueOf(currentMonitor.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.DOC_LEVEL_MONITOR
-                ) {
-                    updatedMetadata = MonitorMetadataService.recreateRunContext(metadata, currentMonitor)
-                    if (docLevelMonitorQueries.docLevelQueryIndexExists(currentMonitor.dataSources)) {
-                        client.suspendUntil<Client, BulkByScrollResponse> {
-                            DeleteByQueryRequestBuilder(client, DeleteByQueryAction.INSTANCE)
-                                .source(currentMonitor.dataSources.queryIndex)
-                                .filter(QueryBuilders.matchQuery("monitor_id", currentMonitor.id))
-                                .execute(it)
-                        }
-                    }
-                    indexDocLevelMonitorQueries(
+                if (!multiTenancyEnabled) {
+                    var updatedMetadata: MonitorMetadata
+                    val (metadata, created) = MonitorMetadataService.getOrCreateMetadata(
                         request.monitor,
-                        currentMonitor.id,
-                        updatedMetadata,
-                        request.refreshPolicy
+                        forceCreateLastRunContext = isDocLevelMonitorRestarted
                     )
-                    MonitorMetadataService.upsertMetadata(updatedMetadata, updating = true)
+
+                    // Recreate runContext if metadata exists
+                    // Delete and insert all queries from/to queryIndex
+
+                    if (!created &&
+                        currentMonitor.isMonitorOfStandardType() &&
+                        Monitor.MonitorType.valueOf(currentMonitor.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.DOC_LEVEL_MONITOR
+                    ) {
+                        updatedMetadata = MonitorMetadataService.recreateRunContext(metadata, currentMonitor)
+                        if (docLevelMonitorQueries.docLevelQueryIndexExists(currentMonitor.dataSources)) {
+                            client.suspendUntil<Client, BulkByScrollResponse> {
+                                DeleteByQueryRequestBuilder(client, DeleteByQueryAction.INSTANCE)
+                                    .source(currentMonitor.dataSources.queryIndex)
+                                    .filter(QueryBuilders.matchQuery("monitor_id", currentMonitor.id))
+                                    .execute(it)
+                            }
+                        }
+                        indexDocLevelMonitorQueries(
+                            request.monitor,
+                            currentMonitor.id,
+                            updatedMetadata,
+                            request.refreshPolicy
+                        )
+                        MonitorMetadataService.upsertMetadata(updatedMetadata, updating = true)
+                    }
                 }
                 // Update external schedule with latest monitor config
                 if (externalSchedulerEnabled) {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportGetMonitorActionTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportGetMonitorActionTests.kt
@@ -149,7 +149,9 @@ class TransportGetMonitorActionTests : OpenSearchTestCase() {
 
         val action = createAction(settings)
         // Invoke the private getAssociatedWorkflows method via reflection
-        val method = action.javaClass.getDeclaredMethod("getAssociatedWorkflows", String::class.java, kotlin.coroutines.Continuation::class.java)
+        val method = action.javaClass.getDeclaredMethod(
+            "getAssociatedWorkflows", String::class.java, kotlin.coroutines.Continuation::class.java
+        )
         method.isAccessible = true
 
         // Use runBlocking to call the suspend function

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportGetMonitorActionTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportGetMonitorActionTests.kt
@@ -62,6 +62,7 @@ class TransportGetMonitorActionTests : OpenSearchTestCase() {
         val settingSet = hashSetOf<Setting<*>>()
         settingSet.addAll(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
         settingSet.add(AlertingSettings.FILTER_BY_BACKEND_ROLES)
+        settingSet.add(AlertingSettings.MULTI_TENANCY_ENABLED)
         val clusterSettings = ClusterSettings(Settings.EMPTY, settingSet)
         whenever(clusterService.clusterSettings).thenReturn(clusterSettings)
     }
@@ -151,6 +152,7 @@ class TransportGetMonitorActionTests : OpenSearchTestCase() {
         val settingSet = hashSetOf<Setting<*>>()
         settingSet.addAll(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
         settingSet.add(AlertingSettings.FILTER_BY_BACKEND_ROLES)
+        settingSet.add(AlertingSettings.MULTI_TENANCY_ENABLED)
         val clusterSettings = ClusterSettings(settings, settingSet)
         whenever(clusterService.clusterSettings).thenReturn(clusterSettings)
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportGetMonitorActionTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportGetMonitorActionTests.kt
@@ -5,11 +5,15 @@
 
 package org.opensearch.alerting.transport
 
+import com.carrotsearch.randomizedtesting.ThreadFilter
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters
 import org.junit.Before
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
+import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
+import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.alerting.AlertingPlugin.Companion.TENANT_ID_HEADER
 import org.opensearch.alerting.settings.AlertingSettings
@@ -34,7 +38,12 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 import org.mockito.Mockito.`when` as whenever
 
+@ThreadLeakFilters(filters = [TransportGetMonitorActionTests.CoroutineThreadFilter::class])
 class TransportGetMonitorActionTests : OpenSearchTestCase() {
+
+    class CoroutineThreadFilter : ThreadFilter {
+        override fun reject(t: Thread): Boolean = t.name.startsWith("DefaultDispatcher-worker")
+    }
 
     private lateinit var client: Client
     private lateinit var sdkClient: SdkClient
@@ -131,6 +140,29 @@ class TransportGetMonitorActionTests : OpenSearchTestCase() {
         invokeDoExecute(action, request, listener)
 
         verify(listener).onFailure(any())
+    }
+
+    fun `test multi-tenancy enabled skips getAssociatedWorkflows search`() {
+        val settings = Settings.builder()
+            .put("plugins.alerting.multi_tenancy_enabled", true)
+            .build()
+
+        val action = createAction(settings)
+        // Invoke the private getAssociatedWorkflows method via reflection
+        val method = action.javaClass.getDeclaredMethod("getAssociatedWorkflows", String::class.java, kotlin.coroutines.Continuation::class.java)
+        method.isAccessible = true
+
+        // Use runBlocking to call the suspend function
+        val result = kotlinx.coroutines.runBlocking {
+            kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn<List<*>> { cont ->
+                method.invoke(action, "test-monitor-id", cont)
+            }
+        }
+
+        // Should return empty list without searching
+        assertTrue(result.isEmpty())
+        // client.search should never be called
+        verify(client, never()).search(any(SearchRequest::class.java), any())
     }
 
     private fun invokeDoExecute(

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorActionTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorActionTests.kt
@@ -140,4 +140,23 @@ class TransportIndexMonitorActionTests : OpenSearchTestCase() {
         assertEquals("", AlertingSettings.JOB_QUEUE_NAME.get(Settings.EMPTY))
         assertEquals("", AlertingSettings.EXTERNAL_SCHEDULER_ROLE_ARN.get(Settings.EMPTY))
     }
+
+    fun `test multi-tenancy enabled skips scheduled job index init`() {
+        val settings = Settings.builder()
+            .put("plugins.alerting.multi_tenancy_enabled", true)
+            .build()
+        // When multi-tenancy is enabled, start() should skip scheduledJobIndices calls.
+        // ScheduledJobIndices.scheduledJobIndexExists() calls clusterService.state() which
+        // is not stubbed (returns null). If the skip logic is broken, this would NPE.
+        val action = createAction(settings)
+        assertNotNull(action)
+    }
+
+    fun `test multi-tenancy disabled uses scheduled job index`() {
+        val settings = Settings.builder()
+            .put("plugins.alerting.multi_tenancy_enabled", false)
+            .build()
+        val action = createAction(settings)
+        assertNotNull(action)
+    }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportMultiTenancyBlockTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportMultiTenancyBlockTests.kt
@@ -5,6 +5,8 @@
 
 package org.opensearch.alerting.transport
 
+import com.carrotsearch.randomizedtesting.ThreadFilter
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters
 import org.junit.Before
 import org.mockito.Mockito
 import org.mockito.Mockito.verify
@@ -73,7 +75,12 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 import org.mockito.Mockito.`when` as whenever
 
+@ThreadLeakFilters(filters = [TransportMultiTenancyBlockTests.CoroutineThreadFilter::class])
 class TransportMultiTenancyBlockTests : OpenSearchTestCase() {
+
+    class CoroutineThreadFilter : ThreadFilter {
+        override fun reject(t: Thread): Boolean = t.name.startsWith("DefaultDispatcher-worker")
+    }
 
     private lateinit var client: Client
     private lateinit var transportService: TransportService
@@ -115,6 +122,10 @@ class TransportMultiTenancyBlockTests : OpenSearchTestCase() {
         settingSet.add(AlertingSettings.MAX_ACTION_THROTTLE_VALUE)
         settingSet.add(DestinationSettings.ALLOW_LIST)
         settingSet.add(AlertingSettings.CROSS_CLUSTER_MONITORING_ENABLED)
+        settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ENABLED)
+        settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ACCOUNT_ID)
+        settingSet.add(AlertingSettings.JOB_QUEUE_NAME)
+        settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ROLE_ARN)
         val clusterSettings = ClusterSettings(multiTenancySettings, settingSet)
         whenever(clusterService.clusterSettings).thenReturn(clusterSettings)
 
@@ -456,6 +467,105 @@ class TransportMultiTenancyBlockTests : OpenSearchTestCase() {
         invokeDoExecute(action, request, listener)
 
         assertMethodNotAllowed(listener)
+    }
+
+    // --- Metadata skip tests ---
+
+    fun `test index query-level monitor skips metadata when multi-tenancy enabled`() {
+        val sdkClient = Mockito.mock(SdkClient::class.java)
+        val action = TransportIndexMonitorAction(
+            transportService, client, actionFilters,
+            scheduledJobIndices,
+            docLevelMonitorQueries,
+            clusterService, multiTenancySettings, xContentRegistry,
+            Mockito.mock(NamedWriteableRegistry::class.java),
+            sdkClient
+        )
+        val monitor = Monitor(
+            name = "test", monitorType = Monitor.MonitorType.QUERY_LEVEL_MONITOR.value,
+            enabled = false, schedule = IntervalSchedule(5, ChronoUnit.MINUTES),
+            lastUpdateTime = Instant.now(), enabledTime = null, user = null,
+            inputs = listOf(SearchInput(listOf("test-index"), SearchSourceBuilder().query(QueryBuilders.matchAllQuery()))),
+            triggers = emptyList(), uiMetadata = mapOf()
+        )
+        val request = IndexMonitorRequest(
+            Monitor.NO_ID, SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
+            org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.POST, monitor
+        )
+
+        // Mock cluster state for index resolution in checkIndicesAndExecute
+        val metadata = org.opensearch.cluster.metadata.Metadata.builder().build()
+        val clusterState = org.opensearch.cluster.ClusterState.builder(
+            org.opensearch.cluster.ClusterName("test")
+        ).metadata(metadata).build()
+        whenever(clusterService.state()).thenReturn(clusterState)
+
+        // Mock the search for index validation (checkIndicesAndExecute)
+        Mockito.doAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            val searchListener = invocation.arguments[1] as ActionListener<SearchResponse>
+            searchListener.onResponse(Mockito.mock(SearchResponse::class.java))
+            null
+        }.`when`(client).search(
+            org.mockito.ArgumentMatchers.any(SearchRequest::class.java),
+            org.mockito.ArgumentMatchers.any()
+        )
+
+        // Mock sdkClient.putDataObjectAsync for the monitor index
+        val putResponse = org.opensearch.remote.metadata.client.PutDataObjectResponse.builder()
+            .id("test-monitor-id")
+            .build()
+        val putFuture: java.util.concurrent.CompletionStage<org.opensearch.remote.metadata.client.PutDataObjectResponse> =
+            java.util.concurrent.CompletableFuture.completedFuture(putResponse)
+        whenever(sdkClient.putDataObjectAsync(org.mockito.ArgumentMatchers.any())).thenReturn(putFuture)
+
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<IndexMonitorResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        // Wait for async completion — the response should succeed without metadata calls.
+        // MonitorMetadataService.getOrCreateMetadata would call sdkClient.getDataObjectAsync,
+        // so if metadata is skipped, getDataObjectAsync should never be called.
+        verify(sdkClient, Mockito.timeout(2000)).putDataObjectAsync(org.mockito.ArgumentMatchers.any())
+        verify(sdkClient, Mockito.after(500).never()).getDataObjectAsync(org.mockito.ArgumentMatchers.any())
+    }
+
+    fun `test execute inline query-level monitor skips metadata when multi-tenancy enabled`() {
+        val action = TransportExecuteMonitorAction(
+            transportService, client, clusterService,
+            MonitorRunnerService,
+            actionFilters, xContentRegistry,
+            docLevelMonitorQueries,
+            multiTenancySettings, Mockito.mock(SdkClient::class.java)
+        )
+        val monitor = Monitor(
+            name = "test", monitorType = Monitor.MonitorType.QUERY_LEVEL_MONITOR.value,
+            enabled = false, schedule = IntervalSchedule(5, ChronoUnit.MINUTES),
+            lastUpdateTime = Instant.now(), enabledTime = null, user = null,
+            inputs = listOf(SearchInput(listOf("test-index"), SearchSourceBuilder().query(QueryBuilders.matchAllQuery()))),
+            triggers = emptyList(), uiMetadata = mapOf()
+        )
+        val request = ExecuteMonitorRequest(true, TimeValue(Instant.now().toEpochMilli()), null, monitor)
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<ExecuteMonitorResponse>
+
+        // MonitorRunnerService is not initialized so runner.launch will throw,
+        // but the important thing is that it reaches executeMonitor (not the metadata block)
+        // and does NOT fail with METHOD_NOT_ALLOWED.
+        try {
+            invokeDoExecute(action, request, listener)
+        } catch (e: Exception) {
+            // Expected — MonitorRunnerService.runnerSupervisor is not initialized
+        }
+
+        // Should NOT be blocked with METHOD_NOT_ALLOWED (query-level is allowed)
+        verify(listener, Mockito.never()).onFailure(
+            org.mockito.ArgumentMatchers.argThat { ex ->
+                val cause = (ex as? org.opensearch.commons.alerting.util.AlertingException)?.cause ?: ex
+                cause is OpenSearchStatusException && cause.status() == RestStatus.METHOD_NOT_ALLOWED
+            }
+        )
     }
 
     // --- Helpers ---


### PR DESCRIPTION
### Description
Skips scheduled job and workflow calls when multi tenancy is enabled

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
