### PR TITLE
small fix to keep alerting builds stable post ppl alerting common uti…

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt
@@ -18,6 +18,7 @@ import org.opensearch.commons.alerting.model.BucketLevelTrigger
 import org.opensearch.commons.alerting.model.DocLevelMonitorInput
 import org.opensearch.commons.alerting.model.DocumentLevelTrigger
 import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.PPLTrigger
 import org.opensearch.commons.alerting.model.QueryLevelTrigger
 import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.util.AlertingException
@@ -30,7 +31,6 @@ import org.opensearch.core.xcontent.XContentParser.Token
 import org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken
 import org.opensearch.index.seqno.SequenceNumbers
 import org.opensearch.rest.BaseRestHandler
-import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
 import org.opensearch.rest.BytesRestResponse
 import org.opensearch.rest.RestChannel
 import org.opensearch.rest.RestHandler.ReplacedRoute
@@ -132,6 +132,14 @@ class RestIndexMonitorAction : BaseRestHandler() {
                         triggers.forEach {
                             if (it !is DocumentLevelTrigger) {
                                 throw IllegalArgumentException("Illegal trigger type, ${it.javaClass.name}, for document level monitor")
+                            }
+                        }
+                    }
+
+                    Monitor.MonitorType.PPL_MONITOR -> {
+                        triggers.forEach {
+                            if (it !is PPLTrigger) {
+                                throw IllegalArgumentException("Illegal trigger type, ${it.javaClass.name}, for PPL monitor")
                             }
                         }
                     }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     apply from: 'build-tools/repositories.gradle'
 
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "3.6.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "3.7.0-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         // 3.0.0-SNAPSHOT -> 3.0.0.0-SNAPSHOT
@@ -126,6 +126,9 @@ allprojects {
             force "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlin_version}"
             force "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlin_version}"
             force "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}"
+            force "org.apache.logging.log4j:log4j-api:2.25.4"
+            force "org.apache.logging.log4j:log4j-core:2.25.4"
+            force "org.apache.httpcomponents.client5:httpclient5:5.6.1"
         }
     }
 


### PR DESCRIPTION
Merging PR https://github.com/opensearch-project/common-utils/pull/940 in common-utils (adding PPL Alerting models) breaks Alerting due to a straightforward compiler error. This PR includes minimal PPL Alerting related changes needed to keep Alerting stable before the true PPL Alerting PRs are raised.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
