### PR TITLE
Move to remote metadata SDK for delete monitor activities

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -371,7 +371,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             settings
         )
 
-        DeleteMonitorService.initialize(client, lockService)
+        DeleteMonitorService.initialize(client, lockService, sdkClient)
 
         val providerType = AlertingSettings.JOB_QUEUE_ACCOUNT_PROVIDER_TYPE.get(settings)
         val monitorJobPoller = MonitorJobPoller(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/DeleteMonitorService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/DeleteMonitorService.kt
@@ -14,8 +14,6 @@ import org.apache.lucene.search.join.ScoreMode
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest
 import org.opensearch.action.admin.indices.exists.indices.IndicesExistsRequest
 import org.opensearch.action.admin.indices.exists.indices.IndicesExistsResponse
-import org.opensearch.action.delete.DeleteRequest
-import org.opensearch.action.delete.DeleteResponse
 import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.IndicesOptions
@@ -27,16 +25,21 @@ import org.opensearch.alerting.core.lock.LockService
 import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.util.ScheduledJobUtils.Companion.WORKFLOW_DELEGATE_PATH
 import org.opensearch.alerting.util.ScheduledJobUtils.Companion.WORKFLOW_MONITOR_PATH
+import org.opensearch.alerting.util.await
 import org.opensearch.alerting.util.use
 import org.opensearch.commons.alerting.action.DeleteMonitorResponse
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.util.AlertingException
+import org.opensearch.commons.utils.currentTenantId
 import org.opensearch.core.action.ActionListener
 import org.opensearch.index.query.QueryBuilders
 import org.opensearch.index.reindex.BulkByScrollResponse
 import org.opensearch.index.reindex.DeleteByQueryAction
 import org.opensearch.index.reindex.DeleteByQueryRequestBuilder
+import org.opensearch.remote.metadata.client.DeleteDataObjectRequest
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.transport.client.Client
 import kotlin.coroutines.resume
@@ -52,13 +55,16 @@ object DeleteMonitorService :
 
     private lateinit var client: Client
     private lateinit var lockService: LockService
+    private lateinit var sdkClient: SdkClient
 
     fun initialize(
         client: Client,
-        lockService: LockService
+        lockService: LockService,
+        sdkClient: SdkClient
     ) {
         DeleteMonitorService.client = client
         DeleteMonitorService.lockService = lockService
+        DeleteMonitorService.sdkClient = sdkClient
     }
 
     /**
@@ -67,29 +73,40 @@ object DeleteMonitorService :
      * @param refreshPolicy
      */
     suspend fun deleteMonitor(monitor: Monitor, refreshPolicy: RefreshPolicy): DeleteMonitorResponse {
-        val deleteResponse = deleteMonitor(monitor.id, refreshPolicy)
+        val deleteResponse = deleteMonitorDoc(monitor.id, refreshPolicy)
         deleteDocLevelMonitorQueriesAndIndices(monitor)
         deleteMetadata(monitor)
         deleteLock(monitor)
-        return DeleteMonitorResponse(deleteResponse.id, deleteResponse.version)
+        return deleteResponse
     }
 
-    private suspend fun deleteMonitor(monitorId: String, refreshPolicy: RefreshPolicy): DeleteResponse {
-        val deleteMonitorRequest = DeleteRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, monitorId)
-            .setRefreshPolicy(refreshPolicy)
-        return client.suspendUntil { delete(deleteMonitorRequest, it) }
+    private suspend fun deleteMonitorDoc(monitorId: String, refreshPolicy: RefreshPolicy): DeleteMonitorResponse {
+        val tenantId = currentTenantId()
+        val deleteRequest = DeleteDataObjectRequest.builder()
+            .index(ScheduledJob.SCHEDULED_JOBS_INDEX)
+            .id(monitorId)
+            .tenantId(tenantId)
+            .refreshPolicy(refreshPolicy)
+            .build()
+        val deleteResponse = sdkClient.deleteDataObjectAsync(deleteRequest).await()
+        return DeleteMonitorResponse(deleteResponse.id(), deleteResponse.deleteResponse().version)
     }
 
     private suspend fun deleteMetadata(monitor: Monitor) {
-        val deleteRequest = DeleteRequest(ScheduledJob.SCHEDULED_JOBS_INDEX, "${monitor.id}-metadata")
-            .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+        val tenantId = currentTenantId()
+        val deleteRequest = DeleteDataObjectRequest.builder()
+            .index(ScheduledJob.SCHEDULED_JOBS_INDEX)
+            .id("${monitor.id}-metadata")
+            .tenantId(tenantId)
+            .refreshPolicy(RefreshPolicy.IMMEDIATE)
+            .build()
         try {
-            val deleteResponse: DeleteResponse = client.suspendUntil { delete(deleteRequest, it) }
-            log.debug("Monitor metadata: ${deleteResponse.id} deletion result: ${deleteResponse.result}")
+            val deleteResponse = sdkClient.deleteDataObjectAsync(deleteRequest).await()
+            log.debug("Monitor metadata: ${deleteResponse.id()} deletion result: ${deleteResponse.status()}")
         } catch (e: Exception) {
             // we only log the error and don't fail the request because if monitor document has been deleted,
             // we cannot retry based on this failure
-            log.error("Failed to delete monitor metadata ${deleteRequest.id()}.", e)
+            log.error("Failed to delete monitor metadata ${monitor.id}-metadata.", e)
         }
     }
 
@@ -187,12 +204,18 @@ object DeleteMonitorService :
             ScoreMode.None
         )
         try {
-            val searchRequest = SearchRequest()
+            val tenantId = currentTenantId()
+            val searchRequest = SearchDataObjectRequest.builder()
                 .indices(ScheduledJob.SCHEDULED_JOBS_INDEX)
-                .source(SearchSourceBuilder().query(queryBuilder))
+                .tenantId(tenantId)
+                .searchSourceBuilder(SearchSourceBuilder().query(queryBuilder))
+                .build()
 
             client.threadPool().threadContext.stashContext().use {
-                val searchResponse: SearchResponse = client.suspendUntil { search(searchRequest, it) }
+                val sdkResponse = sdkClient.searchDataObjectAsync(searchRequest).await()
+                val searchResponse = sdkResponse.searchResponse()
+                    ?: throw RuntimeException("Unknown error searching for workflow delegates")
+
                 if (searchResponse.hits.totalHits?.value == 0L) {
                     return false
                 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
@@ -128,9 +128,15 @@ class TransportDeleteMonitorAction @Inject constructor(
                         deleteExternalSchedule(monitor)
                     }
 
-                    actionListener.onResponse(
-                        DeleteMonitorService.deleteMonitor(monitor, refreshPolicy)
-                    )
+                    val response = DeleteMonitorService.deleteMonitor(monitor, refreshPolicy)
+                    val schedulerAccountId = monitor.metadata
+                        ?.get(ExternalSchedulerService.SCHEDULE_ARN_METADATA_KEY)
+                        ?.let { ExternalSchedulerService.parseScheduleArn(it).accountId }
+                    if (schedulerAccountId != null) {
+                        client.threadPool().threadContext
+                            .putTransient(ExternalSchedulerService.SCHEDULER_ACCOUNT_ID_KEY, schedulerAccountId)
+                    }
+                    actionListener.onResponse(response)
                 } else {
                     actionListener.onFailure(
                         AlertingException("Not allowed to delete this monitor!", RestStatus.FORBIDDEN, IllegalStateException())

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorAction.kt
@@ -61,6 +61,7 @@ class TransportDeleteMonitorAction @Inject constructor(
     SecureTransportAction {
 
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile private var multiTenancyEnabled = AlertingSettings.MULTI_TENANCY_ENABLED.get(settings)
     @Volatile private var externalSchedulerEnabled = AlertingSettings.EXTERNAL_SCHEDULER_ENABLED.get(settings)
     @Volatile private var externalSchedulerAccountId = AlertingSettings.EXTERNAL_SCHEDULER_ACCOUNT_ID.get(settings)
     @Volatile private var externalSchedulerRoleName = AlertingSettings.EXTERNAL_SCHEDULER_ROLE_NAME.get(settings)
@@ -110,7 +111,7 @@ class TransportDeleteMonitorAction @Inject constructor(
                 val canDelete = user == null || !doFilterForUser(user) ||
                     checkUserPermissionsWithResource(user, monitor.user, actionListener, "monitor", monitorId)
 
-                if (DeleteMonitorService.monitorIsWorkflowDelegate(monitor.id)) {
+                if (!multiTenancyEnabled && DeleteMonitorService.monitorIsWorkflowDelegate(monitor.id)) {
                     actionListener.onFailure(
                         AlertingException(
                             "Monitor can't be deleted because it is a part of workflow(s)",

--- a/alerting/src/test/kotlin/org/opensearch/alerting/service/DeleteMonitorServiceTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/service/DeleteMonitorServiceTests.kt
@@ -1,0 +1,271 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.service
+
+import com.carrotsearch.randomizedtesting.ThreadFilter
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters
+import org.junit.Before
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.opensearch.action.delete.DeleteResponse
+import org.opensearch.action.search.SearchResponse
+import org.opensearch.action.support.WriteRequest.RefreshPolicy
+import org.opensearch.alerting.core.lock.LockService
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.util.concurrent.ThreadContext
+import org.opensearch.remote.metadata.client.DeleteDataObjectRequest
+import org.opensearch.remote.metadata.client.DeleteDataObjectResponse
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest
+import org.opensearch.remote.metadata.client.SearchDataObjectResponse
+import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.threadpool.ThreadPool
+import org.opensearch.transport.client.Client
+import org.mockito.Mockito.`when` as whenever
+
+@ThreadLeakFilters(filters = [DeleteMonitorServiceTests.CoroutineThreadFilter::class])
+class DeleteMonitorServiceTests : OpenSearchTestCase() {
+
+    class CoroutineThreadFilter : ThreadFilter {
+        override fun reject(t: Thread): Boolean = t.name.startsWith("DefaultDispatcher-worker")
+    }
+
+    private lateinit var client: Client
+    private lateinit var sdkClient: SdkClient
+    private lateinit var lockService: LockService
+    private lateinit var threadPool: ThreadPool
+    private lateinit var threadContext: ThreadContext
+
+    @Before
+    fun setup() {
+        client = Mockito.mock(Client::class.java)
+        sdkClient = Mockito.mock(SdkClient::class.java)
+        lockService = Mockito.mock(LockService::class.java)
+        threadPool = Mockito.mock(ThreadPool::class.java)
+        threadContext = ThreadContext(Settings.EMPTY)
+
+        whenever(client.threadPool()).thenReturn(threadPool)
+        whenever(threadPool.threadContext).thenReturn(threadContext)
+
+        DeleteMonitorService.initialize(client, lockService, sdkClient)
+    }
+
+    fun `test monitorIsWorkflowDelegate uses SDK search`() {
+        val searchResponse = Mockito.mock(SearchResponse::class.java)
+        val hits = Mockito.mock(org.opensearch.search.SearchHits::class.java)
+        whenever(hits.totalHits).thenReturn(org.apache.lucene.search.TotalHits(0L, org.apache.lucene.search.TotalHits.Relation.EQUAL_TO))
+        whenever(searchResponse.hits).thenReturn(hits)
+
+        val sdkResponse = Mockito.mock(SearchDataObjectResponse::class.java)
+        whenever(sdkResponse.searchResponse()).thenReturn(searchResponse)
+        whenever(sdkClient.searchDataObjectAsync(any(SearchDataObjectRequest::class.java)))
+            .thenReturn(java.util.concurrent.CompletableFuture.completedFuture(sdkResponse))
+
+        val result = kotlinx.coroutines.runBlocking {
+            DeleteMonitorService.monitorIsWorkflowDelegate("test-monitor-id")
+        }
+
+        assertFalse(result)
+        verify(sdkClient).searchDataObjectAsync(any(SearchDataObjectRequest::class.java))
+    }
+
+    fun `test monitorIsWorkflowDelegate returns true when workflows found`() {
+        val searchResponse = Mockito.mock(SearchResponse::class.java)
+        val hits = Mockito.mock(org.opensearch.search.SearchHits::class.java)
+        whenever(hits.totalHits).thenReturn(org.apache.lucene.search.TotalHits(1L, org.apache.lucene.search.TotalHits.Relation.EQUAL_TO))
+        val hit = Mockito.mock(org.opensearch.search.SearchHit::class.java)
+        whenever(hit.id).thenReturn("workflow-1")
+        whenever(hits.hits).thenReturn(arrayOf(hit))
+        whenever(searchResponse.hits).thenReturn(hits)
+
+        val sdkResponse = Mockito.mock(SearchDataObjectResponse::class.java)
+        whenever(sdkResponse.searchResponse()).thenReturn(searchResponse)
+        whenever(sdkClient.searchDataObjectAsync(any(SearchDataObjectRequest::class.java)))
+            .thenReturn(java.util.concurrent.CompletableFuture.completedFuture(sdkResponse))
+
+        val result = kotlinx.coroutines.runBlocking {
+            DeleteMonitorService.monitorIsWorkflowDelegate("test-monitor-id")
+        }
+
+        assertTrue(result)
+    }
+
+    fun `test monitorIsWorkflowDelegate stashes thread context`() {
+        // Put a header in the thread context to verify it gets stashed
+        threadContext.putHeader("_opendistro_security_user", "test-user")
+
+        val searchResponse = Mockito.mock(SearchResponse::class.java)
+        val hits = Mockito.mock(org.opensearch.search.SearchHits::class.java)
+        whenever(hits.totalHits).thenReturn(org.apache.lucene.search.TotalHits(0L, org.apache.lucene.search.TotalHits.Relation.EQUAL_TO))
+        whenever(searchResponse.hits).thenReturn(hits)
+
+        val sdkResponse = Mockito.mock(SearchDataObjectResponse::class.java)
+        whenever(sdkResponse.searchResponse()).thenReturn(searchResponse)
+        whenever(sdkClient.searchDataObjectAsync(any(SearchDataObjectRequest::class.java)))
+            .thenReturn(java.util.concurrent.CompletableFuture.completedFuture(sdkResponse))
+
+        kotlinx.coroutines.runBlocking {
+            DeleteMonitorService.monitorIsWorkflowDelegate("test-monitor-id")
+        }
+
+        // Verify stashContext was called (threadPool().threadContext accessed)
+        verify(client).threadPool()
+    }
+
+    fun `test monitorIsWorkflowDelegate search request targets scheduled jobs index`() {
+        val searchResponse = Mockito.mock(SearchResponse::class.java)
+        val hits = Mockito.mock(org.opensearch.search.SearchHits::class.java)
+        whenever(hits.totalHits).thenReturn(org.apache.lucene.search.TotalHits(0L, org.apache.lucene.search.TotalHits.Relation.EQUAL_TO))
+        whenever(searchResponse.hits).thenReturn(hits)
+
+        val sdkResponse = Mockito.mock(SearchDataObjectResponse::class.java)
+        whenever(sdkResponse.searchResponse()).thenReturn(searchResponse)
+        whenever(sdkClient.searchDataObjectAsync(any(SearchDataObjectRequest::class.java)))
+            .thenReturn(java.util.concurrent.CompletableFuture.completedFuture(sdkResponse))
+
+        kotlinx.coroutines.runBlocking {
+            DeleteMonitorService.monitorIsWorkflowDelegate("test-monitor-id")
+        }
+
+        val captor = ArgumentCaptor.forClass(SearchDataObjectRequest::class.java)
+        verify(sdkClient).searchDataObjectAsync(captor.capture())
+        assertTrue(captor.value.indices().contains(".opendistro-alerting-config"))
+    }
+
+    fun `test monitorIsWorkflowDelegate wraps exception in AlertingException`() {
+        whenever(sdkClient.searchDataObjectAsync(any(SearchDataObjectRequest::class.java)))
+            .thenReturn(java.util.concurrent.CompletableFuture.failedFuture(RuntimeException("connection failed")))
+
+        val exception = expectThrows(org.opensearch.commons.alerting.util.AlertingException::class.java) {
+            kotlinx.coroutines.runBlocking {
+                DeleteMonitorService.monitorIsWorkflowDelegate("test-monitor-id")
+            }
+        }
+        assertNotNull(exception)
+    }
+
+    fun `test deleteMonitorDoc uses SDK delete with correct index and id`() {
+        val deleteResponse = Mockito.mock(DeleteResponse::class.java)
+        whenever(deleteResponse.version).thenReturn(1L)
+
+        val sdkDeleteResponse = Mockito.mock(DeleteDataObjectResponse::class.java)
+        whenever(sdkDeleteResponse.id()).thenReturn("test-monitor-id")
+        whenever(sdkDeleteResponse.deleteResponse()).thenReturn(deleteResponse)
+        whenever(sdkClient.deleteDataObjectAsync(any(DeleteDataObjectRequest::class.java)))
+            .thenReturn(java.util.concurrent.CompletableFuture.completedFuture(sdkDeleteResponse))
+
+        // Mock lock service for deleteLock
+        whenever(lockService.deleteLock(any(), any())).thenAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            val listener = invocation.arguments[1] as org.opensearch.core.action.ActionListener<Boolean>
+            listener.onResponse(true)
+        }
+
+        // We need to call the public deleteMonitor method which calls deleteMonitorDoc internally
+        // But deleteMonitor also calls deleteDocLevelMonitorQueriesAndIndices and deleteMetadata
+        // For this test, we'll use reflection to call deleteMonitorDoc directly
+        val method = DeleteMonitorService.javaClass.getDeclaredMethod(
+            "deleteMonitorDoc",
+            String::class.java,
+            RefreshPolicy::class.java
+        )
+        method.isAccessible = true
+
+        val result = kotlinx.coroutines.runBlocking {
+            @Suppress("UNCHECKED_CAST")
+            method.invoke(DeleteMonitorService, "test-monitor-id", RefreshPolicy.IMMEDIATE) as org.opensearch.commons.alerting.action.DeleteMonitorResponse
+        }
+
+        assertEquals("test-monitor-id", result.id)
+
+        val captor = ArgumentCaptor.forClass(DeleteDataObjectRequest::class.java)
+        verify(sdkClient).deleteDataObjectAsync(captor.capture())
+        assertEquals(".opendistro-alerting-config", captor.value.index())
+        assertEquals("test-monitor-id", captor.value.id())
+    }
+
+    fun `test deleteMetadata uses SDK delete with metadata id suffix`() {
+        val deleteResponse = Mockito.mock(DeleteResponse::class.java)
+        whenever(deleteResponse.version).thenReturn(1L)
+
+        val sdkDeleteResponse = Mockito.mock(DeleteDataObjectResponse::class.java)
+        whenever(sdkDeleteResponse.id()).thenReturn("test-monitor-id-metadata")
+        whenever(sdkDeleteResponse.status()).thenReturn(org.opensearch.core.rest.RestStatus.OK)
+        whenever(sdkDeleteResponse.deleteResponse()).thenReturn(deleteResponse)
+        whenever(sdkClient.deleteDataObjectAsync(any(DeleteDataObjectRequest::class.java)))
+            .thenReturn(java.util.concurrent.CompletableFuture.completedFuture(sdkDeleteResponse))
+
+        val monitor = Mockito.mock(org.opensearch.commons.alerting.model.Monitor::class.java)
+        whenever(monitor.id).thenReturn("test-monitor-id")
+
+        val method = DeleteMonitorService.javaClass.getDeclaredMethod(
+            "deleteMetadata",
+            org.opensearch.commons.alerting.model.Monitor::class.java
+        )
+        method.isAccessible = true
+
+        kotlinx.coroutines.runBlocking {
+            method.invoke(DeleteMonitorService, monitor)
+        }
+
+        val captor = ArgumentCaptor.forClass(DeleteDataObjectRequest::class.java)
+        verify(sdkClient).deleteDataObjectAsync(captor.capture())
+        assertEquals("test-monitor-id-metadata", captor.value.id())
+        assertEquals(".opendistro-alerting-config", captor.value.index())
+    }
+
+    fun `test deleteMetadata does not throw on failure`() {
+        whenever(sdkClient.deleteDataObjectAsync(any(DeleteDataObjectRequest::class.java)))
+            .thenReturn(java.util.concurrent.CompletableFuture.failedFuture(RuntimeException("delete failed")))
+
+        val monitor = Mockito.mock(org.opensearch.commons.alerting.model.Monitor::class.java)
+        whenever(monitor.id).thenReturn("test-monitor-id")
+
+        val method = DeleteMonitorService.javaClass.getDeclaredMethod(
+            "deleteMetadata",
+            org.opensearch.commons.alerting.model.Monitor::class.java
+        )
+        method.isAccessible = true
+
+        // Should not throw - errors are logged but swallowed
+        kotlinx.coroutines.runBlocking {
+            method.invoke(DeleteMonitorService, monitor)
+        }
+    }
+
+    fun `test initialize sets sdkClient`() {
+        val newSdkClient = Mockito.mock(SdkClient::class.java)
+        val newClient = Mockito.mock(Client::class.java)
+        val newLockService = Mockito.mock(LockService::class.java)
+
+        DeleteMonitorService.initialize(newClient, newLockService, newSdkClient)
+
+        // Verify by calling a method that uses sdkClient
+        val searchResponse = Mockito.mock(SearchResponse::class.java)
+        val hits = Mockito.mock(org.opensearch.search.SearchHits::class.java)
+        whenever(hits.totalHits).thenReturn(org.apache.lucene.search.TotalHits(0L, org.apache.lucene.search.TotalHits.Relation.EQUAL_TO))
+        whenever(searchResponse.hits).thenReturn(hits)
+
+        val sdkResponse = Mockito.mock(SearchDataObjectResponse::class.java)
+        whenever(sdkResponse.searchResponse()).thenReturn(searchResponse)
+        whenever(newSdkClient.searchDataObjectAsync(any(SearchDataObjectRequest::class.java)))
+            .thenReturn(java.util.concurrent.CompletableFuture.completedFuture(sdkResponse))
+
+        val newThreadPool = Mockito.mock(ThreadPool::class.java)
+        whenever(newClient.threadPool()).thenReturn(newThreadPool)
+        whenever(newThreadPool.threadContext).thenReturn(ThreadContext(Settings.EMPTY))
+
+        kotlinx.coroutines.runBlocking {
+            DeleteMonitorService.monitorIsWorkflowDelegate("test-id")
+        }
+
+        verify(newSdkClient).searchDataObjectAsync(any(SearchDataObjectRequest::class.java))
+        verify(sdkClient, never()).searchDataObjectAsync(any(SearchDataObjectRequest::class.java))
+    }
+}

--- a/alerting/src/test/kotlin/org/opensearch/alerting/service/DeleteMonitorServiceTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/service/DeleteMonitorServiceTests.kt
@@ -179,7 +179,8 @@ class DeleteMonitorServiceTests : OpenSearchTestCase() {
 
         val result = kotlinx.coroutines.runBlocking {
             @Suppress("UNCHECKED_CAST")
-            method.invoke(DeleteMonitorService, "test-monitor-id", RefreshPolicy.IMMEDIATE) as org.opensearch.commons.alerting.action.DeleteMonitorResponse
+            method.invoke(DeleteMonitorService, "test-monitor-id", RefreshPolicy.IMMEDIATE)
+                as org.opensearch.commons.alerting.action.DeleteMonitorResponse
         }
 
         assertEquals("test-monitor-id", result.id)

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorActionTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportDeleteMonitorActionTests.kt
@@ -62,6 +62,7 @@ class TransportDeleteMonitorActionTests : OpenSearchTestCase() {
         val settingSet = hashSetOf<Setting<*>>()
         settingSet.addAll(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
         settingSet.add(AlertingSettings.FILTER_BY_BACKEND_ROLES)
+        settingSet.add(AlertingSettings.MULTI_TENANCY_ENABLED)
         settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ENABLED)
         settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ACCOUNT_ID)
         settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ROLE_NAME)
@@ -215,6 +216,33 @@ class TransportDeleteMonitorActionTests : OpenSearchTestCase() {
         val captor = ArgumentCaptor.forClass(GetDataObjectRequest::class.java)
         verify(sdkClient, timeout(1000)).getDataObject(captor.capture())
         assertNull(captor.value.tenantId())
+    }
+
+    fun `test action constructs with multi tenancy enabled`() {
+        val settings = Settings.builder()
+            .put("plugins.alerting.multi_tenancy_enabled", true)
+            .build()
+
+        val settingSet = hashSetOf<Setting<*>>()
+        settingSet.addAll(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        settingSet.add(AlertingSettings.FILTER_BY_BACKEND_ROLES)
+        settingSet.add(AlertingSettings.MULTI_TENANCY_ENABLED)
+        settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ENABLED)
+        settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ACCOUNT_ID)
+        settingSet.add(AlertingSettings.EXTERNAL_SCHEDULER_ROLE_NAME)
+        val cs = ClusterSettings(settings, settingSet)
+        whenever(clusterService.clusterSettings).thenReturn(cs)
+
+        val action = TransportDeleteMonitorAction(
+            Mockito.mock(TransportService::class.java),
+            client,
+            Mockito.mock(ActionFilters::class.java),
+            clusterService,
+            settings,
+            Mockito.mock(NamedXContentRegistry::class.java),
+            sdkClient
+        )
+        assertNotNull(action)
     }
 
     private fun invokeDoExecute(


### PR DESCRIPTION
### Description
Update the delete monitor flow to be compatible with the remote metadata SDK

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
