### PR TITLE
fix: Gate system index lifecycle operations when multi-tenancy is enabled

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunnerExecutionContext.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunnerExecutionContext.kt
@@ -72,4 +72,5 @@ data class MonitorRunnerExecutionContext(
     @Volatile var totalNodesFanOut: Int = AlertingSettings.DEFAULT_FAN_OUT_NODES,
     @Volatile var lockService: LockService? = null,
     @Volatile var multiTenantTriggerEvalEnabled: Boolean = false,
+    var multiTenancyEnabled: Boolean = false,
 )

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunnerService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunnerService.kt
@@ -264,6 +264,8 @@ object MonitorRunnerService : JobRunner, CoroutineScope, AbstractLifecycleCompon
             monitorCtx.multiTenantTriggerEvalEnabled = it
         }
 
+        monitorCtx.multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(monitorCtx.settings)
+
         return this
     }
 
@@ -299,6 +301,7 @@ object MonitorRunnerService : JobRunner, CoroutineScope, AbstractLifecycleCompon
     override fun doClose() {}
 
     override fun postIndex(job: ScheduledJob) {
+        if (monitorCtx.multiTenancyEnabled) return
         if (job is Monitor) {
             launch {
                 try {
@@ -327,6 +330,7 @@ object MonitorRunnerService : JobRunner, CoroutineScope, AbstractLifecycleCompon
     }
 
     override fun postDelete(jobId: String) {
+        if (monitorCtx.multiTenancyEnabled) return
         launch {
             try {
                 monitorCtx.moveAlertsRetryPolicy!!.retry(logger) {
@@ -438,7 +442,9 @@ object MonitorRunnerService : JobRunner, CoroutineScope, AbstractLifecycleCompon
     ): MonitorRunResult<*> {
         // Updating the scheduled job index at the start of monitor execution runs for when there is an upgrade the the schema mapping
         // has not been updated.
-        if (!IndexUtils.scheduledJobIndexUpdated && monitorCtx.clusterService != null && monitorCtx.client != null) {
+        if (!monitorCtx.multiTenancyEnabled && !IndexUtils.scheduledJobIndexUpdated &&
+            monitorCtx.clusterService != null && monitorCtx.client != null
+        ) {
             IndexUtils.updateIndexMapping(
                 ScheduledJob.SCHEDULED_JOBS_INDEX,
                 ScheduledJobIndices.scheduledJobMappings(), monitorCtx.clusterService!!.state(), monitorCtx.client!!.admin().indices(),

--- a/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
@@ -83,7 +83,8 @@ class AlertIndices(
     settings: Settings,
     private val client: Client,
     private val threadPool: ThreadPool,
-    private val clusterService: ClusterService
+    private val clusterService: ClusterService,
+    private val multiTenancyEnabled: Boolean = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
 ) : ClusterStateListener {
 
     init {
@@ -254,10 +255,12 @@ class AlertIndices(
     }
 
     fun isAlertInitialized(): Boolean {
+        if (multiTenancyEnabled) return true
         return alertIndexInitialized && alertHistoryIndexInitialized
     }
 
     fun isAlertInitialized(dataSources: DataSources): Boolean {
+        if (multiTenancyEnabled) return true
         val alertsIndex = dataSources.alertsIndex
         val alertsHistoryIndex = dataSources.alertsHistoryIndex
         if (alertsIndex == ALERT_INDEX && alertsHistoryIndex == ALERT_HISTORY_WRITE_INDEX) {
@@ -279,6 +282,7 @@ class AlertIndices(
     fun isFindingHistoryEnabled(): Boolean = findingHistoryEnabled
 
     suspend fun createOrUpdateAlertIndex() {
+        if (multiTenancyEnabled) return
         if (!alertIndexInitialized) {
             alertIndexInitialized = createIndex(ALERT_INDEX, alertMapping())
             if (alertIndexInitialized) IndexUtils.alertIndexUpdated()
@@ -288,6 +292,7 @@ class AlertIndices(
         alertIndexInitialized
     }
     suspend fun createOrUpdateAlertIndex(dataSources: DataSources) {
+        if (multiTenancyEnabled) return
         if (dataSources.alertsIndex == ALERT_INDEX) {
             return createOrUpdateAlertIndex()
         }
@@ -300,6 +305,7 @@ class AlertIndices(
     }
 
     suspend fun createOrUpdateInitialAlertHistoryIndex(dataSources: DataSources) {
+        if (multiTenancyEnabled) return
         if (dataSources.alertsIndex == ALERT_INDEX) {
             return createOrUpdateInitialAlertHistoryIndex()
         }
@@ -318,6 +324,7 @@ class AlertIndices(
         }
     }
     suspend fun createOrUpdateInitialAlertHistoryIndex() {
+        if (multiTenancyEnabled) return
         if (!alertHistoryIndexInitialized) {
             alertHistoryIndexInitialized = createIndex(ALERT_HISTORY_INDEX_PATTERN, alertMapping(), ALERT_HISTORY_WRITE_INDEX)
             if (alertHistoryIndexInitialized)
@@ -332,6 +339,7 @@ class AlertIndices(
     }
 
     suspend fun createOrUpdateInitialFindingHistoryIndex() {
+        if (multiTenancyEnabled) return
         if (!findingHistoryIndexInitialized) {
             findingHistoryIndexInitialized = createIndex(FINDING_HISTORY_INDEX_PATTERN, findingMapping(), FINDING_HISTORY_WRITE_INDEX)
             if (findingHistoryIndexInitialized) {
@@ -347,6 +355,7 @@ class AlertIndices(
     }
 
     suspend fun createOrUpdateInitialFindingHistoryIndex(dataSources: DataSources) {
+        if (multiTenancyEnabled) return
         if (dataSources.findingsIndex == FINDING_HISTORY_WRITE_INDEX) {
             return createOrUpdateInitialFindingHistoryIndex()
         }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/alerts/AlertIndicesMultiTenancyTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/alerts/AlertIndicesMultiTenancyTests.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.alerts
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.mockito.Mockito
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.opensearch.Version
+import org.opensearch.alerting.settings.AlertingSettings
+import org.opensearch.cluster.node.DiscoveryNode
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.ClusterSettings
+import org.opensearch.common.settings.Setting
+import org.opensearch.common.settings.Settings
+import org.opensearch.commons.alerting.model.DataSources
+import org.opensearch.test.ClusterServiceUtils
+import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.threadpool.ThreadPool
+import org.opensearch.transport.client.Client
+
+class AlertIndicesMultiTenancyTests : OpenSearchTestCase() {
+
+    private lateinit var client: Client
+    private lateinit var threadPool: ThreadPool
+    private lateinit var clusterService: ClusterService
+
+    private val multiTenancySettings: Settings = Settings.builder()
+        .put("plugins.alerting.multi_tenancy_enabled", true)
+        .build()
+
+    private val defaultSettings: Settings = Settings.builder().build()
+
+    private fun buildClusterService(settings: Settings): ClusterService {
+        val settingSet = hashSetOf<Setting<*>>()
+        settingSet.addAll(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        settingSet.add(AlertingSettings.ALERT_HISTORY_ENABLED)
+        settingSet.add(AlertingSettings.ALERT_HISTORY_MAX_DOCS)
+        settingSet.add(AlertingSettings.ALERT_HISTORY_INDEX_MAX_AGE)
+        settingSet.add(AlertingSettings.ALERT_HISTORY_ROLLOVER_PERIOD)
+        settingSet.add(AlertingSettings.ALERT_HISTORY_RETENTION_PERIOD)
+        settingSet.add(AlertingSettings.REQUEST_TIMEOUT)
+        settingSet.add(AlertingSettings.FINDING_HISTORY_ENABLED)
+        settingSet.add(AlertingSettings.FINDING_HISTORY_MAX_DOCS)
+        settingSet.add(AlertingSettings.FINDING_HISTORY_INDEX_MAX_AGE)
+        settingSet.add(AlertingSettings.FINDING_HISTORY_ROLLOVER_PERIOD)
+        settingSet.add(AlertingSettings.FINDING_HISTORY_RETENTION_PERIOD)
+        settingSet.add(AlertingSettings.MULTI_TENANCY_ENABLED)
+        val discoveryNode = DiscoveryNode("node", buildNewFakeTransportAddress(), Version.CURRENT)
+        val clusterSettings = ClusterSettings(settings, settingSet)
+        return Mockito.spy(ClusterServiceUtils.createClusterService(threadPool, discoveryNode, clusterSettings))
+    }
+
+    @Before
+    fun setup() {
+        client = Mockito.mock(Client::class.java)
+        threadPool = Mockito.mock(ThreadPool::class.java)
+    }
+
+    fun `test createOrUpdateAlertIndex does not call client when multiTenancyEnabled`() {
+        clusterService = buildClusterService(multiTenancySettings)
+        val alertIndices = AlertIndices(multiTenancySettings, client, threadPool, clusterService)
+
+        runBlocking {
+            alertIndices.createOrUpdateAlertIndex()
+        }
+
+        verify(client, never()).admin()
+    }
+
+    fun `test createOrUpdateAlertIndex with dataSources does not call client when multiTenancyEnabled`() {
+        clusterService = buildClusterService(multiTenancySettings)
+        val alertIndices = AlertIndices(multiTenancySettings, client, threadPool, clusterService)
+
+        runBlocking {
+            alertIndices.createOrUpdateAlertIndex(DataSources())
+        }
+
+        verify(client, never()).admin()
+    }
+
+    fun `test createOrUpdateInitialAlertHistoryIndex does not call client when multiTenancyEnabled`() {
+        clusterService = buildClusterService(multiTenancySettings)
+        val alertIndices = AlertIndices(multiTenancySettings, client, threadPool, clusterService)
+
+        runBlocking {
+            alertIndices.createOrUpdateInitialAlertHistoryIndex()
+        }
+
+        verify(client, never()).admin()
+    }
+
+    fun `test createOrUpdateInitialAlertHistoryIndex with dataSources does not call client when multiTenancyEnabled`() {
+        clusterService = buildClusterService(multiTenancySettings)
+        val alertIndices = AlertIndices(multiTenancySettings, client, threadPool, clusterService)
+
+        runBlocking {
+            alertIndices.createOrUpdateInitialAlertHistoryIndex(DataSources())
+        }
+
+        verify(client, never()).admin()
+    }
+
+    fun `test createOrUpdateInitialFindingHistoryIndex does not call client when multiTenancyEnabled`() {
+        clusterService = buildClusterService(multiTenancySettings)
+        val alertIndices = AlertIndices(multiTenancySettings, client, threadPool, clusterService)
+
+        runBlocking {
+            alertIndices.createOrUpdateInitialFindingHistoryIndex()
+        }
+
+        verify(client, never()).admin()
+    }
+
+    fun `test createOrUpdateInitialFindingHistoryIndex with dataSources does not call client when multiTenancyEnabled`() {
+        clusterService = buildClusterService(multiTenancySettings)
+        val alertIndices = AlertIndices(multiTenancySettings, client, threadPool, clusterService)
+
+        runBlocking {
+            alertIndices.createOrUpdateInitialFindingHistoryIndex(DataSources())
+        }
+
+        verify(client, never()).admin()
+    }
+
+    fun `test isAlertInitialized returns true when multiTenancyEnabled`() {
+        clusterService = buildClusterService(multiTenancySettings)
+        val alertIndices = AlertIndices(multiTenancySettings, client, threadPool, clusterService)
+
+        assertTrue(alertIndices.isAlertInitialized())
+    }
+
+    fun `test isAlertInitialized with dataSources returns true when multiTenancyEnabled`() {
+        clusterService = buildClusterService(multiTenancySettings)
+        val alertIndices = AlertIndices(multiTenancySettings, client, threadPool, clusterService)
+
+        assertTrue(alertIndices.isAlertInitialized(DataSources()))
+    }
+
+    fun `test isAlertInitialized returns false when multiTenancyDisabled and indices not initialized`() {
+        clusterService = buildClusterService(defaultSettings)
+        val alertIndices = AlertIndices(defaultSettings, client, threadPool, clusterService)
+
+        assertFalse(alertIndices.isAlertInitialized())
+    }
+}


### PR DESCRIPTION
Skip createOrUpdateAlertIndex, createOrUpdateInitialAlertHistoryIndex, createOrUpdateInitialFindingHistoryIndex, moveAlerts, and scheduledJobs index mapping updates when multi-tenancy is enabled. These operations attempt to create/check OpenSearch system indices that don't exist in the DDB storage route.

