### PR TITLE
Use role name and construct ARN at runtime for scheduler identities

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -189,6 +189,7 @@ dependencies {
     implementation "software.amazon.awssdk:sdk-core:${versions.aws}"
     implementation "software.amazon.awssdk:utils:${versions.aws}"
     implementation "software.amazon.awssdk:regions:${versions.aws}"
+    implementation "software.amazon.awssdk:arns:${versions.aws}"
 
     testImplementation "org.antlr:antlr4-runtime:${versions.antlr4}"
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -492,8 +492,8 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             AlertingSettings.EXTERNAL_SCHEDULER_ACCOUNT_ID,
             AlertingSettings.JOB_QUEUE_NAME,
             AlertingSettings.JOB_QUEUE_MESSAGE_GROUP_KEY_NAME,
-            AlertingSettings.EXTERNAL_SCHEDULER_ROLE_ARN,
-            AlertingSettings.EXTERNAL_SCHEDULER_EXECUTION_ROLE_ARN,
+            AlertingSettings.EXTERNAL_SCHEDULER_ROLE_NAME,
+            AlertingSettings.EXTERNAL_SCHEDULER_EXECUTION_ROLE_NAME,
             AlertingSettings.JOB_QUEUE_ACCOUNT_ID,
             AlertingSettings.JOB_QUEUE_ACCOUNT_PROVIDER_TYPE,
             AlertingSettings.TARGET_TYPE_TO_SERVICE_NAME

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -52,6 +52,7 @@ import org.opensearch.alerting.resthandler.RestSearchEmailAccountAction
 import org.opensearch.alerting.resthandler.RestSearchEmailGroupAction
 import org.opensearch.alerting.resthandler.RestSearchMonitorAction
 import org.opensearch.alerting.script.TriggerScript
+import org.opensearch.alerting.service.AssumeRoleCredentialsCache
 import org.opensearch.alerting.service.DeleteMonitorService
 import org.opensearch.alerting.service.ExternalSchedulerService
 import org.opensearch.alerting.service.MonitorJobPoller
@@ -152,6 +153,8 @@ import org.opensearch.script.ScriptService
 import org.opensearch.threadpool.ThreadPool
 import org.opensearch.transport.client.Client
 import org.opensearch.watcher.ResourceWatcherService
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.sts.StsClient
 import java.util.function.Supplier
 
 /**
@@ -386,6 +389,19 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
         )
 
         ExternalSchedulerService.initialize(settings)
+        if (AlertingSettings.EXTERNAL_SCHEDULER_ENABLED.get(settings)) {
+            val region = REMOTE_METADATA_REGION.get(settings)
+            val roleName = AlertingSettings.EXTERNAL_SCHEDULER_ROLE_NAME.get(settings)
+            if (!region.isNullOrBlank() && roleName.isNotBlank()) {
+                val stsClient = StsClient.builder()
+                    .region(Region.of(region))
+                    .build()
+                ExternalSchedulerService.credentialsCache = AssumeRoleCredentialsCache(
+                    stsClient,
+                    "arn:aws:iam::%s:role/$roleName"
+                )
+            }
+        }
 
         return listOf(
             sweeper,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -153,8 +153,6 @@ import org.opensearch.script.ScriptService
 import org.opensearch.threadpool.ThreadPool
 import org.opensearch.transport.client.Client
 import org.opensearch.watcher.ResourceWatcherService
-import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.services.sts.StsClient
 import java.util.function.Supplier
 
 /**
@@ -393,11 +391,8 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             val region = REMOTE_METADATA_REGION.get(settings)
             val roleName = AlertingSettings.EXTERNAL_SCHEDULER_ROLE_NAME.get(settings)
             if (!region.isNullOrBlank() && roleName.isNotBlank()) {
-                val stsClient = StsClient.builder()
-                    .region(Region.of(region))
-                    .build()
                 ExternalSchedulerService.credentialsCache = AssumeRoleCredentialsCache(
-                    stsClient,
+                    region,
                     "arn:aws:iam::%s:role/$roleName"
                 )
             }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/AssumeRoleCredentialsCache.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/AssumeRoleCredentialsCache.kt
@@ -6,6 +6,7 @@
 package org.opensearch.alerting.service
 
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sts.StsClient
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest
@@ -14,13 +15,19 @@ import java.util.concurrent.ConcurrentHashMap
 /**
  * Caches [AwsCredentialsProvider] instances per account ID, using
  * [StsAssumeRoleCredentialsProvider] for automatic credential refresh on expiry.
+ * The [StsClient] is lazily created on first use.
  */
 class AssumeRoleCredentialsCache(
-    private val stsClient: StsClient,
+    private val region: String,
     private val roleArnFormat: String,
     private val sessionPrefix: String = "alerting"
 ) {
     private val cache = ConcurrentHashMap<String, AwsCredentialsProvider>()
+    private val stsClient: StsClient by lazy {
+        StsClient.builder()
+            .region(Region.of(region))
+            .build()
+    }
 
     fun getCredentialsProvider(accountId: String): AwsCredentialsProvider {
         return cache.computeIfAbsent(accountId) {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/ExternalSchedulerService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/ExternalSchedulerService.kt
@@ -11,6 +11,7 @@ import org.opensearch.alerting.settings.AlertingSettings.Companion.REMOTE_METADA
 import org.opensearch.common.settings.Settings
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.util.ScheduleTranslator
+import software.amazon.awssdk.arns.Arn
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.scheduler.SchedulerClient
 import software.amazon.awssdk.services.scheduler.model.ActionAfterCompletion
@@ -45,8 +46,8 @@ object ExternalSchedulerService {
      */
     const val SCHEDULER_ACCOUNT_ID_KEY = "x-scheduler-account-id"
 
-    /** Monitor metadata key that persists the EB cell account ID used for scheduling. */
-    const val EB_CELL_ACCOUNT_ID_METADATA_KEY = "ebCellAccountId"
+    /** Monitor metadata key that stores the full ARN of the created EventBridge schedule. */
+    const val SCHEDULE_ARN_METADATA_KEY = "schedule_arn"
 
     @Volatile
     var credentialsCache: AssumeRoleCredentialsCache? = null
@@ -176,5 +177,25 @@ object ExternalSchedulerService {
                 .credentialsProvider(cache.getCredentialsProvider(routing.accountId))
                 .build()
         }
+    }
+
+    /** Builds the schedule ARN from routing info and monitor ID. */
+    fun buildScheduleArn(routing: SchedulerRoutingResolver.Routing, monitorId: String): String {
+        val resolvedRegion = requireNotNull(region) { "region must be set" }
+        return "arn:aws:scheduler:$resolvedRegion:${routing.accountId}:schedule/default/${scheduleName(monitorId)}"
+    }
+
+    /**
+     * Parsed components of a schedule ARN.
+     */
+    data class ScheduleArnInfo(val region: String, val accountId: String, val name: String)
+
+    /** Parses a schedule ARN into its components using [Arn.fromString]. */
+    fun parseScheduleArn(arn: String): ScheduleArnInfo {
+        val parsed = Arn.fromString(arn)
+        val region = parsed.region().orElseThrow { IllegalArgumentException("Schedule ARN missing region: $arn") }
+        val accountId = parsed.accountId().orElseThrow { IllegalArgumentException("Schedule ARN missing account ID: $arn") }
+        val name = parsed.resourceAsString().substringAfterLast("/")
+        return ScheduleArnInfo(region, accountId, name)
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/ExternalSchedulerService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/ExternalSchedulerService.kt
@@ -45,6 +45,9 @@ object ExternalSchedulerService {
      */
     const val SCHEDULER_ACCOUNT_ID_KEY = "x-scheduler-account-id"
 
+    /** Monitor metadata key that persists the EB cell account ID used for scheduling. */
+    const val EB_CELL_ACCOUNT_ID_METADATA_KEY = "ebCellAccountId"
+
     @Volatile
     var credentialsCache: AssumeRoleCredentialsCache? = null
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/SchedulerRoutingResolver.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/SchedulerRoutingResolver.kt
@@ -21,26 +21,26 @@ object SchedulerRoutingResolver {
     fun resolve(
         settingsAccountId: String,
         settingsQueueName: String,
-        settingsRoleArn: String,
-        settingsExecutionRoleArn: String? = null,
+        settingsRoleName: String,
+        settingsExecutionRoleName: String? = null,
         threadContextAccountIdOverride: String?
     ): Routing? {
         val accountId = pickAccountId(settingsAccountId, threadContextAccountIdOverride) ?: return null
         val queueName = settingsQueueName.takeIf { it.isNotBlank() } ?: return null
-        val roleArn = settingsRoleArn.takeIf { it.isNotBlank() } ?: return null
-        val executionRoleArn = settingsExecutionRoleArn?.takeIf { it.isNotBlank() } ?: return null
-        return Routing(accountId, queueName, roleArn, executionRoleArn)
+        val roleName = settingsRoleName.takeIf { it.isNotBlank() } ?: return null
+        val executionRoleName = settingsExecutionRoleName?.takeIf { it.isNotBlank() } ?: return null
+        return Routing(accountId, queueName, buildRoleArn(accountId, roleName), buildRoleArn(accountId, executionRoleName))
     }
 
     /** Delete only needs accountId + roleArn; queueName is set to empty. */
     fun resolveForDelete(
         settingsAccountId: String,
-        settingsRoleArn: String,
+        settingsRoleName: String,
         threadContextAccountIdOverride: String?
     ): Routing? {
         val accountId = pickAccountId(settingsAccountId, threadContextAccountIdOverride) ?: return null
-        val roleArn = settingsRoleArn.takeIf { it.isNotBlank() } ?: return null
-        return Routing(accountId, "", roleArn, "")
+        val roleName = settingsRoleName.takeIf { it.isNotBlank() } ?: return null
+        return Routing(accountId, "", buildRoleArn(accountId, roleName), "")
     }
 
     /** ThreadContext override wins; falls back to plugin setting; null if both are blank. */
@@ -48,4 +48,8 @@ object SchedulerRoutingResolver {
         if (!override.isNullOrBlank()) return override
         return settingValue.takeIf { it.isNotBlank() }
     }
+
+    /** Constructs an IAM role ARN from account ID and role name. */
+    private fun buildRoleArn(accountId: String, roleName: String): String =
+        "arn:aws:iam::$accountId:role/$roleName"
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/SchedulerRoutingResolver.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/SchedulerRoutingResolver.kt
@@ -24,11 +24,15 @@ object SchedulerRoutingResolver {
         settingsRoleName: String,
         settingsExecutionRoleName: String? = null,
         threadContextAccountIdOverride: String?
-    ): Routing? {
-        val accountId = pickAccountId(settingsAccountId, threadContextAccountIdOverride) ?: return null
-        val queueName = settingsQueueName.takeIf { it.isNotBlank() } ?: return null
-        val roleName = settingsRoleName.takeIf { it.isNotBlank() } ?: return null
-        val executionRoleName = settingsExecutionRoleName?.takeIf { it.isNotBlank() } ?: return null
+    ): Routing {
+        val accountId = pickAccountId(settingsAccountId, threadContextAccountIdOverride)
+            ?: error("External scheduler account ID is not configured and no override was provided")
+        val queueName = settingsQueueName.takeIf { it.isNotBlank() }
+            ?: error("External scheduler queue name is not configured")
+        val roleName = settingsRoleName.takeIf { it.isNotBlank() }
+            ?: error("External scheduler role name is not configured")
+        val executionRoleName = settingsExecutionRoleName?.takeIf { it.isNotBlank() }
+            ?: error("External scheduler execution role name is not configured")
         return Routing(accountId, queueName, buildRoleArn(accountId, roleName), buildRoleArn(accountId, executionRoleName))
     }
 
@@ -37,9 +41,11 @@ object SchedulerRoutingResolver {
         settingsAccountId: String,
         settingsRoleName: String,
         threadContextAccountIdOverride: String?
-    ): Routing? {
-        val accountId = pickAccountId(settingsAccountId, threadContextAccountIdOverride) ?: return null
-        val roleName = settingsRoleName.takeIf { it.isNotBlank() } ?: return null
+    ): Routing {
+        val accountId = pickAccountId(settingsAccountId, threadContextAccountIdOverride)
+            ?: error("External scheduler account ID is not configured and no override was provided")
+        val roleName = settingsRoleName.takeIf { it.isNotBlank() }
+            ?: error("External scheduler role name is not configured")
         return Routing(accountId, "", buildRoleArn(accountId, roleName), "")
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
@@ -374,15 +374,15 @@ class AlertingSettings {
             Setting.Property.NodeScope, Setting.Property.Dynamic
         )
 
-        /** IAM role ARN that EventBridge assumes to send messages to the target SQS queue. */
-        val EXTERNAL_SCHEDULER_ROLE_ARN = Setting.simpleString(
-            "plugins.alerting.external_scheduler.role_arn",
+        /** IAM role name that EventBridge assumes to send messages to the target SQS queue. The full ARN is constructed from the account ID. */
+        val EXTERNAL_SCHEDULER_ROLE_NAME = Setting.simpleString(
+            "plugins.alerting.external_scheduler.role_name",
             Setting.Property.NodeScope, Setting.Property.Dynamic
         )
 
-        /** IAM role ARN that EventBridge Scheduler assumes at fire time (Target.roleArn). Required when external scheduler is enabled. */
-        val EXTERNAL_SCHEDULER_EXECUTION_ROLE_ARN = Setting.simpleString(
-            "plugins.alerting.external_scheduler.execution_role_arn",
+        /** IAM role name that EventBridge Scheduler assumes at fire time (Target.roleArn). The full ARN is constructed from the account ID. */
+        val EXTERNAL_SCHEDULER_EXECUTION_ROLE_NAME = Setting.simpleString(
+            "plugins.alerting.external_scheduler.execution_role_name",
             Setting.Property.NodeScope, Setting.Property.Dynamic
         )
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
@@ -63,7 +63,7 @@ class TransportDeleteMonitorAction @Inject constructor(
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
     @Volatile private var externalSchedulerEnabled = AlertingSettings.EXTERNAL_SCHEDULER_ENABLED.get(settings)
     @Volatile private var externalSchedulerAccountId = AlertingSettings.EXTERNAL_SCHEDULER_ACCOUNT_ID.get(settings)
-    @Volatile private var externalSchedulerRoleArn = AlertingSettings.EXTERNAL_SCHEDULER_ROLE_ARN.get(settings)
+    @Volatile private var externalSchedulerRoleName = AlertingSettings.EXTERNAL_SCHEDULER_ROLE_NAME.get(settings)
 
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.EXTERNAL_SCHEDULER_ENABLED) {
@@ -72,8 +72,8 @@ class TransportDeleteMonitorAction @Inject constructor(
         clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.EXTERNAL_SCHEDULER_ACCOUNT_ID) {
             externalSchedulerAccountId = it
         }
-        clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.EXTERNAL_SCHEDULER_ROLE_ARN) {
-            externalSchedulerRoleArn = it
+        clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.EXTERNAL_SCHEDULER_ROLE_NAME) {
+            externalSchedulerRoleName = it
         }
         listenFilterBySettingChange(clusterService)
     }
@@ -152,7 +152,7 @@ class TransportDeleteMonitorAction @Inject constructor(
         private fun deleteExternalSchedule(monitor: Monitor) {
             val routing = SchedulerRoutingResolver.resolveForDelete(
                 settingsAccountId = externalSchedulerAccountId,
-                settingsRoleArn = externalSchedulerRoleArn,
+                settingsRoleName = externalSchedulerRoleName,
                 threadContextAccountIdOverride = client.threadPool().threadContext
                     .getTransient<String>(ExternalSchedulerService.SCHEDULER_ACCOUNT_ID_KEY)
             ) ?: return

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
@@ -153,10 +153,8 @@ class TransportDeleteMonitorAction @Inject constructor(
             val routing = SchedulerRoutingResolver.resolveForDelete(
                 settingsAccountId = externalSchedulerAccountId,
                 settingsRoleName = externalSchedulerRoleName,
-                threadContextAccountIdOverride = client.threadPool().threadContext
-                    .getTransient<String>(ExternalSchedulerService.SCHEDULER_ACCOUNT_ID_KEY)
-            ) ?: return
-
+                threadContextAccountIdOverride = monitor.metadata?.get(ExternalSchedulerService.EB_CELL_ACCOUNT_ID_METADATA_KEY)
+            )
             ExternalSchedulerService.deleteSchedule(monitor.id, routing)
         }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
@@ -150,10 +150,14 @@ class TransportDeleteMonitorAction @Inject constructor(
          * record so the schedule deletion can be retried.
          */
         private fun deleteExternalSchedule(monitor: Monitor) {
+            val scheduleArn = monitor.metadata?.get(ExternalSchedulerService.SCHEDULE_ARN_METADATA_KEY)
+            val accountIdOverride = scheduleArn?.let {
+                ExternalSchedulerService.parseScheduleArn(it).accountId
+            }
             val routing = SchedulerRoutingResolver.resolveForDelete(
                 settingsAccountId = externalSchedulerAccountId,
                 settingsRoleName = externalSchedulerRoleName,
-                threadContextAccountIdOverride = monitor.metadata?.get(ExternalSchedulerService.EB_CELL_ACCOUNT_ID_METADATA_KEY)
+                threadContextAccountIdOverride = accountIdOverride
             )
             ExternalSchedulerService.deleteSchedule(monitor.id, routing)
         }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -640,10 +640,14 @@ class TransportIndexMonitorAction @Inject constructor(
                     }
                 }
 
-                // Create external schedule for monitor execution
+                // Create external schedule and update monitor with the schedule ARN
                 if (externalSchedulerEnabled) {
                     try {
-                        createExternalSchedule(request.monitor, tenantId)
+                        val scheduleArn = createExternalSchedule(request.monitor)
+                        val updatedMetadata = (request.monitor.metadata.orEmpty()) +
+                            (ExternalSchedulerService.SCHEDULE_ARN_METADATA_KEY to scheduleArn)
+                        request.monitor = request.monitor.copy(metadata = updatedMetadata)
+                        updateMonitorMetadata(request.monitor, tenantId)
                     } catch (t: Exception) {
                         log.error("Failed to create EB schedule for monitor ${indexResponse.id}. Rolling back.", t)
                         cleanupMonitorAfterPartialFailure(request.monitor, indexResponse)
@@ -881,22 +885,24 @@ class TransportIndexMonitorAction @Inject constructor(
         }
 
         /**
-         * Reads scheduler routing info from plugin settings (with optional ThreadContext
-         * override for account id) and creates an external schedule.
+         * Creates an external schedule and returns the schedule ARN.
          */
-        private fun createExternalSchedule(monitor: Monitor, tenantId: String?) {
+        private fun createExternalSchedule(monitor: Monitor): String {
             val routing = resolveRouting(schedulerAccountId)
             val targetInput = buildScheduleJobPayloadJson(monitor)
             ExternalSchedulerService.createSchedule(monitor, routing, targetInput)
+            return ExternalSchedulerService.buildScheduleArn(routing, monitor.id)
         }
 
         /**
-         * Reads scheduler routing info from plugin settings (with account id from existing
-         * monitor metadata) and updates the external schedule. Always refreshes
-         * Target.Input with the latest monitor config.
+         * Reads the schedule ARN from the existing monitor's metadata to determine
+         * the target account, then updates the external schedule with the latest monitor config.
          */
         private fun updateExternalSchedule(monitor: Monitor, currentMonitor: Monitor, tenantId: String?) {
-            val accountIdOverride = currentMonitor.metadata?.get(ExternalSchedulerService.EB_CELL_ACCOUNT_ID_METADATA_KEY)
+            val scheduleArn = currentMonitor.metadata?.get(ExternalSchedulerService.SCHEDULE_ARN_METADATA_KEY)
+            val accountIdOverride = scheduleArn?.let {
+                ExternalSchedulerService.parseScheduleArn(it).accountId
+            }
             val routing = resolveRouting(accountIdOverride)
             val targetInput = buildScheduleJobPayloadJson(monitor)
             ExternalSchedulerService.updateSchedule(monitor, routing, targetInput)
@@ -918,6 +924,20 @@ class TransportIndexMonitorAction @Inject constructor(
             val builder = XContentFactory.jsonBuilder()
             payload.toXContent(builder, ToXContent.EMPTY_PARAMS)
             return builder.toString()
+        }
+
+        private suspend fun updateMonitorMetadata(monitor: Monitor, tenantId: String?) {
+            val monitorObj = ToXContentObject { builder, params ->
+                monitor.toXContentWithUser(builder, ToXContent.MapParams(mapOf("with_type" to "true")))
+            }
+            val putRequest = PutDataObjectRequest.builder()
+                .index(SCHEDULED_JOBS_INDEX)
+                .id(monitor.id)
+                .tenantId(tenantId)
+                .overwriteIfExists(true)
+                .dataObject(monitorObj)
+                .build()
+            sdkClient.putDataObjectAsync(putRequest).await()
         }
 
         private fun resolveRouting(accountIdOverride: String?): SchedulerRoutingResolver.Routing = SchedulerRoutingResolver.resolve(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -127,8 +127,8 @@ class TransportIndexMonitorAction @Inject constructor(
     @Volatile private var externalSchedulerEnabled = AlertingSettings.EXTERNAL_SCHEDULER_ENABLED.get(settings)
     @Volatile private var externalSchedulerAccountId = AlertingSettings.EXTERNAL_SCHEDULER_ACCOUNT_ID.get(settings)
     @Volatile private var jobQueueName = AlertingSettings.JOB_QUEUE_NAME.get(settings)
-    @Volatile private var externalSchedulerRoleArn = AlertingSettings.EXTERNAL_SCHEDULER_ROLE_ARN.get(settings)
-    @Volatile private var externalSchedulerExecutionRoleArn = AlertingSettings.EXTERNAL_SCHEDULER_EXECUTION_ROLE_ARN.get(settings)
+    @Volatile private var externalSchedulerRoleName = AlertingSettings.EXTERNAL_SCHEDULER_ROLE_NAME.get(settings)
+    @Volatile private var externalSchedulerExecutionRoleName = AlertingSettings.EXTERNAL_SCHEDULER_EXECUTION_ROLE_NAME.get(settings)
 
     private val multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
 
@@ -151,11 +151,11 @@ class TransportIndexMonitorAction @Inject constructor(
         clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.JOB_QUEUE_NAME) {
             jobQueueName = it
         }
-        clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.EXTERNAL_SCHEDULER_ROLE_ARN) {
-            externalSchedulerRoleArn = it
+        clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.EXTERNAL_SCHEDULER_ROLE_NAME) {
+            externalSchedulerRoleName = it
         }
-        clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.EXTERNAL_SCHEDULER_EXECUTION_ROLE_ARN) {
-            externalSchedulerExecutionRoleArn = it
+        clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.EXTERNAL_SCHEDULER_EXECUTION_ROLE_NAME) {
+            externalSchedulerExecutionRoleName = it
         }
         listenFilterBySettingChange(clusterService)
     }
@@ -918,8 +918,8 @@ class TransportIndexMonitorAction @Inject constructor(
         private fun resolveRouting(): SchedulerRoutingResolver.Routing? = SchedulerRoutingResolver.resolve(
             settingsAccountId = externalSchedulerAccountId,
             settingsQueueName = jobQueueName,
-            settingsRoleArn = externalSchedulerRoleArn,
-            settingsExecutionRoleArn = externalSchedulerExecutionRoleArn,
+            settingsRoleName = externalSchedulerRoleName,
+            settingsExecutionRoleName = externalSchedulerExecutionRoleName,
             threadContextAccountIdOverride = client.threadPool().threadContext
                 .getTransient<String>(ExternalSchedulerService.SCHEDULER_ACCOUNT_ID_KEY)
         )

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -265,8 +265,10 @@ class TransportIndexMonitorAction @Inject constructor(
                 override fun onResponse(searchResponse: SearchResponse) {
                     // User has read access to configured indices in the monitor, now create monitor with out user context.
                     val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+                    val schedulerAccountId = client.threadPool().threadContext
+                        .getTransient<String>(ExternalSchedulerService.SCHEDULER_ACCOUNT_ID_KEY)
                     client.threadPool().threadContext.stashContext().use {
-                        IndexMonitorHandler(client, actionListener, request, user, tenantId).resolveUserAndStart()
+                        IndexMonitorHandler(client, actionListener, request, user, tenantId, schedulerAccountId).resolveUserAndStart()
                     }
                 }
 
@@ -304,8 +306,10 @@ class TransportIndexMonitorAction @Inject constructor(
         user: User?,
     ) {
         val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+        val schedulerAccountId = client.threadPool().threadContext
+            .getTransient<String>(ExternalSchedulerService.SCHEDULER_ACCOUNT_ID_KEY)
         client.threadPool().threadContext.stashContext().use {
-            IndexMonitorHandler(client, actionListener, request, user, tenantId).resolveUserAndStartForAD()
+            IndexMonitorHandler(client, actionListener, request, user, tenantId, schedulerAccountId).resolveUserAndStartForAD()
         }
     }
 
@@ -315,6 +319,7 @@ class TransportIndexMonitorAction @Inject constructor(
         private val request: IndexMonitorRequest,
         private val user: User?,
         private val tenantId: String?,
+        private val schedulerAccountId: String?,
     ) {
 
         fun resolveUserAndStart() {
@@ -845,7 +850,7 @@ class TransportIndexMonitorAction @Inject constructor(
                 // Update external schedule with latest monitor config
                 if (externalSchedulerEnabled) {
                     try {
-                        updateExternalSchedule(request.monitor, tenantId)
+                        updateExternalSchedule(request.monitor, currentMonitor, tenantId)
                     } catch (t: Exception) {
                         log.error("Failed to update EB schedule for monitor ${request.monitorId}", t)
                         actionListener.onFailure(AlertingException.wrap(t))
@@ -878,21 +883,21 @@ class TransportIndexMonitorAction @Inject constructor(
         /**
          * Reads scheduler routing info from plugin settings (with optional ThreadContext
          * override for account id) and creates an external schedule.
-         * No-op when required settings are blank.
          */
         private fun createExternalSchedule(monitor: Monitor, tenantId: String?) {
-            val routing = resolveRouting() ?: return
+            val routing = resolveRouting(schedulerAccountId)
             val targetInput = buildScheduleJobPayloadJson(monitor)
             ExternalSchedulerService.createSchedule(monitor, routing, targetInput)
         }
 
         /**
-         * Reads scheduler routing info from plugin settings (with optional ThreadContext
-         * override for account id) and updates the external schedule. Always refreshes
+         * Reads scheduler routing info from plugin settings (with account id from existing
+         * monitor metadata) and updates the external schedule. Always refreshes
          * Target.Input with the latest monitor config.
          */
-        private fun updateExternalSchedule(monitor: Monitor, tenantId: String?) {
-            val routing = resolveRouting() ?: return
+        private fun updateExternalSchedule(monitor: Monitor, currentMonitor: Monitor, tenantId: String?) {
+            val accountIdOverride = currentMonitor.metadata?.get(ExternalSchedulerService.EB_CELL_ACCOUNT_ID_METADATA_KEY)
+            val routing = resolveRouting(accountIdOverride)
             val targetInput = buildScheduleJobPayloadJson(monitor)
             ExternalSchedulerService.updateSchedule(monitor, routing, targetInput)
         }
@@ -915,13 +920,12 @@ class TransportIndexMonitorAction @Inject constructor(
             return builder.toString()
         }
 
-        private fun resolveRouting(): SchedulerRoutingResolver.Routing? = SchedulerRoutingResolver.resolve(
+        private fun resolveRouting(accountIdOverride: String?): SchedulerRoutingResolver.Routing = SchedulerRoutingResolver.resolve(
             settingsAccountId = externalSchedulerAccountId,
             settingsQueueName = jobQueueName,
             settingsRoleName = externalSchedulerRoleName,
             settingsExecutionRoleName = externalSchedulerExecutionRoleName,
-            threadContextAccountIdOverride = client.threadPool().threadContext
-                .getTransient<String>(ExternalSchedulerService.SCHEDULER_ACCOUNT_ID_KEY)
+            threadContextAccountIdOverride = accountIdOverride
         )
     }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/service/ExternalSchedulerServiceTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/service/ExternalSchedulerServiceTests.kt
@@ -100,4 +100,44 @@ class ExternalSchedulerServiceTests {
             assertTrue(e.message!!.contains("credentialsCache"))
         }
     }
+
+    @Test
+    fun `buildScheduleArn constructs correct ARN`() {
+        ExternalSchedulerService.initialize(
+            org.opensearch.common.settings.Settings.builder()
+                .put("plugins.alerting.remote_metadata_region", "us-east-1").build()
+        )
+        val routing = SchedulerRoutingResolver.Routing("444455556666", "queue", "arn:aws:iam::444:role/r", "arn:aws:iam::444:role/e")
+        val arn = ExternalSchedulerService.buildScheduleArn(routing, "mon-xyz")
+        assertEquals("arn:aws:scheduler:us-east-1:444455556666:schedule/default/monitor-mon-xyz", arn)
+    }
+
+    @Test
+    fun `parseScheduleArn extracts region accountId and name`() {
+        val arn = "arn:aws:scheduler:us-west-2:111222333444:schedule/default/monitor-abc123"
+        val info = ExternalSchedulerService.parseScheduleArn(arn)
+        assertEquals("us-west-2", info.region)
+        assertEquals("111222333444", info.accountId)
+        assertEquals("monitor-abc123", info.name)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `parseScheduleArn throws on missing region`() {
+        ExternalSchedulerService.parseScheduleArn("arn:aws:scheduler::111222333444:schedule/default/monitor-abc")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `parseScheduleArn throws on missing account ID`() {
+        ExternalSchedulerService.parseScheduleArn("arn:aws:scheduler:us-west-2::schedule/default/monitor-abc")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `parseScheduleArn throws on invalid ARN`() {
+        ExternalSchedulerService.parseScheduleArn("not-an-arn")
+    }
+
+    @Test
+    fun `SCHEDULE_ARN_METADATA_KEY is schedule_arn`() {
+        assertEquals("schedule_arn", ExternalSchedulerService.SCHEDULE_ARN_METADATA_KEY)
+    }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/service/SchedulerRoutingResolverTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/service/SchedulerRoutingResolverTests.kt
@@ -13,80 +13,82 @@ class SchedulerRoutingResolverTests {
 
     private val acct = "111111111111"
     private val override = "999999999999"
-    private val queue = "arn:aws:sqs:us-east-1:111:queue"
-    private val role = "arn:aws:iam::111:role/eb"
-    private val execRole = "arn:aws:iam::111:role/eb-exec"
+    private val queue = "my-queue"
+    private val roleName = "eb-role"
+    private val execRoleName = "eb-exec-role"
 
     // ---------- resolve() — create/update path ----------
 
     @Test fun `resolve uses plugin settings when no override`() {
-        val r = SchedulerRoutingResolver.resolve(acct, queue, role, execRole, threadContextAccountIdOverride = null)!!
+        val r = SchedulerRoutingResolver.resolve(acct, queue, roleName, execRoleName, threadContextAccountIdOverride = null)!!
         assertEquals(acct, r.accountId)
         assertEquals(queue, r.queueName)
-        assertEquals(role, r.roleArn)
-        assertEquals(execRole, r.executionRoleArn)
+        assertEquals("arn:aws:iam::$acct:role/$roleName", r.roleArn)
+        assertEquals("arn:aws:iam::$acct:role/$execRoleName", r.executionRoleArn)
     }
 
-    @Test fun `resolve applies ThreadContext override for accountId`() {
-        val r = SchedulerRoutingResolver.resolve(acct, queue, role, execRole, threadContextAccountIdOverride = override)!!
+    @Test fun `resolve applies ThreadContext override for accountId and constructs ARN with override`() {
+        val r = SchedulerRoutingResolver.resolve(acct, queue, roleName, execRoleName, threadContextAccountIdOverride = override)!!
         assertEquals(override, r.accountId)
+        assertEquals("arn:aws:iam::$override:role/$roleName", r.roleArn)
+        assertEquals("arn:aws:iam::$override:role/$execRoleName", r.executionRoleArn)
     }
 
     @Test fun `resolve treats blank override as absent`() {
-        val r = SchedulerRoutingResolver.resolve(acct, queue, role, execRole, threadContextAccountIdOverride = "   ")!!
+        val r = SchedulerRoutingResolver.resolve(acct, queue, roleName, execRoleName, threadContextAccountIdOverride = "   ")!!
         assertEquals(acct, r.accountId)
     }
 
     @Test fun `resolve returns null when accountId missing in both setting and override`() {
-        assertNull(SchedulerRoutingResolver.resolve("", queue, role, execRole, threadContextAccountIdOverride = null))
-        assertNull(SchedulerRoutingResolver.resolve("", queue, role, execRole, threadContextAccountIdOverride = ""))
+        assertNull(SchedulerRoutingResolver.resolve("", queue, roleName, execRoleName, threadContextAccountIdOverride = null))
+        assertNull(SchedulerRoutingResolver.resolve("", queue, roleName, execRoleName, threadContextAccountIdOverride = ""))
     }
 
     @Test fun `resolve still succeeds when setting blank but override provided`() {
-        val r = SchedulerRoutingResolver.resolve("", queue, role, execRole, threadContextAccountIdOverride = override)!!
+        val r = SchedulerRoutingResolver.resolve("", queue, roleName, execRoleName, threadContextAccountIdOverride = override)!!
         assertEquals(override, r.accountId)
     }
 
     @Test fun `resolve returns null when queueName blank`() {
-        assertNull(SchedulerRoutingResolver.resolve(acct, "", role, execRole, threadContextAccountIdOverride = null))
+        assertNull(SchedulerRoutingResolver.resolve(acct, "", roleName, execRoleName, threadContextAccountIdOverride = null))
     }
 
-    @Test fun `resolve returns null when roleArn blank`() {
-        assertNull(SchedulerRoutingResolver.resolve(acct, queue, "", execRole, threadContextAccountIdOverride = null))
+    @Test fun `resolve returns null when roleName blank`() {
+        assertNull(SchedulerRoutingResolver.resolve(acct, queue, "", execRoleName, threadContextAccountIdOverride = null))
     }
 
-    @Test fun `resolve returns null when executionRoleArn blank`() {
-        assertNull(SchedulerRoutingResolver.resolve(acct, queue, role, "  ", threadContextAccountIdOverride = null))
+    @Test fun `resolve returns null when executionRoleName blank`() {
+        assertNull(SchedulerRoutingResolver.resolve(acct, queue, roleName, "  ", threadContextAccountIdOverride = null))
     }
 
-    @Test fun `resolve returns null when executionRoleArn omitted`() {
-        assertNull(SchedulerRoutingResolver.resolve(acct, queue, role, threadContextAccountIdOverride = null))
+    @Test fun `resolve returns null when executionRoleName omitted`() {
+        assertNull(SchedulerRoutingResolver.resolve(acct, queue, roleName, threadContextAccountIdOverride = null))
     }
 
     // ---------- resolveForDelete() ----------
 
     @Test fun `resolveForDelete uses plugin settings when no override`() {
-        val r = SchedulerRoutingResolver.resolveForDelete(acct, role, threadContextAccountIdOverride = null)!!
+        val r = SchedulerRoutingResolver.resolveForDelete(acct, roleName, threadContextAccountIdOverride = null)!!
         assertEquals(acct, r.accountId)
-        assertEquals(role, r.roleArn)
+        assertEquals("arn:aws:iam::$acct:role/$roleName", r.roleArn)
     }
 
-    @Test fun `resolveForDelete applies ThreadContext override`() {
-        val r = SchedulerRoutingResolver.resolveForDelete(acct, role, threadContextAccountIdOverride = override)!!
+    @Test fun `resolveForDelete applies ThreadContext override and constructs ARN with override`() {
+        val r = SchedulerRoutingResolver.resolveForDelete(acct, roleName, threadContextAccountIdOverride = override)!!
         assertEquals(override, r.accountId)
+        assertEquals("arn:aws:iam::$override:role/$roleName", r.roleArn)
     }
 
     @Test fun `resolveForDelete returns null when accountId missing`() {
-        assertNull(SchedulerRoutingResolver.resolveForDelete("", role, threadContextAccountIdOverride = null))
+        assertNull(SchedulerRoutingResolver.resolveForDelete("", roleName, threadContextAccountIdOverride = null))
     }
 
-    @Test fun `resolveForDelete returns null when roleArn missing`() {
+    @Test fun `resolveForDelete returns null when roleName missing`() {
         assertNull(SchedulerRoutingResolver.resolveForDelete(acct, "", threadContextAccountIdOverride = null))
     }
 
     @Test fun `resolveForDelete does not require queueName`() {
-        // No queueName parameter at all — setup covers delete path independent of create/update
-        val r = SchedulerRoutingResolver.resolveForDelete(acct, role, threadContextAccountIdOverride = null)
+        val r = SchedulerRoutingResolver.resolveForDelete(acct, roleName, threadContextAccountIdOverride = null)
         assertEquals(acct, r?.accountId)
     }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/service/SchedulerRoutingResolverTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/service/SchedulerRoutingResolverTests.kt
@@ -6,7 +6,6 @@
 package org.opensearch.alerting.service
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Test
 
 class SchedulerRoutingResolverTests {
@@ -20,7 +19,7 @@ class SchedulerRoutingResolverTests {
     // ---------- resolve() — create/update path ----------
 
     @Test fun `resolve uses plugin settings when no override`() {
-        val r = SchedulerRoutingResolver.resolve(acct, queue, roleName, execRoleName, threadContextAccountIdOverride = null)!!
+        val r = SchedulerRoutingResolver.resolve(acct, queue, roleName, execRoleName, threadContextAccountIdOverride = null)
         assertEquals(acct, r.accountId)
         assertEquals(queue, r.queueName)
         assertEquals("arn:aws:iam::$acct:role/$roleName", r.roleArn)
@@ -28,67 +27,73 @@ class SchedulerRoutingResolverTests {
     }
 
     @Test fun `resolve applies ThreadContext override for accountId and constructs ARN with override`() {
-        val r = SchedulerRoutingResolver.resolve(acct, queue, roleName, execRoleName, threadContextAccountIdOverride = override)!!
+        val r = SchedulerRoutingResolver.resolve(acct, queue, roleName, execRoleName, threadContextAccountIdOverride = override)
         assertEquals(override, r.accountId)
         assertEquals("arn:aws:iam::$override:role/$roleName", r.roleArn)
         assertEquals("arn:aws:iam::$override:role/$execRoleName", r.executionRoleArn)
     }
 
     @Test fun `resolve treats blank override as absent`() {
-        val r = SchedulerRoutingResolver.resolve(acct, queue, roleName, execRoleName, threadContextAccountIdOverride = "   ")!!
+        val r = SchedulerRoutingResolver.resolve(acct, queue, roleName, execRoleName, threadContextAccountIdOverride = "   ")
         assertEquals(acct, r.accountId)
     }
 
-    @Test fun `resolve returns null when accountId missing in both setting and override`() {
-        assertNull(SchedulerRoutingResolver.resolve("", queue, roleName, execRoleName, threadContextAccountIdOverride = null))
-        assertNull(SchedulerRoutingResolver.resolve("", queue, roleName, execRoleName, threadContextAccountIdOverride = ""))
+    @Test(expected = IllegalStateException::class)
+    fun `resolve throws when accountId missing in both setting and override`() {
+        SchedulerRoutingResolver.resolve("", queue, roleName, execRoleName, threadContextAccountIdOverride = null)
     }
 
     @Test fun `resolve still succeeds when setting blank but override provided`() {
-        val r = SchedulerRoutingResolver.resolve("", queue, roleName, execRoleName, threadContextAccountIdOverride = override)!!
+        val r = SchedulerRoutingResolver.resolve("", queue, roleName, execRoleName, threadContextAccountIdOverride = override)
         assertEquals(override, r.accountId)
     }
 
-    @Test fun `resolve returns null when queueName blank`() {
-        assertNull(SchedulerRoutingResolver.resolve(acct, "", roleName, execRoleName, threadContextAccountIdOverride = null))
+    @Test(expected = IllegalStateException::class)
+    fun `resolve throws when queueName blank`() {
+        SchedulerRoutingResolver.resolve(acct, "", roleName, execRoleName, threadContextAccountIdOverride = null)
     }
 
-    @Test fun `resolve returns null when roleName blank`() {
-        assertNull(SchedulerRoutingResolver.resolve(acct, queue, "", execRoleName, threadContextAccountIdOverride = null))
+    @Test(expected = IllegalStateException::class)
+    fun `resolve throws when roleName blank`() {
+        SchedulerRoutingResolver.resolve(acct, queue, "", execRoleName, threadContextAccountIdOverride = null)
     }
 
-    @Test fun `resolve returns null when executionRoleName blank`() {
-        assertNull(SchedulerRoutingResolver.resolve(acct, queue, roleName, "  ", threadContextAccountIdOverride = null))
+    @Test(expected = IllegalStateException::class)
+    fun `resolve throws when executionRoleName blank`() {
+        SchedulerRoutingResolver.resolve(acct, queue, roleName, "  ", threadContextAccountIdOverride = null)
     }
 
-    @Test fun `resolve returns null when executionRoleName omitted`() {
-        assertNull(SchedulerRoutingResolver.resolve(acct, queue, roleName, threadContextAccountIdOverride = null))
+    @Test(expected = IllegalStateException::class)
+    fun `resolve throws when executionRoleName omitted`() {
+        SchedulerRoutingResolver.resolve(acct, queue, roleName, threadContextAccountIdOverride = null)
     }
 
     // ---------- resolveForDelete() ----------
 
     @Test fun `resolveForDelete uses plugin settings when no override`() {
-        val r = SchedulerRoutingResolver.resolveForDelete(acct, roleName, threadContextAccountIdOverride = null)!!
+        val r = SchedulerRoutingResolver.resolveForDelete(acct, roleName, threadContextAccountIdOverride = null)
         assertEquals(acct, r.accountId)
         assertEquals("arn:aws:iam::$acct:role/$roleName", r.roleArn)
     }
 
     @Test fun `resolveForDelete applies ThreadContext override and constructs ARN with override`() {
-        val r = SchedulerRoutingResolver.resolveForDelete(acct, roleName, threadContextAccountIdOverride = override)!!
+        val r = SchedulerRoutingResolver.resolveForDelete(acct, roleName, threadContextAccountIdOverride = override)
         assertEquals(override, r.accountId)
         assertEquals("arn:aws:iam::$override:role/$roleName", r.roleArn)
     }
 
-    @Test fun `resolveForDelete returns null when accountId missing`() {
-        assertNull(SchedulerRoutingResolver.resolveForDelete("", roleName, threadContextAccountIdOverride = null))
+    @Test(expected = IllegalStateException::class)
+    fun `resolveForDelete throws when accountId missing`() {
+        SchedulerRoutingResolver.resolveForDelete("", roleName, threadContextAccountIdOverride = null)
     }
 
-    @Test fun `resolveForDelete returns null when roleName missing`() {
-        assertNull(SchedulerRoutingResolver.resolveForDelete(acct, "", threadContextAccountIdOverride = null))
+    @Test(expected = IllegalStateException::class)
+    fun `resolveForDelete throws when roleName missing`() {
+        SchedulerRoutingResolver.resolveForDelete(acct, "", threadContextAccountIdOverride = null)
     }
 
     @Test fun `resolveForDelete does not require queueName`() {
         val r = SchedulerRoutingResolver.resolveForDelete(acct, roleName, threadContextAccountIdOverride = null)
-        assertEquals(acct, r?.accountId)
+        assertEquals(acct, r.accountId)
     }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorActionTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorActionTests.kt
@@ -64,7 +64,7 @@ class TransportDeleteMonitorActionTests : OpenSearchTestCase() {
         settingSet.add(AlertingSettings.FILTER_BY_BACKEND_ROLES)
         settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ENABLED)
         settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ACCOUNT_ID)
-        settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ROLE_ARN)
+        settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ROLE_NAME)
         val clusterSettings = ClusterSettings(Settings.EMPTY, settingSet)
         whenever(clusterService.clusterSettings).thenReturn(clusterSettings)
     }
@@ -123,7 +123,7 @@ class TransportDeleteMonitorActionTests : OpenSearchTestCase() {
         val settings = Settings.builder()
             .put("plugins.alerting.external_scheduler.enabled", true)
             .put("plugins.alerting.external_scheduler.account_id", "111111111111")
-            .put("plugins.alerting.external_scheduler.role_arn", "arn:aws:iam::111:role/eb")
+            .put("plugins.alerting.external_scheduler.role_name", "eb")
             .build()
 
         val settingSet = hashSetOf<Setting<*>>()
@@ -131,7 +131,7 @@ class TransportDeleteMonitorActionTests : OpenSearchTestCase() {
         settingSet.add(AlertingSettings.FILTER_BY_BACKEND_ROLES)
         settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ENABLED)
         settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ACCOUNT_ID)
-        settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ROLE_ARN)
+        settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ROLE_NAME)
         val cs = ClusterSettings(settings, settingSet)
         whenever(clusterService.clusterSettings).thenReturn(cs)
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorActionTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorActionTests.kt
@@ -160,16 +160,17 @@ class TransportDeleteMonitorActionTests : OpenSearchTestCase() {
         assertEquals("999999999999", value)
     }
 
-    fun `test EB cell account ID read from monitor metadata`() {
-        val metadata = mapOf(ExternalSchedulerService.EB_CELL_ACCOUNT_ID_METADATA_KEY to "444455556666")
-        val accountId = metadata[ExternalSchedulerService.EB_CELL_ACCOUNT_ID_METADATA_KEY]
-        assertEquals("444455556666", accountId)
+    fun `test schedule ARN read from monitor metadata`() {
+        val arn = "arn:aws:scheduler:us-west-2:444455556666:schedule/default/monitor-abc123"
+        val metadata = mapOf(ExternalSchedulerService.SCHEDULE_ARN_METADATA_KEY to arn)
+        val value = metadata[ExternalSchedulerService.SCHEDULE_ARN_METADATA_KEY]
+        assertEquals(arn, value)
     }
 
-    fun `test EB cell account ID null when metadata absent`() {
+    fun `test schedule ARN null when metadata absent`() {
         val metadata: Map<String, String>? = null
-        val accountId = metadata?.get(ExternalSchedulerService.EB_CELL_ACCOUNT_ID_METADATA_KEY)
-        assertNull(accountId)
+        val value = metadata?.get(ExternalSchedulerService.SCHEDULE_ARN_METADATA_KEY)
+        assertNull(value)
     }
 
     fun `test tenantId preserved across stashContext and scope launch`() {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorActionTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorActionTests.kt
@@ -160,6 +160,18 @@ class TransportDeleteMonitorActionTests : OpenSearchTestCase() {
         assertEquals("999999999999", value)
     }
 
+    fun `test EB cell account ID read from monitor metadata`() {
+        val metadata = mapOf(ExternalSchedulerService.EB_CELL_ACCOUNT_ID_METADATA_KEY to "444455556666")
+        val accountId = metadata[ExternalSchedulerService.EB_CELL_ACCOUNT_ID_METADATA_KEY]
+        assertEquals("444455556666", accountId)
+    }
+
+    fun `test EB cell account ID null when metadata absent`() {
+        val metadata: Map<String, String>? = null
+        val accountId = metadata?.get(ExternalSchedulerService.EB_CELL_ACCOUNT_ID_METADATA_KEY)
+        assertNull(accountId)
+    }
+
     fun `test tenantId preserved across stashContext and scope launch`() {
         val expectedTenantId = "test-tenant:test-scope"
         threadContext.putHeader(TENANT_ID_HEADER, expectedTenantId)

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorActionTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorActionTests.kt
@@ -176,4 +176,18 @@ class TransportIndexMonitorActionTests : OpenSearchTestCase() {
         val action = createAction(settings)
         assertNotNull(action)
     }
+
+    fun `test schedule ARN stored in monitor metadata map`() {
+        val arn = "arn:aws:scheduler:us-west-2:111222333444:schedule/default/monitor-test123"
+        val metadata = mapOf(ExternalSchedulerService.SCHEDULE_ARN_METADATA_KEY to arn)
+        assertEquals(arn, metadata[ExternalSchedulerService.SCHEDULE_ARN_METADATA_KEY])
+    }
+
+    fun `test schedule ARN parsed for account ID on update`() {
+        val arn = "arn:aws:scheduler:us-west-2:555666777888:schedule/default/monitor-m1"
+        val info = ExternalSchedulerService.parseScheduleArn(arn)
+        assertEquals("555666777888", info.accountId)
+        assertEquals("us-west-2", info.region)
+        assertEquals("monitor-m1", info.name)
+    }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorActionTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorActionTests.kt
@@ -66,7 +66,8 @@ class TransportIndexMonitorActionTests : OpenSearchTestCase() {
         settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ENABLED)
         settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ACCOUNT_ID)
         settingSet.add(AlertingSettings.JOB_QUEUE_NAME)
-        settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ROLE_ARN)
+        settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ROLE_NAME)
+        settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_EXECUTION_ROLE_NAME)
         return ClusterSettings(settings, settingSet)
     }
 
@@ -101,7 +102,7 @@ class TransportIndexMonitorActionTests : OpenSearchTestCase() {
             .put("plugins.alerting.external_scheduler.enabled", true)
             .put("plugins.alerting.external_scheduler.account_id", "111111111111")
             .put("plugins.alerting.external_scheduler.queue_arn", "arn:aws:sqs:us-east-1:111:queue")
-            .put("plugins.alerting.external_scheduler.role_arn", "arn:aws:iam::111:role/eb")
+            .put("plugins.alerting.external_scheduler.role_name", "eb")
             .build()
 
         val action = createAction(settings)
@@ -127,7 +128,7 @@ class TransportIndexMonitorActionTests : OpenSearchTestCase() {
         assertTrue(AlertingSettings.EXTERNAL_SCHEDULER_ENABLED.isDynamic)
         assertTrue(AlertingSettings.EXTERNAL_SCHEDULER_ACCOUNT_ID.isDynamic)
         assertTrue(AlertingSettings.JOB_QUEUE_NAME.isDynamic)
-        assertTrue(AlertingSettings.EXTERNAL_SCHEDULER_ROLE_ARN.isDynamic)
+        assertTrue(AlertingSettings.EXTERNAL_SCHEDULER_ROLE_NAME.isDynamic)
     }
 
     fun `test scheduler enabled defaults to false`() {
@@ -138,7 +139,7 @@ class TransportIndexMonitorActionTests : OpenSearchTestCase() {
     fun `test scheduler string settings default to empty`() {
         assertEquals("", AlertingSettings.EXTERNAL_SCHEDULER_ACCOUNT_ID.get(Settings.EMPTY))
         assertEquals("", AlertingSettings.JOB_QUEUE_NAME.get(Settings.EMPTY))
-        assertEquals("", AlertingSettings.EXTERNAL_SCHEDULER_ROLE_ARN.get(Settings.EMPTY))
+        assertEquals("", AlertingSettings.EXTERNAL_SCHEDULER_ROLE_NAME.get(Settings.EMPTY))
     }
 
     fun `test multi-tenancy enabled skips scheduled job index init`() {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorActionTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorActionTests.kt
@@ -124,6 +124,22 @@ class TransportIndexMonitorActionTests : OpenSearchTestCase() {
         assertEquals("999999999999", value)
     }
 
+    fun `test scheduler account id is lost after stashContext`() {
+        threadContext.putTransient(ExternalSchedulerService.SCHEDULER_ACCOUNT_ID_KEY, "999999999999")
+        threadContext.stashContext().use {
+            val value = threadContext.getTransient<String>(ExternalSchedulerService.SCHEDULER_ACCOUNT_ID_KEY)
+            assertNull("Transient should be null inside stashed context", value)
+        }
+    }
+
+    fun `test scheduler account id preserved when read before stash`() {
+        threadContext.putTransient(ExternalSchedulerService.SCHEDULER_ACCOUNT_ID_KEY, "999999999999")
+        val preserved = threadContext.getTransient<String>(ExternalSchedulerService.SCHEDULER_ACCOUNT_ID_KEY)
+        threadContext.stashContext().use {
+            assertEquals("999999999999", preserved)
+        }
+    }
+
     fun `test scheduler settings are registered as dynamic`() {
         assertTrue(AlertingSettings.EXTERNAL_SCHEDULER_ENABLED.isDynamic)
         assertTrue(AlertingSettings.EXTERNAL_SCHEDULER_ACCOUNT_ID.isDynamic)

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportMultiTenancyBlockTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportMultiTenancyBlockTests.kt
@@ -125,7 +125,8 @@ class TransportMultiTenancyBlockTests : OpenSearchTestCase() {
         settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ENABLED)
         settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ACCOUNT_ID)
         settingSet.add(AlertingSettings.JOB_QUEUE_NAME)
-        settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ROLE_ARN)
+        settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ROLE_NAME)
+        settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_EXECUTION_ROLE_NAME)
         val clusterSettings = ClusterSettings(multiTenancySettings, settingSet)
         whenever(clusterService.clusterSettings).thenReturn(clusterSettings)
 


### PR DESCRIPTION
### Description
Since the account ID for scheduling is resolved at runtime, the roles used must also be constructed at runtime. This PR changes the settings to take role names rather than ARNs

Also fixes a few gaps/bugs:
* Initialize the AssumeRoleCredsCache
* Add schedule ARN to monitor metadata
* Use existing schedule for update/delete monitor

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
