### PR TITLE
Preserve tenancy context across stashes and coroutines

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt
@@ -34,6 +34,7 @@ import org.opensearch.commons.alerting.model.MonitorMetadata
 import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.model.remote.monitors.RemoteDocLevelMonitorInput
 import org.opensearch.commons.alerting.util.AlertingException
+import org.opensearch.commons.utils.currentTenantId
 import org.opensearch.core.rest.RestStatus
 import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.core.xcontent.ToXContent
@@ -77,9 +78,6 @@ object MonitorMetadataService :
         this.clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.INDEX_TIMEOUT) { indexTimeout = it }
     }
 
-    private fun getTenantId(): String? =
-        client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
-
     @Suppress("ComplexMethod", "ReturnCount")
     suspend fun upsertMetadata(metadata: MonitorMetadata, updating: Boolean): MonitorMetadata {
         try {
@@ -90,7 +88,7 @@ object MonitorMetadataService :
                 val putRequestBuilder = PutDataObjectRequest.builder()
                     .index(ScheduledJob.SCHEDULED_JOBS_INDEX)
                     .id(metadata.id)
-                    .tenantId(getTenantId())
+                    .tenantId(currentTenantId())
                     .dataObject(metadataObj)
 
                 if (updating) {
@@ -177,7 +175,7 @@ object MonitorMetadataService :
             val getRequest = GetDataObjectRequest.builder()
                 .index(ScheduledJob.SCHEDULED_JOBS_INDEX)
                 .id(metadataId)
-                .tenantId(getTenantId())
+                .tenantId(currentTenantId())
                 .build()
 
             val response = sdkClient.getDataObjectAsync(getRequest).await()

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeAlertAction.kt
@@ -14,6 +14,7 @@ import org.opensearch.action.ActionRequest
 import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
+import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.util.await
@@ -33,6 +34,7 @@ import org.opensearch.commons.alerting.model.Alert
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.commons.alerting.util.optionalTimeField
+import org.opensearch.commons.utils.TenantContext
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.xcontent.NamedXContentRegistry
@@ -86,8 +88,9 @@ class TransportAcknowledgeAlertAction @Inject constructor(
     ) {
         val request = acknowledgeAlertRequest as? AcknowledgeAlertRequest
             ?: recreateObject(acknowledgeAlertRequest) { AcknowledgeAlertRequest(it) }
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
         client.threadPool().threadContext.stashContext().use {
-            scope.launch {
+            scope.launch(TenantContext(tenantId)) {
                 val getMonitorResponse: GetMonitorResponse =
                     transportGetMonitorAction.client.suspendUntil {
                         val getMonitorRequest = GetMonitorRequest(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeChainedAlertAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportAcknowledgeChainedAlertAction.kt
@@ -24,6 +24,7 @@ import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.action.support.WriteRequest
 import org.opensearch.action.update.UpdateRequest
+import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.util.ScheduledJobUtils
@@ -45,6 +46,7 @@ import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.model.Workflow
 import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.commons.alerting.util.optionalTimeField
+import org.opensearch.commons.utils.TenantContext
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.rest.RestStatus
@@ -105,8 +107,9 @@ class TransportAcknowledgeChainedAlertAction @Inject constructor(
 
         val request = AcknowledgeChainedAlertRequest as? AcknowledgeChainedAlertRequest
             ?: recreateObject(AcknowledgeChainedAlertRequest) { AcknowledgeChainedAlertRequest(it) }
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
         client.threadPool().threadContext.stashContext().use {
-            scope.launch {
+            scope.launch(TenantContext(tenantId)) {
                 try {
                     val getResponse = getWorkflow(request.workflowId)
                     if (getResponse.isExists == false) {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteAlertingCommentAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteAlertingCommentAction.kt
@@ -28,6 +28,8 @@ import org.opensearch.commons.alerting.action.DeleteCommentResponse
 import org.opensearch.commons.alerting.model.Comment
 import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.commons.authuser.User
+import org.opensearch.commons.utils.TenantContext
+import org.opensearch.commons.utils.currentTenantId
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.rest.RestStatus
@@ -88,7 +90,8 @@ class TransportDeleteAlertingCommentAction @Inject constructor(
         if (!validateUserBackendRoles(user, actionListener)) {
             return
         }
-        scope.launch {
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+        scope.launch(TenantContext(tenantId)) {
             DeleteCommentHandler(
                 client,
                 actionListener,
@@ -129,7 +132,7 @@ class TransportDeleteAlertingCommentAction @Inject constructor(
                 val deleteRequest = DeleteDataObjectRequest.builder()
                     .index(sourceIndex)
                     .id(commentId)
-                    .tenantId(client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER))
+                    .tenantId(currentTenantId())
                     .build()
 
                 if (canDelete) {
@@ -158,7 +161,7 @@ class TransportDeleteAlertingCommentAction @Inject constructor(
                     .query(queryBuilder)
             val searchRequest = SearchDataObjectRequest.builder()
                 .indices(ALL_COMMENTS_INDEX_PATTERN)
-                .tenantId(client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER))
+                .tenantId(currentTenantId())
                 .searchSourceBuilder(searchSourceBuilder)
                 .build()
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
@@ -32,6 +32,8 @@ import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.commons.authuser.User
+import org.opensearch.commons.utils.TenantContext
+import org.opensearch.commons.utils.currentTenantId
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.rest.RestStatus
@@ -84,7 +86,8 @@ class TransportDeleteMonitorAction @Inject constructor(
         if (!validateUserBackendRoles(user, actionListener)) {
             return
         }
-        scope.launch {
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+        scope.launch(TenantContext(tenantId)) {
             DeleteMonitorHandler(
                 client,
                 actionListener,
@@ -158,7 +161,7 @@ class TransportDeleteMonitorAction @Inject constructor(
         }
 
         private suspend fun getMonitor(): Monitor {
-            val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+            val tenantId = currentTenantId()
             val getRequest = GetDataObjectRequest.builder()
                 .index(ScheduledJob.SCHEDULED_JOBS_INDEX)
                 .id(monitorId)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteWorkflowAction.kt
@@ -23,6 +23,7 @@ import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.action.support.WriteRequest.RefreshPolicy
+import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.core.lock.LockModel
 import org.opensearch.alerting.core.lock.LockService
 import org.opensearch.alerting.opensearchapi.addFilter
@@ -48,6 +49,7 @@ import org.opensearch.commons.alerting.model.Workflow
 import org.opensearch.commons.alerting.model.WorkflowMetadata
 import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.commons.authuser.User
+import org.opensearch.commons.utils.TenantContext
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.rest.RestStatus
@@ -114,7 +116,8 @@ class TransportDeleteWorkflowAction @Inject constructor(
             return
         }
 
-        scope.launch {
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+        scope.launch(TenantContext(tenantId)) {
             DeleteWorkflowHandler(
                 client,
                 actionListener,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
@@ -26,6 +26,7 @@ import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.alerting.AlertService
+import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.MonitorRunnerService
 import org.opensearch.alerting.TriggerService
 import org.opensearch.alerting.action.GetDestinationsAction
@@ -100,6 +101,7 @@ import org.opensearch.commons.alerting.model.userErrorMessage
 import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.commons.alerting.util.string
 import org.opensearch.commons.notifications.model.NotificationConfigInfo
+import org.opensearch.commons.utils.TenantContext
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.common.Strings
 import org.opensearch.core.common.bytes.BytesReference
@@ -205,7 +207,8 @@ class TransportDocLevelMonitorFanOutAction
         request: DocLevelMonitorFanOutRequest,
         listener: ActionListener<DocLevelMonitorFanOutResponse>
     ) {
-        scope.launch {
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+        scope.launch(TenantContext(tenantId)) {
             executeMonitor(request, listener)
         }
     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
@@ -36,6 +36,7 @@ import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.commons.alerting.util.isMonitorOfStandardType
 import org.opensearch.commons.authuser.User
+import org.opensearch.commons.utils.TenantContext
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.rest.RestStatus
 import org.opensearch.core.xcontent.NamedXContentRegistry
@@ -73,12 +74,13 @@ class TransportExecuteMonitorAction @Inject constructor(
         log.debug("User and roles string from thread context: $userStr")
         val user: User? = User.parse(userStr)
 
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
         client.threadPool().threadContext.stashContext().use {
             val executeMonitor = fun(monitor: Monitor) {
                 // Launch the coroutine with the clients threadContext. This is needed to preserve authentication information
                 // stored on the threadContext set by the security plugin when using the Alerting plugin with the Security plugin.
                 // runner.launch(ElasticThreadContextElement(client.threadPool().threadContext)) {
-                runner.launch {
+                runner.launch(TenantContext(tenantId)) {
                     val (periodStart, periodEnd) = if (execMonitorRequest.requestStart != null) {
                         Pair(
                             Instant.ofEpochMilli(execMonitorRequest.requestStart.millis),
@@ -106,7 +108,6 @@ class TransportExecuteMonitorAction @Inject constructor(
             }
 
             if (execMonitorRequest.monitorId != null && execMonitorRequest.monitor == null) {
-                val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
                 val getRequest = GetDataObjectRequest.builder()
                     .index(ScheduledJob.SCHEDULED_JOBS_INDEX)
                     .id(execMonitorRequest.monitorId)
@@ -187,7 +188,7 @@ class TransportExecuteMonitorAction @Inject constructor(
                     Monitor.MonitorType.valueOf(monitor.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.DOC_LEVEL_MONITOR
                 ) {
                     try {
-                        scope.launch {
+                        scope.launch(TenantContext(tenantId)) {
                             if (!docLevelMonitorQueries.docLevelQueryIndexExists(monitor.dataSources)) {
                                 docLevelMonitorQueries.initDocLevelQueryIndex(monitor.dataSources)
                                 log.info("Central Percolation index ${ScheduledJob.DOC_LEVEL_QUERIES_INDEX} created")

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
@@ -254,7 +254,12 @@ class TransportGetAlertsAction @Inject constructor(
         }
     }
 
-    fun search(alertIndex: String, searchSourceBuilder: SearchSourceBuilder, actionListener: ActionListener<GetAlertsResponse>, tenantId: String? = null) {
+    fun search(
+        alertIndex: String,
+        searchSourceBuilder: SearchSourceBuilder,
+        actionListener: ActionListener<GetAlertsResponse>,
+        tenantId: String? = null,
+    ) {
         val sdkSearchRequest = SearchDataObjectRequest.builder()
             .indices(alertIndex)
             .tenantId(tenantId)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
@@ -31,6 +31,8 @@ import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.commons.authuser.User
+import org.opensearch.commons.utils.TenantContext
+import org.opensearch.commons.utils.currentTenantId
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry
@@ -148,11 +150,12 @@ class TransportGetAlertsAction @Inject constructor(
             .size(tableProp.size)
             .from(tableProp.startIndex)
 
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
         client.threadPool().threadContext.stashContext().use {
-            scope.launch {
+            scope.launch(TenantContext(tenantId)) {
                 try {
                     val alertIndex = resolveAlertsIndexName(getAlertsRequest)
-                    getAlerts(alertIndex, searchSourceBuilder, actionListener, user)
+                    getAlerts(alertIndex, searchSourceBuilder, actionListener, user, tenantId)
                 } catch (t: Exception) {
                     log.error("Failed to get alerts", t)
                     if (t is AlertingException) {
@@ -202,7 +205,7 @@ class TransportGetAlertsAction @Inject constructor(
     }
 
     private suspend fun getMonitor(getAlertsRequest: GetAlertsRequest): Monitor? {
-        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+        val tenantId = currentTenantId()
         val getRequest = GetDataObjectRequest.builder()
             .index(ScheduledJob.SCHEDULED_JOBS_INDEX)
             .id(getAlertsRequest.monitorId!!)
@@ -230,28 +233,28 @@ class TransportGetAlertsAction @Inject constructor(
         searchSourceBuilder: SearchSourceBuilder,
         actionListener: ActionListener<GetAlertsResponse>,
         user: User?,
+        tenantId: String? = null,
     ) {
         // user is null when: 1/ security is disabled. 2/when user is super-admin.
         if (user == null) {
             // user is null when: 1/ security is disabled. 2/when user is super-admin.
-            search(alertIndex, searchSourceBuilder, actionListener)
+            search(alertIndex, searchSourceBuilder, actionListener, tenantId)
         } else if (!doFilterForUser(user)) {
             // security is enabled and filterby is disabled.
-            search(alertIndex, searchSourceBuilder, actionListener)
+            search(alertIndex, searchSourceBuilder, actionListener, tenantId)
         } else {
             // security is enabled and filterby is enabled.
             try {
                 log.info("Filtering result by: ${user.backendRoles}")
                 addFilter(user, searchSourceBuilder, "monitor_user.backend_roles.keyword")
-                search(alertIndex, searchSourceBuilder, actionListener)
+                search(alertIndex, searchSourceBuilder, actionListener, tenantId)
             } catch (ex: IOException) {
                 actionListener.onFailure(AlertingException.wrap(ex))
             }
         }
     }
 
-    fun search(alertIndex: String, searchSourceBuilder: SearchSourceBuilder, actionListener: ActionListener<GetAlertsResponse>) {
-        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+    fun search(alertIndex: String, searchSourceBuilder: SearchSourceBuilder, actionListener: ActionListener<GetAlertsResponse>, tenantId: String? = null) {
         val sdkSearchRequest = SearchDataObjectRequest.builder()
             .indices(alertIndex)
             .tenantId(tenantId)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetDestinationsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetDestinationsAction.kt
@@ -149,7 +149,11 @@ class TransportGetDestinationsAction @Inject constructor(
         }
     }
 
-    fun search(searchSourceBuilder: SearchSourceBuilder, actionListener: ActionListener<GetDestinationsResponse>, tenantId: String? = null) {
+    fun search(
+        searchSourceBuilder: SearchSourceBuilder,
+        actionListener: ActionListener<GetDestinationsResponse>,
+        tenantId: String? = null,
+    ) {
         val sdkSearchRequest = SearchDataObjectRequest.builder()
             .indices(ScheduledJob.SCHEDULED_JOBS_INDEX)
             .tenantId(tenantId)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetDestinationsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetDestinationsAction.kt
@@ -122,36 +122,34 @@ class TransportGetDestinationsAction @Inject constructor(
         }
         searchSourceBuilder.query(queryBuilder)
 
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
         client.threadPool().threadContext.stashContext().use {
-            resolve(searchSourceBuilder, actionListener, user)
+            resolve(searchSourceBuilder, actionListener, user, tenantId)
         }
     }
 
     fun resolve(
         searchSourceBuilder: SearchSourceBuilder,
         actionListener: ActionListener<GetDestinationsResponse>,
-        user: User?
+        user: User?,
+        tenantId: String? = null,
     ) {
         if (user == null) {
-            // user is null when: 1/ security is disabled. 2/when user is super-admin.
-            search(searchSourceBuilder, actionListener)
+            search(searchSourceBuilder, actionListener, tenantId)
         } else if (!doFilterForUser(user)) {
-            // security is enabled and filterby is disabled.
-            search(searchSourceBuilder, actionListener)
+            search(searchSourceBuilder, actionListener, tenantId)
         } else {
-            // security is enabled and filterby is enabled.
             try {
                 log.info("Filtering result by: ${user.backendRoles}")
                 addFilter(user, searchSourceBuilder, "destination.user.backend_roles.keyword")
-                search(searchSourceBuilder, actionListener)
+                search(searchSourceBuilder, actionListener, tenantId)
             } catch (ex: IOException) {
                 actionListener.onFailure(AlertingException.wrap(ex))
             }
         }
     }
 
-    fun search(searchSourceBuilder: SearchSourceBuilder, actionListener: ActionListener<GetDestinationsResponse>) {
-        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+    fun search(searchSourceBuilder: SearchSourceBuilder, actionListener: ActionListener<GetDestinationsResponse>, tenantId: String? = null) {
         val sdkSearchRequest = SearchDataObjectRequest.builder()
             .indices(ScheduledJob.SCHEDULED_JOBS_INDEX)
             .tenantId(tenantId)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetFindingsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetFindingsAction.kt
@@ -19,6 +19,7 @@ import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
+import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.alerts.AlertIndices.Companion.ALL_FINDING_INDEX_PATTERN
 import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.settings.AlertingSettings
@@ -37,6 +38,7 @@ import org.opensearch.commons.alerting.model.Finding
 import org.opensearch.commons.alerting.model.FindingDocument
 import org.opensearch.commons.alerting.model.FindingWithDocs
 import org.opensearch.commons.alerting.util.AlertingException
+import org.opensearch.commons.utils.TenantContext
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.common.Strings
@@ -148,8 +150,9 @@ class TransportGetFindingsSearchAction @Inject constructor(
                 )
         }
         searchSourceBuilder.query(queryBuilder).trackTotalHits(true)
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
         client.threadPool().threadContext.stashContext().use {
-            scope.launch {
+            scope.launch(TenantContext(tenantId)) {
                 try {
                     val indexName = resolveFindingsIndexName(getFindingsRequest)
                     val getFindingsResponse = search(searchSourceBuilder, indexName)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetMonitorAction.kt
@@ -36,6 +36,7 @@ import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.model.Workflow
 import org.opensearch.commons.alerting.util.AlertingException
+import org.opensearch.commons.utils.TenantContext
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.rest.RestStatus
@@ -133,7 +134,7 @@ class TransportGetMonitorAction @Inject constructor(
                     if (!checkUserPermissionsWithResource(user, monitor?.user, actionListener, "monitor", transformedRequest.monitorId)) {
                         return@whenComplete
                     }
-                    scope.launch {
+                    scope.launch(TenantContext(tenantId)) {
                         val associatedCompositeMonitors = getAssociatedWorkflows(getResponse.id)
                         actionListener.onResponse(
                             GetMonitorResponse(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetRemoteIndexesAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetRemoteIndexesAction.kt
@@ -20,6 +20,7 @@ import org.opensearch.action.admin.indices.resolve.ResolveIndexAction
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.action.support.IndicesOptions
+import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.action.GetRemoteIndexesAction
 import org.opensearch.alerting.action.GetRemoteIndexesRequest
 import org.opensearch.alerting.action.GetRemoteIndexesResponse
@@ -33,6 +34,7 @@ import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
 import org.opensearch.common.settings.Settings
 import org.opensearch.commons.alerting.util.AlertingException
+import org.opensearch.commons.utils.TenantContext
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.rest.RestStatus
 import org.opensearch.core.xcontent.NamedXContentRegistry
@@ -110,8 +112,9 @@ class TransportGetRemoteIndexesAction @Inject constructor(
             return
         }
 
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
         client.threadPool().threadContext.stashContext().use {
-            scope.launch {
+            scope.launch(TenantContext(tenantId)) {
                 val singleThreadContext = newSingleThreadContext("GetRemoteIndexesActionThread")
                 withContext(singleThreadContext) {
                     it.restore()

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetWorkflowAlertsAction.kt
@@ -33,6 +33,8 @@ import org.opensearch.commons.alerting.action.GetWorkflowAlertsResponse
 import org.opensearch.commons.alerting.model.Alert
 import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.commons.authuser.User
+import org.opensearch.commons.utils.TenantContext
+import org.opensearch.commons.utils.currentTenantId
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.rest.RestStatus
@@ -157,8 +159,9 @@ class TransportGetWorkflowAlertsAction @Inject constructor(
             .size(tableProp.size)
             .from(from)
 
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
         client.threadPool().threadContext.stashContext().use {
-            scope.launch {
+            scope.launch(TenantContext(tenantId)) {
                 try {
                     val alertIndex = resolveAlertsIndexName(getWorkflowAlertsRequest)
                     getAlerts(getWorkflowAlertsRequest, alertIndex, searchSourceBuilder, actionListener, user)
@@ -225,7 +228,7 @@ class TransportGetWorkflowAlertsAction @Inject constructor(
         try {
             val searchRequest = SearchDataObjectRequest.builder()
                 .indices(alertIndex)
-                .tenantId(client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER))
+                .tenantId(currentTenantId())
                 .searchSourceBuilder(searchSourceBuilder)
                 .build()
             val alerts = mutableListOf<Alert>()
@@ -277,7 +280,7 @@ class TransportGetWorkflowAlertsAction @Inject constructor(
             searchRequest.source().query(queryBuilder)
             val sdkSearchRequest = SearchDataObjectRequest.builder()
                 .indices(*searchRequest.indices())
-                .tenantId(client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER))
+                .tenantId(currentTenantId())
                 .searchSourceBuilder(searchRequest.source())
                 .build()
             val sdkResponse = sdkClient.searchDataObject(sdkSearchRequest)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexAlertingCommentAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexAlertingCommentAction.kt
@@ -37,6 +37,8 @@ import org.opensearch.commons.alerting.model.Alert
 import org.opensearch.commons.alerting.model.Comment
 import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.commons.authuser.User
+import org.opensearch.commons.utils.TenantContext
+import org.opensearch.commons.utils.currentTenantId
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry
@@ -140,8 +142,9 @@ constructor(
 
         val user = readUserFromThreadContext(client)
 
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
         client.threadPool().threadContext.stashContext().use {
-            scope.launch {
+            scope.launch(TenantContext(tenantId)) {
                 IndexCommentHandler(client, actionListener, transformedRequest, user).start()
             }
         }
@@ -189,7 +192,7 @@ constructor(
                 user = user
             )
 
-            val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+            val tenantId = currentTenantId()
             val wrappedComment = ToXContentObject { builder, params ->
                 comment.toXContentWithUser(builder)
             }
@@ -235,7 +238,7 @@ constructor(
             // retains everything from the original comment except content and lastUpdatedTime
             val requestComment = currentComment.copy(content = request.content, lastUpdatedTime = Instant.now())
 
-            val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+            val tenantId = currentTenantId()
             val wrappedComment = ToXContentObject { builder, params ->
                 requestComment.toXContentWithUser(builder)
             }
@@ -279,7 +282,7 @@ constructor(
                     .seqNoAndPrimaryTerm(true)
                     .query(queryBuilder)
 
-            val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+            val tenantId = currentTenantId()
             val sdkSearchRequest = SearchDataObjectRequest.builder()
                 .indices(AlertIndices.ALL_ALERT_INDEX_PATTERN)
                 .tenantId(tenantId)
@@ -335,7 +338,7 @@ constructor(
                     .seqNoAndPrimaryTerm(true)
                     .query(queryBuilder)
 
-            val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+            val tenantId = currentTenantId()
             val sdkSearchRequest = SearchDataObjectRequest.builder()
                 .indices(CommentsIndices.ALL_COMMENTS_INDEX_PATTERN)
                 .tenantId(tenantId)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -74,7 +74,6 @@ import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.commons.alerting.util.isMonitorOfStandardType
 import org.opensearch.commons.authuser.User
 import org.opensearch.commons.utils.TenantContext
-import org.opensearch.commons.utils.currentTenantId
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -73,6 +73,8 @@ import org.opensearch.commons.alerting.model.remote.monitors.RemoteDocLevelMonit
 import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.commons.alerting.util.isMonitorOfStandardType
 import org.opensearch.commons.authuser.User
+import org.opensearch.commons.utils.TenantContext
+import org.opensearch.commons.utils.currentTenantId
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry
@@ -263,8 +265,9 @@ class TransportIndexMonitorAction @Inject constructor(
             object : ActionListener<SearchResponse> {
                 override fun onResponse(searchResponse: SearchResponse) {
                     // User has read access to configured indices in the monitor, now create monitor with out user context.
+                    val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
                     client.threadPool().threadContext.stashContext().use {
-                        IndexMonitorHandler(client, actionListener, request, user).resolveUserAndStart()
+                        IndexMonitorHandler(client, actionListener, request, user, tenantId).resolveUserAndStart()
                     }
                 }
 
@@ -301,8 +304,9 @@ class TransportIndexMonitorAction @Inject constructor(
         request: IndexMonitorRequest,
         user: User?,
     ) {
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
         client.threadPool().threadContext.stashContext().use {
-            IndexMonitorHandler(client, actionListener, request, user).resolveUserAndStartForAD()
+            IndexMonitorHandler(client, actionListener, request, user, tenantId).resolveUserAndStartForAD()
         }
     }
 
@@ -311,6 +315,7 @@ class TransportIndexMonitorAction @Inject constructor(
         private val actionListener: ActionListener<IndexMonitorResponse>,
         private val request: IndexMonitorRequest,
         private val user: User?,
+        private val tenantId: String?,
     ) {
 
         fun resolveUserAndStart() {
@@ -383,7 +388,7 @@ class TransportIndexMonitorAction @Inject constructor(
                     override fun onFailure(t: Exception) {
                         // https://github.com/opensearch-project/alerting/issues/646
                         if (ExceptionsHelper.unwrapCause(t) is ResourceAlreadyExistsException) {
-                            scope.launch {
+                            scope.launch(TenantContext(tenantId)) {
                                 // Wait for the yellow status
                                 val request = ClusterHealthRequest()
                                     .indices(SCHEDULED_JOBS_INDEX)
@@ -441,12 +446,12 @@ class TransportIndexMonitorAction @Inject constructor(
             }
 
             if (request.method == RestRequest.Method.PUT) {
-                scope.launch {
+                scope.launch(TenantContext(tenantId)) {
                     updateMonitor()
                 }
             } else if (multiTenancyEnabled) {
                 // Skip local scheduled-job index search for monitor count when multi-tenancy is enabled.
-                scope.launch {
+                scope.launch(TenantContext(tenantId)) {
                     indexMonitor()
                 }
             } else {
@@ -517,7 +522,7 @@ class TransportIndexMonitorAction @Inject constructor(
                     )
                 )
             } else {
-                scope.launch {
+                scope.launch(TenantContext(tenantId)) {
                     indexMonitor()
                 }
             }
@@ -574,7 +579,6 @@ class TransportIndexMonitorAction @Inject constructor(
 
             log.info("Creating new monitor: ${request.monitor.name}, type: ${request.monitor.monitorType}")
 
-            val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
             val monitorObj = ToXContentObject { builder, params ->
                 request.monitor.toXContentWithUser(builder, ToXContent.MapParams(mapOf("with_type" to "true")))
             }
@@ -693,7 +697,6 @@ class TransportIndexMonitorAction @Inject constructor(
         }
 
         private suspend fun updateMonitor() {
-            val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
             val getRequest = GetDataObjectRequest.builder()
                 .index(SCHEDULED_JOBS_INDEX)
                 .id(request.monitorId)
@@ -771,7 +774,6 @@ class TransportIndexMonitorAction @Inject constructor(
 
             log.info("Updating monitor, ${currentMonitor.id}")
 
-            val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
             val monitorObj = ToXContentObject { builder, params ->
                 request.monitor.toXContentWithUser(builder, ToXContent.MapParams(mapOf("with_type" to "true")))
             }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
@@ -27,8 +27,8 @@ import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse
-import org.opensearch.alerting.MonitorMetadataService
 import org.opensearch.alerting.AlertingPlugin
+import org.opensearch.alerting.MonitorMetadataService
 import org.opensearch.alerting.MonitorRunnerService.monitorCtx
 import org.opensearch.alerting.WorkflowMetadataService
 import org.opensearch.alerting.core.ScheduledJobIndices
@@ -70,7 +70,6 @@ import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.commons.alerting.util.isMonitorOfStandardType
 import org.opensearch.commons.authuser.User
 import org.opensearch.commons.utils.TenantContext
-import org.opensearch.commons.utils.currentTenantId
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
@@ -28,6 +28,7 @@ import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 import org.opensearch.alerting.MonitorMetadataService
+import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.MonitorRunnerService.monitorCtx
 import org.opensearch.alerting.WorkflowMetadataService
 import org.opensearch.alerting.core.ScheduledJobIndices
@@ -68,6 +69,8 @@ import org.opensearch.commons.alerting.model.Workflow
 import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.commons.alerting.util.isMonitorOfStandardType
 import org.opensearch.commons.authuser.User
+import org.opensearch.commons.utils.TenantContext
+import org.opensearch.commons.utils.currentTenantId
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry
@@ -195,7 +198,8 @@ class TransportIndexWorkflowAction @Inject constructor(
             }
         }
 
-        scope.launch {
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+        scope.launch(TenantContext(tenantId)) {
             try {
                 val triggerCount = transformedRequest.workflow.triggers.size
                 if (triggerCount > maxTriggersPerMonitor) {
@@ -216,7 +220,7 @@ class TransportIndexWorkflowAction @Inject constructor(
                         override fun onResponse(response: AcknowledgedResponse) {
                             // Stash the context and start the workflow creation
                             client.threadPool().threadContext.stashContext().use {
-                                IndexWorkflowHandler(client, actionListener, transformedRequest, user).resolveUserAndStart()
+                                IndexWorkflowHandler(client, actionListener, transformedRequest, user, tenantId).resolveUserAndStart()
                             }
                         }
 
@@ -247,9 +251,10 @@ class TransportIndexWorkflowAction @Inject constructor(
         private val actionListener: ActionListener<IndexWorkflowResponse>,
         private val request: IndexWorkflowRequest,
         private val user: User?,
+        private val tenantId: String?,
     ) {
         fun resolveUserAndStart() {
-            scope.launch {
+            scope.launch(TenantContext(tenantId)) {
                 if (user == null) {
                     // Security is disabled, add empty user to Workflow. user is null for older versions.
                     request.workflow = request.workflow
@@ -273,7 +278,7 @@ class TransportIndexWorkflowAction @Inject constructor(
                     override fun onFailure(t: Exception) {
                         // https://github.com/opensearch-project/alerting/issues/646
                         if (ExceptionsHelper.unwrapCause(t) is ResourceAlreadyExistsException) {
-                            scope.launch {
+                            scope.launch(TenantContext(tenantId)) {
                                 // Wait for the yellow status
                                 val request = ClusterHealthRequest()
                                     .indices(SCHEDULED_JOBS_INDEX)
@@ -323,11 +328,11 @@ class TransportIndexWorkflowAction @Inject constructor(
          */
         private fun prepareWorkflowIndexing() {
             if (request.method == RestRequest.Method.PUT) {
-                scope.launch {
+                scope.launch(TenantContext(tenantId)) {
                     updateWorkflow()
                 }
             } else {
-                scope.launch {
+                scope.launch(TenantContext(tenantId)) {
                     indexWorkflow()
                 }
             }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchAlertingCommentAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchAlertingCommentAction.kt
@@ -32,6 +32,8 @@ import org.opensearch.commons.alerting.model.Alert
 import org.opensearch.commons.alerting.model.Comment
 import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.commons.authuser.User
+import org.opensearch.commons.utils.TenantContext
+import org.opensearch.commons.utils.currentTenantId
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry
@@ -101,20 +103,22 @@ class TransportSearchAlertingCommentAction @Inject constructor(
             .version(true)
 
         val user = readUserFromThreadContext(client)
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
         client.threadPool().threadContext.stashContext().use {
-            scope.launch {
+            scope.launch(TenantContext(tenantId)) {
                 resolve(transformedRequest, actionListener, user)
             }
         }
     }
 
     suspend fun resolve(searchCommentRequest: SearchCommentRequest, actionListener: ActionListener<SearchResponse>, user: User?) {
+        val tenantId = currentTenantId()
         if (user == null) {
             // user is null when: 1/ security is disabled. 2/when user is super-admin.
-            search(searchCommentRequest.searchRequest, actionListener)
+            search(searchCommentRequest.searchRequest, actionListener, tenantId)
         } else if (!doFilterForUser(user)) {
             // security is enabled and filterby is disabled.
-            search(searchCommentRequest.searchRequest, actionListener)
+            search(searchCommentRequest.searchRequest, actionListener, tenantId)
         } else {
             // security is enabled and filterby is enabled.
             try {
@@ -131,15 +135,14 @@ class TransportSearchAlertingCommentAction @Inject constructor(
                     )
                 )
 
-                search(searchCommentRequest.searchRequest, actionListener)
+                search(searchCommentRequest.searchRequest, actionListener, tenantId)
             } catch (ex: IOException) {
                 actionListener.onFailure(AlertingException.wrap(ex))
             }
         }
     }
 
-    fun search(searchRequest: SearchRequest, actionListener: ActionListener<SearchResponse>) {
-        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+    fun search(searchRequest: SearchRequest, actionListener: ActionListener<SearchResponse>, tenantId: String? = null) {
         val sdkSearchRequest = SearchDataObjectRequest.builder()
             .indices(*searchRequest.indices())
             .tenantId(tenantId)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
@@ -154,7 +154,7 @@ class TransportSearchMonitorAction @Inject constructor(
         return false
     }
 
-    fun search(searchRequest: SearchRequest, actionListener: ActionListener<SearchResponse>, tenantId: String?) {
+    fun search(searchRequest: SearchRequest, actionListener: ActionListener<SearchResponse>, tenantId: String? = null) {
         val sdkSearchRequest = SearchDataObjectRequest.builder()
             .indices(*searchRequest.indices())
             .tenantId(tenantId)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
@@ -101,7 +101,12 @@ class TransportSearchMonitorAction @Inject constructor(
         }
     }
 
-    fun resolve(searchMonitorRequest: SearchMonitorRequest, actionListener: ActionListener<SearchResponse>, user: User?, tenantId: String?) {
+    fun resolve(
+        searchMonitorRequest: SearchMonitorRequest,
+        actionListener: ActionListener<SearchResponse>,
+        user: User?,
+        tenantId: String?,
+    ) {
         if (user == null) {
             // user header is null when: 1/ security is disabled. 2/when user is super-admin.
             search(searchMonitorRequest.searchRequest, actionListener, tenantId)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
@@ -95,23 +95,24 @@ class TransportSearchMonitorAction @Inject constructor(
             .version(true)
         addOwnerFieldIfNotExists(transformedRequest.searchRequest)
         val user = readUserFromThreadContext(client)
+        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
         client.threadPool().threadContext.stashContext().use {
-            resolve(transformedRequest, actionListener, user)
+            resolve(transformedRequest, actionListener, user, tenantId)
         }
     }
 
-    fun resolve(searchMonitorRequest: SearchMonitorRequest, actionListener: ActionListener<SearchResponse>, user: User?) {
+    fun resolve(searchMonitorRequest: SearchMonitorRequest, actionListener: ActionListener<SearchResponse>, user: User?, tenantId: String?) {
         if (user == null) {
             // user header is null when: 1/ security is disabled. 2/when user is super-admin.
-            search(searchMonitorRequest.searchRequest, actionListener)
+            search(searchMonitorRequest.searchRequest, actionListener, tenantId)
         } else if (!doFilterForUser(user)) {
             // security is enabled and filterby is disabled.
-            search(searchMonitorRequest.searchRequest, actionListener)
+            search(searchMonitorRequest.searchRequest, actionListener, tenantId)
         } else {
             // security is enabled and filterby is enabled.
             log.info("Filtering result by: ${user.backendRoles}")
             addFilter(user, searchMonitorRequest.searchRequest.source(), "monitor.user.backend_roles.keyword")
-            search(searchMonitorRequest.searchRequest, actionListener)
+            search(searchMonitorRequest.searchRequest, actionListener, tenantId)
         }
     }
 
@@ -148,8 +149,7 @@ class TransportSearchMonitorAction @Inject constructor(
         return false
     }
 
-    fun search(searchRequest: SearchRequest, actionListener: ActionListener<SearchResponse>) {
-        val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+    fun search(searchRequest: SearchRequest, actionListener: ActionListener<SearchResponse>, tenantId: String?) {
         val sdkSearchRequest = SearchDataObjectRequest.builder()
             .indices(*searchRequest.indices())
             .tenantId(tenantId)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
@@ -105,7 +105,7 @@ class TransportSearchMonitorAction @Inject constructor(
         searchMonitorRequest: SearchMonitorRequest,
         actionListener: ActionListener<SearchResponse>,
         user: User?,
-        tenantId: String?,
+        tenantId: String? = null,
     ) {
         if (user == null) {
             // user header is null when: 1/ security is disabled. 2/when user is super-admin.

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TenantContextPreservationTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TenantContextPreservationTests.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.transport
+
+import com.carrotsearch.randomizedtesting.ThreadFilter
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.opensearch.alerting.AlertingPlugin.Companion.TENANT_ID_HEADER
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.util.concurrent.ThreadContext
+import org.opensearch.commons.utils.TenantContext
+import org.opensearch.commons.utils.currentTenantId
+import org.opensearch.test.OpenSearchTestCase
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Tests that verify TenantContext preserves the tenant ID across
+ * thread context stashes and coroutine scope launches, matching
+ * the pattern used in alerting TransportActions.
+ */
+@ThreadLeakFilters(filters = [TenantContextPreservationTests.CoroutineThreadFilter::class])
+class TenantContextPreservationTests : OpenSearchTestCase() {
+
+    class CoroutineThreadFilter : ThreadFilter {
+        override fun reject(t: Thread): Boolean = t.name.startsWith("DefaultDispatcher-worker")
+    }
+
+    private val scope = CoroutineScope(Dispatchers.IO)
+
+    fun `test tenantId preserved after stashContext via TenantContext`() {
+        val threadContext = ThreadContext(Settings.EMPTY)
+        val expectedTenantId = "tenant-123:scope-abc"
+        threadContext.putHeader(TENANT_ID_HEADER, expectedTenantId)
+
+        // Capture tenantId before stash (as TransportActions do)
+        val tenantId = threadContext.getHeader(TENANT_ID_HEADER)
+
+        val result = AtomicReference<String?>()
+        val latch = CountDownLatch(1)
+
+        // Stash context (header is now gone from threadContext)
+        threadContext.stashContext().use {
+            assertNull(threadContext.getHeader(TENANT_ID_HEADER))
+
+            // Launch with TenantContext (as TransportActions do)
+            scope.launch(TenantContext(tenantId)) {
+                result.set(currentTenantId())
+                latch.countDown()
+            }
+        }
+
+        assertTrue(latch.await(2, TimeUnit.SECONDS))
+        assertEquals(expectedTenantId, result.get())
+    }
+
+    fun `test null tenantId preserved when header absent`() {
+        val threadContext = ThreadContext(Settings.EMPTY)
+        // No header set
+
+        val tenantId = threadContext.getHeader(TENANT_ID_HEADER)
+        assertNull(tenantId)
+
+        val result = AtomicReference<String?>("sentinel")
+        val latch = CountDownLatch(1)
+
+        threadContext.stashContext().use {
+            scope.launch(TenantContext(tenantId)) {
+                result.set(currentTenantId())
+                latch.countDown()
+            }
+        }
+
+        assertTrue(latch.await(2, TimeUnit.SECONDS))
+        assertNull(result.get())
+    }
+
+    fun `test concurrent requests have isolated tenantIds`() {
+        val result1 = AtomicReference<String?>()
+        val result2 = AtomicReference<String?>()
+        val latch = CountDownLatch(2)
+
+        scope.launch(TenantContext("tenant-a")) {
+            // Simulate some work
+            result1.set(currentTenantId())
+            latch.countDown()
+        }
+
+        scope.launch(TenantContext("tenant-b")) {
+            result2.set(currentTenantId())
+            latch.countDown()
+        }
+
+        assertTrue(latch.await(2, TimeUnit.SECONDS))
+        assertEquals("tenant-a", result1.get())
+        assertEquals("tenant-b", result2.get())
+    }
+
+    fun `test tenantId available in nested suspend functions`() {
+        val expectedTenantId = "tenant-nested"
+        val result = AtomicReference<String?>()
+        val latch = CountDownLatch(1)
+
+        scope.launch(TenantContext(expectedTenantId)) {
+            val id = nestedSuspendFunction()
+            result.set(id)
+            latch.countDown()
+        }
+
+        assertTrue(latch.await(2, TimeUnit.SECONDS))
+        assertEquals(expectedTenantId, result.get())
+    }
+
+    private suspend fun nestedSuspendFunction(): String? {
+        return deeperSuspendFunction()
+    }
+
+    private suspend fun deeperSuspendFunction(): String? {
+        return currentTenantId()
+    }
+}

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorActionTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorActionTests.kt
@@ -8,11 +8,13 @@ package org.opensearch.alerting.transport
 import com.carrotsearch.randomizedtesting.ThreadFilter
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters
 import org.junit.Before
+import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
 import org.mockito.Mockito.timeout
 import org.mockito.Mockito.verify
 import org.opensearch.action.support.ActionFilters
+import org.opensearch.alerting.AlertingPlugin.Companion.TENANT_ID_HEADER
 import org.opensearch.alerting.service.ExternalSchedulerService
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.cluster.service.ClusterService
@@ -156,6 +158,50 @@ class TransportDeleteMonitorActionTests : OpenSearchTestCase() {
         threadContext.putTransient(ExternalSchedulerService.SCHEDULER_ACCOUNT_ID_KEY, "999999999999")
         val value = threadContext.getTransient<String>(ExternalSchedulerService.SCHEDULER_ACCOUNT_ID_KEY)
         assertEquals("999999999999", value)
+    }
+
+    fun `test tenantId preserved across stashContext and scope launch`() {
+        val expectedTenantId = "test-tenant:test-scope"
+        threadContext.putHeader(TENANT_ID_HEADER, expectedTenantId)
+
+        val response = GetDataObjectResponse.builder()
+            .id("test-monitor-id")
+            .index(".opendistro-alerting-config")
+            .source(null)
+            .build()
+        whenever(sdkClient.getDataObject(any(GetDataObjectRequest::class.java))).thenReturn(response)
+
+        val action = createAction()
+        val request = DeleteMonitorRequest("test-monitor-id", org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE)
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<DeleteMonitorResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        val captor = ArgumentCaptor.forClass(GetDataObjectRequest::class.java)
+        verify(sdkClient, timeout(1000)).getDataObject(captor.capture())
+        assertEquals(expectedTenantId, captor.value.tenantId())
+    }
+
+    fun `test null tenantId preserved when header absent`() {
+        // No TENANT_ID_HEADER set in threadContext
+        val response = GetDataObjectResponse.builder()
+            .id("test-monitor-id")
+            .index(".opendistro-alerting-config")
+            .source(null)
+            .build()
+        whenever(sdkClient.getDataObject(any(GetDataObjectRequest::class.java))).thenReturn(response)
+
+        val action = createAction()
+        val request = DeleteMonitorRequest("test-monitor-id", org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE)
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<DeleteMonitorResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        val captor = ArgumentCaptor.forClass(GetDataObjectRequest::class.java)
+        verify(sdkClient, timeout(1000)).getDataObject(captor.capture())
+        assertNull(captor.value.tenantId())
     }
 
     private fun invokeDoExecute(

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportGetDestinationsActionTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportGetDestinationsActionTests.kt
@@ -135,4 +135,54 @@ class TransportGetDestinationsActionTests : OpenSearchTestCase() {
         verify(listener).onResponse(captor.capture())
         assertEquals(0, captor.value.totalDestinations)
     }
+
+    fun `test resolve passes tenantId through to search`() {
+        val expectedTenantId = "test-tenant:test-scope"
+
+        val future: CompletionStage<SearchDataObjectResponse> =
+            CompletableFuture.completedFuture(SearchDataObjectResponse(null as org.opensearch.action.search.SearchResponse?))
+        whenever(sdkClient.searchDataObjectAsync(any(SearchDataObjectRequest::class.java))).thenReturn(future)
+
+        val action = TransportGetDestinationsAction(
+            Mockito.mock(TransportService::class.java),
+            client,
+            clusterService,
+            Mockito.mock(ActionFilters::class.java),
+            Settings.EMPTY,
+            Mockito.mock(NamedXContentRegistry::class.java),
+            sdkClient
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<GetDestinationsResponse>
+        action.resolve(SearchSourceBuilder(), listener, null, expectedTenantId)
+
+        val captor = ArgumentCaptor.forClass(SearchDataObjectRequest::class.java)
+        verify(sdkClient).searchDataObjectAsync(captor.capture())
+        assertEquals(expectedTenantId, captor.value.tenantId())
+    }
+
+    fun `test resolve passes null tenantId when not provided`() {
+        val future: CompletionStage<SearchDataObjectResponse> =
+            CompletableFuture.completedFuture(SearchDataObjectResponse(null as org.opensearch.action.search.SearchResponse?))
+        whenever(sdkClient.searchDataObjectAsync(any(SearchDataObjectRequest::class.java))).thenReturn(future)
+
+        val action = TransportGetDestinationsAction(
+            Mockito.mock(TransportService::class.java),
+            client,
+            clusterService,
+            Mockito.mock(ActionFilters::class.java),
+            Settings.EMPTY,
+            Mockito.mock(NamedXContentRegistry::class.java),
+            sdkClient
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<GetDestinationsResponse>
+        action.resolve(SearchSourceBuilder(), listener, null)
+
+        val captor = ArgumentCaptor.forClass(SearchDataObjectRequest::class.java)
+        verify(sdkClient).searchDataObjectAsync(captor.capture())
+        assertNull(captor.value.tenantId())
+    }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorActionTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorActionTests.kt
@@ -137,6 +137,53 @@ class TransportSearchMonitorActionTests : OpenSearchTestCase() {
         verify(listener).onResponse(any())
     }
 
+    fun `test resolve passes tenantId to search`() {
+        val expectedTenantId = "test-tenant:test-scope"
+
+        val future: CompletionStage<SearchDataObjectResponse> =
+            CompletableFuture.completedFuture(SearchDataObjectResponse(null as org.opensearch.action.search.SearchResponse?))
+        whenever(sdkClient.searchDataObjectAsync(any(SearchDataObjectRequest::class.java))).thenReturn(future)
+
+        val action = createAction()
+
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<org.opensearch.action.search.SearchResponse>
+        action.resolve(
+            org.opensearch.commons.alerting.action.SearchMonitorRequest(
+                org.opensearch.action.search.SearchRequest(".opendistro-alerting-config")
+            ),
+            listener,
+            null,
+            expectedTenantId
+        )
+
+        val captor = ArgumentCaptor.forClass(SearchDataObjectRequest::class.java)
+        verify(sdkClient).searchDataObjectAsync(captor.capture())
+        assertEquals(expectedTenantId, captor.value.tenantId())
+    }
+
+    fun `test resolve passes null tenantId when not provided`() {
+        val future: CompletionStage<SearchDataObjectResponse> =
+            CompletableFuture.completedFuture(SearchDataObjectResponse(null as org.opensearch.action.search.SearchResponse?))
+        whenever(sdkClient.searchDataObjectAsync(any(SearchDataObjectRequest::class.java))).thenReturn(future)
+
+        val action = createAction()
+
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<org.opensearch.action.search.SearchResponse>
+        action.resolve(
+            org.opensearch.commons.alerting.action.SearchMonitorRequest(
+                org.opensearch.action.search.SearchRequest(".opendistro-alerting-config")
+            ),
+            listener,
+            null
+        )
+
+        val captor = ArgumentCaptor.forClass(SearchDataObjectRequest::class.java)
+        verify(sdkClient).searchDataObjectAsync(captor.capture())
+        assertNull(captor.value.tenantId())
+    }
+
     private fun createAction(): TransportSearchMonitorAction {
         return TransportSearchMonitorAction(
             Mockito.mock(TransportService::class.java),


### PR DESCRIPTION
### Description
Restores the tenantId after context is stashed in transport actions

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
