### PR TITLE
PPL Alerting: Create, Read, Update, Delete (#2128)

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -103,6 +103,8 @@ import org.opensearch.commons.alerting.model.ClusterMetricsInput
 import org.opensearch.commons.alerting.model.DocLevelMonitorInput
 import org.opensearch.commons.alerting.model.DocumentLevelTrigger
 import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.PPLInput
+import org.opensearch.commons.alerting.model.PPLTrigger
 import org.opensearch.commons.alerting.model.QueryLevelTrigger
 import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.model.ScheduledJob.Companion.SCHEDULED_JOBS_INDEX
@@ -223,6 +225,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
 
     override fun getActions(): List<ActionPlugin.ActionHandler<out ActionRequest, out ActionResponse>> {
         return listOf(
+            // Alerting V1
             ActionPlugin.ActionHandler(ScheduledJobsStatsAction.INSTANCE, ScheduledJobsStatsTransportAction::class.java),
             ActionPlugin.ActionHandler(AlertingActions.INDEX_MONITOR_ACTION_TYPE, TransportIndexMonitorAction::class.java),
             ActionPlugin.ActionHandler(AlertingActions.GET_MONITOR_ACTION_TYPE, TransportGetMonitorAction::class.java),
@@ -258,12 +261,14 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             Monitor.XCONTENT_REGISTRY,
             SearchInput.XCONTENT_REGISTRY,
             DocLevelMonitorInput.XCONTENT_REGISTRY,
+            PPLInput.XCONTENT_REGISTRY,
             QueryLevelTrigger.XCONTENT_REGISTRY,
             BucketLevelTrigger.XCONTENT_REGISTRY,
             ClusterMetricsInput.XCONTENT_REGISTRY,
             DocumentLevelTrigger.XCONTENT_REGISTRY,
             ChainedAlertTrigger.XCONTENT_REGISTRY,
             RemoteMonitorTrigger.XCONTENT_REGISTRY,
+            PPLTrigger.XCONTENT_REGISTRY,
             Workflow.XCONTENT_REGISTRY
         )
     }
@@ -432,7 +437,13 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             AlertingSettings.COMMENTS_MAX_CONTENT_SIZE,
             AlertingSettings.MAX_COMMENTS_PER_ALERT,
             AlertingSettings.MAX_COMMENTS_PER_NOTIFICATION,
-            AlertingSettings.NOTIFICATION_CONTEXT_RESULTS_ALLOWED_ROLES
+            AlertingSettings.NOTIFICATION_CONTEXT_RESULTS_ALLOWED_ROLES,
+            AlertingSettings.PPL_MONITOR_EXECUTION_MAX_DURATION,
+            AlertingSettings.PPL_MAX_QUERY_LENGTH,
+            AlertingSettings.PPL_QUERY_RESULTS_MAX_DATAROWS,
+            AlertingSettings.PPL_QUERY_RESULTS_MAX_SIZE,
+            AlertingSettings.NOTIFICATION_SUBJECT_SOURCE_MAX_LENGTH,
+            AlertingSettings.NOTIFICATION_MESSAGE_SOURCE_MAX_LENGTH,
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
@@ -5,34 +5,19 @@
 
 package org.opensearch.alerting
 
-import org.opensearch.OpenSearchSecurityException
-import org.opensearch.alerting.action.GetDestinationsAction
-import org.opensearch.alerting.action.GetDestinationsRequest
-import org.opensearch.alerting.action.GetDestinationsResponse
-import org.opensearch.alerting.model.destination.Destination
 import org.opensearch.alerting.opensearchapi.InjectorContextElement
-import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.opensearchapi.withClosableContext
 import org.opensearch.alerting.script.QueryLevelTriggerExecutionContext
 import org.opensearch.alerting.script.TriggerExecutionContext
-import org.opensearch.alerting.util.destinationmigration.NotificationActionConfigs
-import org.opensearch.alerting.util.destinationmigration.NotificationApiUtils.Companion.getNotificationConfigInfo
-import org.opensearch.alerting.util.destinationmigration.getTitle
-import org.opensearch.alerting.util.destinationmigration.publishLegacyNotification
-import org.opensearch.alerting.util.destinationmigration.sendNotification
-import org.opensearch.alerting.util.isAllowed
-import org.opensearch.alerting.util.isTestAction
+import org.opensearch.alerting.util.getConfigAndSendNotification
 import org.opensearch.alerting.util.use
 import org.opensearch.commons.alerting.model.ActionRunResult
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.MonitorRunResult
-import org.opensearch.commons.alerting.model.Table
 import org.opensearch.commons.alerting.model.WorkflowRunContext
 import org.opensearch.commons.alerting.model.action.Action
-import org.opensearch.commons.notifications.model.NotificationConfigInfo
 import org.opensearch.core.common.Strings
 import org.opensearch.transport.TransportService
-import org.opensearch.transport.client.node.NodeClient
 import java.time.Instant
 
 abstract class MonitorRunner {
@@ -92,104 +77,5 @@ abstract class MonitorRunner {
         } catch (e: Exception) {
             ActionRunResult(action.id, action.name, mapOf(), false, MonitorRunnerService.currentTime(), e)
         }
-    }
-
-    protected suspend fun getConfigAndSendNotification(
-        action: Action,
-        monitorCtx: MonitorRunnerExecutionContext,
-        subject: String?,
-        message: String
-    ): String {
-        val config = getConfigForNotificationAction(action, monitorCtx)
-        if (config.destination == null && config.channel == null) {
-            throw IllegalStateException("Unable to find a Notification Channel or Destination config with id [${action.destinationId}]")
-        }
-
-        // Adding a check on TEST_ACTION Destination type here to avoid supporting it as a LegacyBaseMessage type
-        // just for Alerting integration tests
-        if (config.destination?.isTestAction() == true) {
-            return "test action"
-        }
-
-        if (config.destination?.isAllowed(monitorCtx.allowList) == false) {
-            throw IllegalStateException(
-                "Monitor contains a Destination type that is not allowed: ${config.destination.type}"
-            )
-        }
-
-        var actionResponseContent = ""
-        actionResponseContent = config.channel
-            ?.sendNotification(
-                monitorCtx.client!!,
-                config.channel.getTitle(subject),
-                message
-            ) ?: actionResponseContent
-
-        actionResponseContent = config.destination
-            ?.buildLegacyBaseMessage(subject, message, monitorCtx.destinationContextFactory!!.getDestinationContext(config.destination))
-            ?.publishLegacyNotification(monitorCtx.client!!)
-            ?: actionResponseContent
-
-        return actionResponseContent
-    }
-
-    /**
-     * The "destination" ID referenced in a Monitor Action could either be a Notification config or a Destination config
-     * depending on whether the background migration process has already migrated it from a Destination to a Notification config.
-     *
-     * To cover both of these cases, the Notification config will take precedence and if it is not found, the Destination will be retrieved.
-     */
-    private suspend fun getConfigForNotificationAction(
-        action: Action,
-        monitorCtx: MonitorRunnerExecutionContext
-    ): NotificationActionConfigs {
-        var destination: Destination? = null
-        var notificationPermissionException: Exception? = null
-
-        var channel: NotificationConfigInfo? = null
-        try {
-            channel = getNotificationConfigInfo(monitorCtx.client as NodeClient, action.destinationId)
-        } catch (e: OpenSearchSecurityException) {
-            notificationPermissionException = e
-        }
-
-        // If the channel was not found, try to retrieve the Destination
-        if (channel == null) {
-            destination = try {
-                val table = Table(
-                    "asc",
-                    "destination.name.keyword",
-                    null,
-                    1,
-                    0,
-                    null
-                )
-                val getDestinationsRequest = GetDestinationsRequest(
-                    action.destinationId,
-                    0L,
-                    null,
-                    table,
-                    "ALL"
-                )
-
-                val getDestinationsResponse: GetDestinationsResponse = monitorCtx.client!!.suspendUntil {
-                    monitorCtx.client!!.execute(GetDestinationsAction.INSTANCE, getDestinationsRequest, it)
-                }
-                getDestinationsResponse.destinations.firstOrNull()
-            } catch (e: IllegalStateException) {
-                // Catching the exception thrown when the Destination was not found so the NotificationActionConfigs object can be returned
-                null
-            } catch (e: OpenSearchSecurityException) {
-                if (notificationPermissionException != null)
-                    throw notificationPermissionException
-                else
-                    throw e
-            }
-
-            if (destination == null && notificationPermissionException != null)
-                throw notificationPermissionException
-        }
-
-        return NotificationActionConfigs(destination, channel)
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/PPLUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/PPLUtils.kt
@@ -11,7 +11,12 @@ import com.fasterxml.jackson.databind.node.ArrayNode
 import org.json.JSONObject
 import org.opensearch.alerting.core.ppl.PPLPluginInterface
 import org.opensearch.alerting.opensearchapi.suspendUntil
+import org.opensearch.commons.utils.recreateObject
+import org.opensearch.core.action.ActionListener
+import org.opensearch.core.action.ActionResponse
+import org.opensearch.sql.plugin.transport.PPLQueryAction
 import org.opensearch.sql.plugin.transport.TransportPPLQueryRequest
+import org.opensearch.sql.plugin.transport.TransportPPLQueryResponse
 import org.opensearch.transport.client.node.NodeClient
 
 object PPLUtils {
@@ -101,7 +106,7 @@ object PPLUtils {
             "/_plugins/_ppl"
         }
 
-        // call PPL plugin to execute query
+        // prepare request to SQL/PPL Plugin
         val transportPplQueryRequest = TransportPPLQueryRequest(
             query,
             JSONObject(mapOf("query" to query)),
@@ -117,6 +122,39 @@ object PPLUtils {
         }
 
         return mapper.readTree(transportPplQueryResponse.result)
+    }
+
+    fun executePplQuery(
+        query: String,
+        explain: Boolean,
+        client: NodeClient,
+        listener: ActionListener<TransportPPLQueryResponse>
+    ) {
+        val path = if (explain) {
+            "/_plugins/_ppl/_explain"
+        } else {
+            "/_plugins/_ppl"
+        }
+
+        // prepare request to SQL/PPL Plugin
+        val request = TransportPPLQueryRequest(
+            query,
+            JSONObject(mapOf("query" to query)),
+            path
+        )
+
+        val wrappedListener = object : ActionListener<ActionResponse> {
+            override fun onResponse(response: ActionResponse) {
+                val recreated = recreateObject(response) { TransportPPLQueryResponse(it) }
+                listener.onResponse(recreated)
+            }
+
+            override fun onFailure(exception: Exception) {
+                listener.onFailure(exception)
+            }
+        } as ActionListener<TransportPPLQueryResponse>
+
+        client.execute(PPLQueryAction.INSTANCE, request, wrappedListener)
     }
 
     fun capAndReformatPPLQueryResults(rawQueryResults: JsonNode, maxSize: Long): List<Map<String, Any?>> {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestGetAlertsAction.kt
@@ -11,7 +11,6 @@ import org.opensearch.commons.alerting.action.AlertingActions
 import org.opensearch.commons.alerting.action.GetAlertsRequest
 import org.opensearch.commons.alerting.model.Table
 import org.opensearch.rest.BaseRestHandler
-import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
 import org.opensearch.rest.RestHandler.ReplacedRoute
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt
@@ -43,7 +43,7 @@ import org.opensearch.rest.action.RestResponseListener
 import org.opensearch.transport.client.node.NodeClient
 import java.io.IOException
 import java.time.Instant
-import java.util.*
+import java.util.Locale
 
 private val log = LogManager.getLogger(RestIndexMonitorAction::class.java)
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportGetAlertsAction.kt
@@ -31,6 +31,8 @@ import org.opensearch.commons.alerting.action.AlertingActions
 import org.opensearch.commons.alerting.action.GetAlertsRequest
 import org.opensearch.commons.alerting.action.GetAlertsResponse
 import org.opensearch.commons.alerting.model.Alert
+import org.opensearch.commons.alerting.model.Alert.Companion.MONITOR_NAME_FIELD
+import org.opensearch.commons.alerting.model.Alert.Companion.TRIGGER_NAME_FIELD
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.util.AlertingException
@@ -135,8 +137,8 @@ class TransportGetAlertsAction @Inject constructor(
                     QueryBuilders
                         .queryStringQuery(tableProp.searchString)
                         .defaultOperator(Operator.AND)
-                        .field("monitor_name")
-                        .field("trigger_name")
+                        .field(MONITOR_NAME_FIELD)
+                        .field(TRIGGER_NAME_FIELD)
                 )
         }
         val searchSourceBuilder = SearchSourceBuilder()

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -30,6 +30,10 @@ import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.action.support.WriteRequest.RefreshPolicy
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 import org.opensearch.alerting.MonitorMetadataService
+import org.opensearch.alerting.PPLUtils.appendCustomCondition
+import org.opensearch.alerting.PPLUtils.appendDataRowsLimit
+import org.opensearch.alerting.PPLUtils.customConditionIsValid
+import org.opensearch.alerting.PPLUtils.executePplQuery
 import org.opensearch.alerting.core.ScheduledJobIndices
 import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.service.DeleteMonitorService
@@ -37,6 +41,10 @@ import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.settings.AlertingSettings.Companion.ALERTING_MAX_MONITORS
 import org.opensearch.alerting.settings.AlertingSettings.Companion.INDEX_TIMEOUT
 import org.opensearch.alerting.settings.AlertingSettings.Companion.MAX_ACTION_THROTTLE_VALUE
+import org.opensearch.alerting.settings.AlertingSettings.Companion.NOTIFICATION_MESSAGE_SOURCE_MAX_LENGTH
+import org.opensearch.alerting.settings.AlertingSettings.Companion.NOTIFICATION_SUBJECT_SOURCE_MAX_LENGTH
+import org.opensearch.alerting.settings.AlertingSettings.Companion.PPL_MAX_QUERY_LENGTH
+import org.opensearch.alerting.settings.AlertingSettings.Companion.PPL_QUERY_RESULTS_MAX_DATAROWS
 import org.opensearch.alerting.settings.AlertingSettings.Companion.REQUEST_TIMEOUT
 import org.opensearch.alerting.settings.DestinationSettings.Companion.ALLOW_LIST
 import org.opensearch.alerting.util.DocLevelMonitorQueries
@@ -59,12 +67,16 @@ import org.opensearch.commons.alerting.action.IndexMonitorResponse
 import org.opensearch.commons.alerting.model.DocLevelMonitorInput
 import org.opensearch.commons.alerting.model.DocLevelMonitorInput.Companion.DOC_LEVEL_INPUT_FIELD
 import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.Monitor.MonitorType
 import org.opensearch.commons.alerting.model.MonitorMetadata
+import org.opensearch.commons.alerting.model.PPLInput
+import org.opensearch.commons.alerting.model.PPLTrigger
 import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.model.ScheduledJob.Companion.SCHEDULED_JOBS_INDEX
 import org.opensearch.commons.alerting.model.SearchInput
 import org.opensearch.commons.alerting.model.remote.monitors.RemoteDocLevelMonitorInput
 import org.opensearch.commons.alerting.model.remote.monitors.RemoteDocLevelMonitorInput.Companion.REMOTE_DOC_LEVEL_MONITOR_INPUT_FIELD
+import org.opensearch.commons.alerting.model.userErrorMessage
 import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.commons.alerting.util.isMonitorOfStandardType
 import org.opensearch.commons.authuser.User
@@ -80,9 +92,11 @@ import org.opensearch.index.reindex.DeleteByQueryAction
 import org.opensearch.index.reindex.DeleteByQueryRequestBuilder
 import org.opensearch.rest.RestRequest
 import org.opensearch.search.builder.SearchSourceBuilder
+import org.opensearch.sql.plugin.transport.TransportPPLQueryResponse
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService
 import org.opensearch.transport.client.Client
+import org.opensearch.transport.client.node.NodeClient
 import java.io.IOException
 import java.time.Duration
 import java.util.Locale
@@ -110,6 +124,13 @@ class TransportIndexMonitorAction @Inject constructor(
     @Volatile private var indexTimeout = INDEX_TIMEOUT.get(settings)
     @Volatile private var maxActionThrottle = MAX_ACTION_THROTTLE_VALUE.get(settings)
     @Volatile private var allowList = ALLOW_LIST.get(settings)
+
+    // PPL Alerting related settings
+    @Volatile private var maxQueryLength = PPL_MAX_QUERY_LENGTH.get(settings)
+    @Volatile private var maxQueryResults = PPL_QUERY_RESULTS_MAX_DATAROWS.get(settings)
+    @Volatile private var notificationSubjectMaxLength = NOTIFICATION_SUBJECT_SOURCE_MAX_LENGTH.get(settings)
+    @Volatile private var notificationMessageMaxLength = NOTIFICATION_MESSAGE_SOURCE_MAX_LENGTH.get(settings)
+
     @Volatile override var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
 
     init {
@@ -118,6 +139,16 @@ class TransportIndexMonitorAction @Inject constructor(
         clusterService.clusterSettings.addSettingsUpdateConsumer(INDEX_TIMEOUT) { indexTimeout = it }
         clusterService.clusterSettings.addSettingsUpdateConsumer(MAX_ACTION_THROTTLE_VALUE) { maxActionThrottle = it }
         clusterService.clusterSettings.addSettingsUpdateConsumer(ALLOW_LIST) { allowList = it }
+
+        clusterService.clusterSettings.addSettingsUpdateConsumer(PPL_MAX_QUERY_LENGTH) { maxQueryLength = it }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(PPL_QUERY_RESULTS_MAX_DATAROWS) { maxQueryResults = it }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(NOTIFICATION_SUBJECT_SOURCE_MAX_LENGTH) {
+            notificationSubjectMaxLength = it
+        }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(NOTIFICATION_MESSAGE_SOURCE_MAX_LENGTH) {
+            notificationMessageMaxLength = it
+        }
+
         listenFilterBySettingChange(clusterService)
     }
 
@@ -167,11 +198,13 @@ class TransportIndexMonitorAction @Inject constructor(
             }
         }
 
-        if (!isADMonitor(transformedRequest.monitor)) {
-            checkIndicesAndExecute(client, actionListener, transformedRequest, user)
-        } else {
+        if (isADMonitor(transformedRequest.monitor)) {
             // check if user has access to any anomaly detector for AD monitor
             checkAnomalyDetectorAndExecute(client, actionListener, transformedRequest, user)
+        } else if (transformedRequest.monitor.monitorType == MonitorType.PPL_MONITOR.value) {
+            checkPPLQueryAndExecute(actionListener, transformedRequest, user)
+        } else {
+            checkIndicesAndExecute(client, actionListener, transformedRequest, user)
         }
     }
 
@@ -231,6 +264,211 @@ class TransportIndexMonitorAction @Inject constructor(
                                 )
                                 false -> t
                             }
+                        )
+                    )
+                }
+            }
+        )
+    }
+
+    private fun checkPPLQueryAndExecute(
+        actionListener: ActionListener<IndexMonitorResponse>,
+        indexMonitorRequest: IndexMonitorRequest,
+        user: User?
+    ) {
+        val pplMonitor = indexMonitorRequest.monitor
+
+        // run basic validations against the PPL Monitor
+        val pplMonitorValid = validatePPLMonitor(pplMonitor, actionListener)
+        if (!pplMonitorValid) {
+            return
+        }
+
+        // validate the PPL query syntax and that user has permissions to
+        // the indices being queried. if it does, proceed to index the
+        // PPL Monitor
+        validatePPLQuery(pplMonitor, actionListener) {
+            val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
+            val schedulerAccountId = client.threadPool().threadContext
+                .getTransient<String>(ExternalSchedulerService.SCHEDULER_ACCOUNT_ID_KEY)
+
+            // user permissions to indices have already been checked if we made it to the onResponse(),
+            // proceed without the context of the user, otherwise,
+            // we would get permissions errors trying to search the alerting-config
+            // index as the user. pass the user object itself so backend
+            // roles can be matched and checked downstream
+            client.threadPool().threadContext.stashContext().use {
+                val pplMonitor = indexMonitorRequest.monitor
+                if (user == null) {
+                    indexMonitorRequest.monitor = pplMonitor
+                        .copy(user = User("", listOf(), listOf(), mapOf()))
+                } else {
+                    indexMonitorRequest.monitor = pplMonitor
+                        .copy(user = User(user.name, user.backendRoles, user.roles, user.customAttributes))
+                }
+                IndexMonitorHandler(
+                    client,
+                    actionListener,
+                    indexMonitorRequest,
+                    user,
+                    tenantId,
+                    schedulerAccountId
+                ).resolveUserAndStart()
+            }
+        }
+    }
+
+    private fun validatePPLMonitor(pplMonitor: Monitor, actionListener: ActionListener<IndexMonitorResponse>): Boolean {
+        pplMonitor.triggers.forEach { trigger ->
+            val pplTrigger = trigger as PPLTrigger
+
+            if (pplTrigger.conditionType == PPLTrigger.ConditionType.NUMBER_OF_RESULTS &&
+                pplTrigger.numResultsValue!! > maxQueryResults
+            ) {
+                actionListener.onFailure(
+                    AlertingException.wrap(
+                        IllegalArgumentException(
+                            "Trigger ${trigger.id} checks for number of results threshold of ${trigger.numResultsValue}, " +
+                                "but PPL Alerting is configured only to retrieve $maxQueryResults query results maximum. " +
+                                "Please lower the number of results value to one below this maximum value, or adjust the cluster " +
+                                "setting: ${PPL_QUERY_RESULTS_MAX_DATAROWS.key}"
+                        )
+                    )
+                )
+                return false
+            }
+
+            pplTrigger.actions.forEach { action ->
+                if ((action.subjectTemplate?.idOrCode?.length ?: 0) > notificationSubjectMaxLength) {
+                    actionListener.onFailure(
+                        AlertingException.wrap(
+                            IllegalArgumentException(
+                                "Notification subject source cannot exceed length: $notificationSubjectMaxLength"
+                            )
+                        )
+                    )
+                    return false
+                }
+
+                if (action.messageTemplate.idOrCode.length > notificationMessageMaxLength) {
+                    actionListener.onFailure(
+                        AlertingException.wrap(
+                            IllegalArgumentException(
+                                "Notification message source cannot exceed length: $notificationMessageMaxLength"
+                            )
+                        )
+                    )
+                    return false
+                }
+            }
+        }
+
+        val query = (pplMonitor.inputs[0] as PPLInput).query
+
+        // ensure the query length doesn't exceed the limit
+        if (query.length > maxQueryLength) {
+            actionListener.onFailure(
+                AlertingException.wrap(
+                    IllegalArgumentException(
+                        "PPL Query length must be at most $maxQueryLength but was ${query.length}"
+                    )
+                )
+            )
+            return false
+        }
+
+        return true
+    }
+
+    private fun validatePPLQuery(
+        pplMonitor: Monitor,
+        actionListener: ActionListener<IndexMonitorResponse>,
+        onSuccess: () -> Unit
+    ) {
+        // first attempt to run the monitor query and all possible
+        // extensions of it (from custom conditions)
+        val baseQuery = (pplMonitor.inputs[0] as PPLInput).query
+
+        val limitedQueryToExecute = appendDataRowsLimit(baseQuery, maxQueryResults)
+
+        // now PPL explain the base query as is.
+        // if there are any PPL syntax, index not found, insufficient index permissions, or other errors,
+        // this will throw an exception from the SQL/PPL plugin
+        executePplQuery(
+            limitedQueryToExecute,
+            true,
+            client as NodeClient,
+            object : ActionListener<TransportPPLQueryResponse> {
+                override fun onResponse(response: TransportPPLQueryResponse) {
+                    // Base query is valid. Now validate custom conditions.
+                    val customTriggers = pplMonitor.triggers
+                        .filterIsInstance<PPLTrigger>()
+                        .filter { it.conditionType == PPLTrigger.ConditionType.CUSTOM }
+
+                    validatePPLCustomConditions(baseQuery, customTriggers, 0, actionListener, onSuccess)
+                }
+
+                override fun onFailure(e: Exception) {
+                    actionListener.onFailure(
+                        AlertingException.wrap(
+                            IllegalArgumentException("PPL Query validation failed: ${e.userErrorMessage()}")
+                        )
+                    )
+                }
+            }
+        )
+    }
+
+    private fun validatePPLCustomConditions(
+        baseQuery: String,
+        customTriggers: List<PPLTrigger>,
+        recursionIndex: Int,
+        actionListener: ActionListener<IndexMonitorResponse>,
+        onSuccess: () -> Unit
+    ) {
+        // base case: the recursion index iterates over the list of custom triggers. if
+        // we have scanned all custom triggers and none of them had issues, all custom
+        // triggers are valid, proceed with indexing the PPL Monitor
+        if (recursionIndex >= customTriggers.size) {
+            onSuccess()
+            return
+        }
+
+        val customTrigger = customTriggers[recursionIndex]
+        val customCondition = customTrigger.customCondition!!
+
+        // validate the custom condition is a where statement and
+        // not some other valid PPL statement
+        if (!customConditionIsValid(customCondition)) {
+            actionListener.onFailure(
+                AlertingException.wrap(
+                    IllegalArgumentException(
+                        "Custom condition for trigger ${customTrigger.name} is invalid, " +
+                            "custom condition must be a valid PPL where statement."
+                    )
+                )
+            )
+            return
+        }
+
+        val queryWithCustomCondition = appendCustomCondition(baseQuery, customCondition)
+        val limitedQueryWithCustomCondition = appendDataRowsLimit(queryWithCustomCondition, maxQueryResults)
+
+        // if the custom condition is invalid, this will throw an exception
+        // from the SQL/PPL plugin and onFailure will be called
+        executePplQuery(
+            limitedQueryWithCustomCondition,
+            true,
+            client as NodeClient,
+            object : ActionListener<TransportPPLQueryResponse> {
+                override fun onResponse(response: TransportPPLQueryResponse) {
+                    validatePPLCustomConditions(baseQuery, customTriggers, recursionIndex + 1, actionListener, onSuccess)
+                }
+
+                override fun onFailure(e: Exception) {
+                    actionListener.onFailure(
+                        AlertingException.wrap(
+                            IllegalArgumentException("PPL Query validation failed: ${e.userErrorMessage()}")
                         )
                     )
                 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
@@ -454,7 +454,7 @@ class TransportIndexWorkflowAction @Inject constructor(
                     user,
                     currentWorkflow.user,
                     actionListener,
-                    "workfklow",
+                    "workflow",
                     request.workflowId
                 )
             ) {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportSearchMonitorAction.kt
@@ -11,7 +11,6 @@ import org.apache.lucene.search.TotalHits.Relation
 import org.opensearch.action.ActionRequest
 import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.search.SearchResponse
-import org.opensearch.action.search.SearchResponse.Clusters
 import org.opensearch.action.search.ShardSearchFailure
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
@@ -112,6 +111,7 @@ class TransportSearchMonitorAction @Inject constructor(
         }
     }
 
+    // Used in Get and Search monitor functionalities to return a "no results" response
     fun getEmptySearchResponse(): SearchResponse {
         val internalSearchResponse = InternalSearchResponse(
             SearchHits(emptyArray(), TotalHits(0L, Relation.EQUAL_TO), 0.0f),

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
@@ -6,13 +6,23 @@
 package org.opensearch.alerting.util
 
 import org.apache.logging.log4j.LogManager
+import org.opensearch.OpenSearchSecurityException
 import org.opensearch.alerting.AlertService
+import org.opensearch.alerting.MonitorRunnerExecutionContext
 import org.opensearch.alerting.MonitorRunnerService
+import org.opensearch.alerting.action.GetDestinationsAction
+import org.opensearch.alerting.action.GetDestinationsRequest
+import org.opensearch.alerting.action.GetDestinationsResponse
 import org.opensearch.alerting.model.AlertContext
 import org.opensearch.alerting.model.destination.Destination
+import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.script.BucketLevelTriggerExecutionContext
 import org.opensearch.alerting.script.DocumentLevelTriggerExecutionContext
-import org.opensearch.alerting.settings.DestinationSettings
+import org.opensearch.alerting.util.destinationmigration.NotificationActionConfigs
+import org.opensearch.alerting.util.destinationmigration.NotificationApiUtils.Companion.getNotificationConfigInfo
+import org.opensearch.alerting.util.destinationmigration.getTitle
+import org.opensearch.alerting.util.destinationmigration.publishLegacyNotification
+import org.opensearch.alerting.util.destinationmigration.sendNotification
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.util.concurrent.ThreadContext
@@ -21,13 +31,16 @@ import org.opensearch.commons.alerting.model.BucketLevelTrigger
 import org.opensearch.commons.alerting.model.BucketLevelTriggerRunResult
 import org.opensearch.commons.alerting.model.DocumentLevelTrigger
 import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.Table
 import org.opensearch.commons.alerting.model.Trigger
 import org.opensearch.commons.alerting.model.action.Action
 import org.opensearch.commons.alerting.model.action.ActionExecutionPolicy
 import org.opensearch.commons.alerting.model.action.ActionExecutionScope
 import org.opensearch.commons.alerting.util.isBucketLevelMonitor
 import org.opensearch.commons.alerting.util.isMonitorOfStandardType
+import org.opensearch.commons.notifications.model.NotificationConfigInfo
 import org.opensearch.script.Script
+import org.opensearch.transport.client.node.NodeClient
 import java.util.Locale
 import kotlin.math.max
 
@@ -286,4 +299,103 @@ fun printsSampleDocData(trigger: Trigger): Boolean {
         )
         validTags.any { tag -> action.messageTemplate.idOrCode.contains(tag) }
     }
+}
+
+suspend fun getConfigAndSendNotification(
+    action: Action,
+    monitorCtx: MonitorRunnerExecutionContext,
+    subject: String?,
+    message: String
+): String {
+    val config = getConfigForNotificationAction(action, monitorCtx)
+    if (config.destination == null && config.channel == null) {
+        throw IllegalStateException("Unable to find a Notification Channel or Destination config with id [${action.destinationId}]")
+    }
+
+    // Adding a check on TEST_ACTION Destination type here to avoid supporting it as a LegacyBaseMessage type
+    // just for Alerting integration tests
+    if (config.destination?.isTestAction() == true) {
+        return "test action"
+    }
+
+    if (config.destination?.isAllowed(monitorCtx.allowList) == false) {
+        throw IllegalStateException(
+            "Monitor contains a Destination type that is not allowed: ${config.destination.type}"
+        )
+    }
+
+    var actionResponseContent = ""
+    actionResponseContent = config.channel
+        ?.sendNotification(
+            monitorCtx.client!!,
+            config.channel.getTitle(subject),
+            message
+        ) ?: actionResponseContent
+
+    actionResponseContent = config.destination
+        ?.buildLegacyBaseMessage(subject, message, monitorCtx.destinationContextFactory!!.getDestinationContext(config.destination))
+        ?.publishLegacyNotification(monitorCtx.client!!)
+        ?: actionResponseContent
+
+    return actionResponseContent
+}
+
+/**
+ * The "destination" ID referenced in a Monitor Action could either be a Notification config or a Destination config
+ * depending on whether the background migration process has already migrated it from a Destination to a Notification config.
+ *
+ * To cover both of these cases, the Notification config will take precedence and if it is not found, the Destination will be retrieved.
+ */
+private suspend fun getConfigForNotificationAction(
+    action: Action,
+    monitorCtx: MonitorRunnerExecutionContext
+): NotificationActionConfigs {
+    var destination: Destination? = null
+    var notificationPermissionException: Exception? = null
+
+    var channel: NotificationConfigInfo? = null
+    try {
+        channel = getNotificationConfigInfo(monitorCtx.client as NodeClient, action.destinationId)
+    } catch (e: OpenSearchSecurityException) {
+        notificationPermissionException = e
+    }
+
+    // If the channel was not found, try to retrieve the Destination
+    if (channel == null) {
+        destination = try {
+            val table = Table(
+                "asc",
+                "destination.name.keyword",
+                null,
+                1,
+                0,
+                null
+            )
+            val getDestinationsRequest = GetDestinationsRequest(
+                action.destinationId,
+                0L,
+                null,
+                table,
+                "ALL"
+            )
+
+            val getDestinationsResponse: GetDestinationsResponse = monitorCtx.client!!.suspendUntil {
+                monitorCtx.client!!.execute(GetDestinationsAction.INSTANCE, getDestinationsRequest, it)
+            }
+            getDestinationsResponse.destinations.firstOrNull()
+        } catch (e: IllegalStateException) {
+            // Catching the exception thrown when the Destination was not found so the NotificationActionConfigs object can be returned
+            null
+        } catch (e: OpenSearchSecurityException) {
+            if (notificationPermissionException != null)
+                throw notificationPermissionException
+            else
+                throw e
+        }
+
+        if (destination == null && notificationPermissionException != null)
+            throw notificationPermissionException
+    }
+
+    return NotificationActionConfigs(destination, channel)
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertingRestTestCase.kt
@@ -54,6 +54,8 @@ import org.opensearch.commons.alerting.model.DocumentLevelTrigger
 import org.opensearch.commons.alerting.model.Finding
 import org.opensearch.commons.alerting.model.FindingWithDocs
 import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.PPLInput
+import org.opensearch.commons.alerting.model.PPLTrigger
 import org.opensearch.commons.alerting.model.QueryLevelTrigger
 import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.model.SearchInput
@@ -66,23 +68,25 @@ import org.opensearch.core.xcontent.ToXContent
 import org.opensearch.core.xcontent.XContentBuilder
 import org.opensearch.core.xcontent.XContentParser
 import org.opensearch.core.xcontent.XContentParserUtils
+import org.opensearch.index.query.QueryBuilders
 import org.opensearch.search.SearchModule
 import org.opensearch.search.builder.SearchSourceBuilder
+import org.opensearch.test.OpenSearchTestCase
 import java.net.URLEncoder
 import java.nio.file.Files
 import java.time.Instant
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
+import java.time.temporal.ChronoUnit.MILLIS
 import java.util.Locale
 import java.util.UUID
+import java.util.concurrent.TimeUnit
 import java.util.stream.Collectors
 import javax.management.MBeanServerInvocationHandler
 import javax.management.ObjectName
 import javax.management.remote.JMXConnectorFactory
 import javax.management.remote.JMXServiceURL
-import kotlin.collections.ArrayList
-import kotlin.collections.HashMap
 
 /**
  * Superclass for tests that interact with an external test cluster using OpenSearch's RestClient
@@ -105,9 +109,11 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
                 Monitor.XCONTENT_REGISTRY,
                 SearchInput.XCONTENT_REGISTRY,
                 DocLevelMonitorInput.XCONTENT_REGISTRY,
+                PPLInput.XCONTENT_REGISTRY,
                 QueryLevelTrigger.XCONTENT_REGISTRY,
                 BucketLevelTrigger.XCONTENT_REGISTRY,
                 DocumentLevelTrigger.XCONTENT_REGISTRY,
+                PPLTrigger.XCONTENT_REGISTRY,
                 Workflow.XCONTENT_REGISTRY,
                 ChainedAlertTrigger.XCONTENT_REGISTRY
             ) + SearchModule(Settings.EMPTY, emptyList()).namedXContents
@@ -148,6 +154,22 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         assertUserNull(monitorJson as HashMap<String, Any>)
 
         return getMonitor(monitorId = monitorJson["_id"] as String)
+    }
+
+    // used only for PPL Monitor tests
+    // a createMonitorWithClient() wrapper that creates an index before proceeding
+    protected fun createPPLIndexThenMonitorWithClient(
+        client: RestClient,
+        monitor: Monitor,
+        rbacRoles: List<String>? = null,
+        refresh: Boolean = true
+    ): Monitor {
+        // every random ppl monitor's query searches index TEST_INDEX_NAME
+        // by default, so create that first before creating the monitor
+        if (!indexExists(TEST_INDEX_NAME)) {
+            createIndex(TEST_INDEX_NAME, Settings.EMPTY, TEST_INDEX_MAPPINGS)
+        }
+        return createMonitorWithClient(client, monitor, rbacRoles, refresh)
     }
 
     protected fun createMonitor(monitor: Monitor, refresh: Boolean = true): Monitor {
@@ -535,6 +557,19 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         return getMonitor(monitorId = monitorId)
     }
 
+    protected fun createRandomPPLMonitor(pplMonitorConfig: Monitor = randomPPLMonitor()): Monitor {
+        // every random ppl monitor's query searches index TEST_INDEX_NAME
+        // by default, so create that first before creating the monitor
+        val indexExistsResponse = adminClient().makeRequest("HEAD", TEST_INDEX_NAME)
+        if (indexExistsResponse.restStatus() == RestStatus.NOT_FOUND) {
+            createIndex(TEST_INDEX_NAME, Settings.EMPTY, TEST_INDEX_MAPPINGS)
+        }
+        logger.info("ppl monitor: $pplMonitorConfig")
+
+        val pplMonitorId = createMonitor(pplMonitorConfig).id
+        return getMonitor(monitorId = pplMonitorId)
+    }
+
     protected fun createRandomDocumentMonitor(refresh: Boolean = false, withMetadata: Boolean = false): Monitor {
         val monitor = randomDocumentLevelMonitor(withMetadata = withMetadata)
         val monitorId = createMonitor(monitor, refresh).id
@@ -644,9 +679,9 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         if (refresh) refreshIndex(indices)
 
         val request = """
-                { "version" : true,
-                  "query": { "match_all": {} }
-                }
+            { "version" : true,
+              "query": { "match_all": {} }
+            }
         """.trimIndent()
         val httpResponse = adminClient().makeRequest("GET", "/$indices/_search", StringEntity(request, APPLICATION_JSON))
         assertEquals("Search failed", RestStatus.OK, httpResponse.restStatus())
@@ -691,9 +726,9 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         if (refresh) refreshIndex(indices)
 
         val request = """
-                { "version" : true,
-                  "query": { "match_all": {} }
-                }
+            { "version" : true,
+              "query": { "match_all": {} }
+            }
         """.trimIndent()
         val httpResponse = adminClient().makeRequest("GET", "/$indices/_search", StringEntity(request, APPLICATION_JSON))
         assertEquals("Search failed", RestStatus.OK, httpResponse.restStatus())
@@ -716,9 +751,9 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         // If this is a test monitor (it doesn't have an ID) and no alerts will be saved for it.
         val searchParams = if (monitor.id != Monitor.NO_ID) mapOf("routing" to monitor.id) else mapOf()
         val request = """
-                { "version" : true,
-                  "query" : { "term" : { "${Alert.MONITOR_ID_FIELD}" : "${monitor.id}" } }
-                }
+            { "version" : true,
+              "query" : { "term" : { "${Alert.MONITOR_ID_FIELD}" : "${monitor.id}" } }
+            }
         """.trimIndent()
         val httpResponse = adminClient().makeRequest("GET", "/$indices/_search", searchParams, StringEntity(request, APPLICATION_JSON))
         assertEquals("Search failed", RestStatus.OK, httpResponse.restStatus())
@@ -880,9 +915,9 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
     protected fun searchMonitors(): SearchResponse {
         var baseEndpoint = "${AlertingPlugin.MONITOR_BASE_URI}/_search?"
         val request = """
-                { "version" : true,
-                  "query": { "match_all": {} }
-                }
+            { "version" : true,
+              "query": { "match_all": {} }
+            }
         """.trimIndent()
         val httpResponse = adminClient().makeRequest("POST", baseEndpoint, StringEntity(request, APPLICATION_JSON))
         assertEquals("Search failed", RestStatus.OK, httpResponse.restStatus())
@@ -1215,9 +1250,9 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
             val testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(twoMinsAgo)
             val testDoc = """
                 {
-                  "test_strict_date_time": "$testTime",
-                  "test_field": "$value",
-                   "number": "$i"
+                    "test_strict_date_time": "$testTime",
+                    "test_field": "$value",
+                    "number": "$i"
                 }
             """.trimIndent()
             // Indexing documents with deterministic doc id to allow for easy selected deletion during testing
@@ -1231,9 +1266,9 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
             val testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(time)
             val testDoc = """
                 {
-                  "test_strict_date_time": "$testTime",
-                  "test_field": "$value",
-                   "number": "$i"
+                    "test_strict_date_time": "$testTime",
+                    "test_field": "$value",
+                    "number": "$i"
                 }
             """.trimIndent()
             // Indexing documents with deterministic doc id to allow for easy selected deletion during testing
@@ -1250,9 +1285,9 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
             val testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(time)
             val testDoc = """
                 {
-                  "test_strict_date_time": "$testTime",
-                  "test_field": "$value",
-                   "number": "$i"
+                    "test_strict_date_time": "$testTime",
+                    "test_field": "$value",
+                    "number": "$i"
                 }
             """.trimIndent()
             // Indexing documents with deterministic doc id to allow for easy selected deletion during testing
@@ -1434,8 +1469,9 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         return map[key]
     }
 
-    fun getAlertingStats(metrics: String = ""): Map<String, Any> {
-        val monitorStatsResponse = client().makeRequest("GET", "/_plugins/_alerting/stats$metrics")
+    fun getAlertingStats(metrics: String = "", alertingVersion: String? = null): Map<String, Any> {
+        val endpoint = "/_plugins/_alerting/stats$metrics${alertingVersion?.let { "?version=$it" }.orEmpty()}"
+        val monitorStatsResponse = client().makeRequest("GET", endpoint)
         val responseMap = createParser(XContentType.JSON.xContent(), monitorStatsResponse.entity.content).map()
         return responseMap
     }
@@ -1513,11 +1549,13 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         val customAttributesString = customAttributes.entries.joinToString(prefix = "{", separator = ", ", postfix = "}") {
             "\"${it.key}\": \"${it.value}\""
         }
-        var entity = " {\n" +
-            "\"password\": \"$password\",\n" +
-            "\"backend_roles\": [$broles],\n" +
-            "\"attributes\": $customAttributesString\n" +
-            "} "
+        var entity = """
+            {
+                "password": "$password",
+                "backend_roles": [$broles],
+                "attributes": $customAttributesString
+            }
+        """.trimIndent()
         request.setJsonEntity(entity)
         client().performRequest(request)
     }
@@ -1525,61 +1563,52 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
     fun patchUserBackendRoles(name: String, backendRoles: Array<String>) {
         val request = Request("PATCH", "/_plugins/_security/api/internalusers/$name")
         val broles = backendRoles.joinToString { "\"$it\"" }
-        var entity = " [{\n" +
-            "\"op\": \"replace\",\n" +
-            "\"path\": \"/backend_roles\",\n" +
-            "\"value\": [$broles]\n" +
-            "}]"
+        var entity = """
+            [{
+                "op": "replace",
+                "path": "/backend_roles",
+                "value": [$broles]
+            }]
+        """.trimIndent()
         request.setJsonEntity(entity)
         client().performRequest(request)
     }
 
     fun createIndexRole(name: String, index: String) {
         val request = Request("PUT", "/_plugins/_security/api/roles/$name")
-        var entity = "{\n" +
-            "\"cluster_permissions\": [\n" +
-            "],\n" +
-            "\"index_permissions\": [\n" +
-            "{\n" +
-            "\"index_patterns\": [\n" +
-            "\"$index\"\n" +
-            "],\n" +
-            "\"dls\": \"\",\n" +
-            "\"fls\": [],\n" +
-            "\"masked_fields\": [],\n" +
-            "\"allowed_actions\": [\n" +
-            "\"crud\"\n" +
-            "]\n" +
-            "}\n" +
-            "],\n" +
-            "\"tenant_permissions\": []\n" +
-            "}"
+        var entity = """
+            {
+                "cluster_permissions": [],
+                "index_permissions": [{
+                    "index_patterns": ["$index"],
+                    "dls": "",
+                    "fls": [],
+                    "masked_fields": [],
+                    "allowed_actions": ["crud"]
+                }],
+                "tenant_permissions": []
+            }
+        """.trimIndent()
         request.setJsonEntity(entity)
         client().performRequest(request)
     }
 
     fun createCustomIndexRole(name: String, index: String, clusterPermissions: String?) {
         val request = Request("PUT", "/_plugins/_security/api/roles/$name")
-        val clusterPermissionsArray = if (clusterPermissions.isNullOrBlank()) "" else "\"$clusterPermissions\""
-        var entity = "{\n" +
-            "\"cluster_permissions\": [\n" +
-            "$clusterPermissionsArray\n" +
-            "],\n" +
-            "\"index_permissions\": [\n" +
-            "{\n" +
-            "\"index_patterns\": [\n" +
-            "\"$index\"\n" +
-            "],\n" +
-            "\"dls\": \"\",\n" +
-            "\"fls\": [],\n" +
-            "\"masked_fields\": [],\n" +
-            "\"allowed_actions\": [\n" +
-            "\"crud\"\n" +
-            "]\n" +
-            "}\n" +
-            "],\n" +
-            "\"tenant_permissions\": []\n" +
-            "}"
+        val clusterPerms = if (clusterPermissions.isNullOrEmpty()) "[]" else "[\"$clusterPermissions\"]"
+        var entity = """
+            {
+                "cluster_permissions": $clusterPerms,
+                "index_permissions": [{
+                    "index_patterns": ["$index"],
+                    "dls": "",
+                    "fls": [],
+                    "masked_fields": [],
+                    "allowed_actions": ["crud"]
+                }],
+                "tenant_permissions": []
+            }
+        """.trimIndent()
         request.setJsonEntity(entity)
         client().performRequest(request)
     }
@@ -1588,55 +1617,43 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         val request = Request("PUT", "/_plugins/_security/api/roles/$name")
 
         val clusterPermissionsStr =
-            clusterPermissions.stream()
-                .filter { p -> !p.isNullOrBlank() }
-                .map { p: String? -> "\"" + p + "\"" }
-                .collect(Collectors.joining(","))
+            clusterPermissions.stream().map { p: String? -> "\"" + p + "\"" }.collect(
+                Collectors.joining(",")
+            )
 
-        var entity = "{\n" +
-            "\"cluster_permissions\": [\n" +
-            "$clusterPermissionsStr\n" +
-            "],\n" +
-            "\"index_permissions\": [\n" +
-            "{\n" +
-            "\"index_patterns\": [\n" +
-            "\"$index\"\n" +
-            "],\n" +
-            "\"dls\": \"\",\n" +
-            "\"fls\": [],\n" +
-            "\"masked_fields\": [],\n" +
-            "\"allowed_actions\": [\n" +
-            "\"crud\"\n" +
-            "]\n" +
-            "}\n" +
-            "],\n" +
-            "\"tenant_permissions\": []\n" +
-            "}"
+        var entity = """
+            {
+                "cluster_permissions": [$clusterPermissionsStr],
+                "index_permissions": [{
+                    "index_patterns": ["$index"],
+                    "dls": "",
+                    "fls": [],
+                    "masked_fields": [],
+                    "allowed_actions": ["crud"]
+                }],
+                "tenant_permissions": []
+            }
+        """.trimIndent()
         request.setJsonEntity(entity)
         client().performRequest(request)
     }
 
     fun createIndexRoleWithDocLevelSecurity(name: String, index: String, dlsQuery: String, clusterPermissions: String? = "") {
         val request = Request("PUT", "/_plugins/_security/api/roles/$name")
-        var entity = "{\n" +
-            "\"cluster_permissions\": [\n" +
-            "\"$clusterPermissions\"\n" +
-            "],\n" +
-            "\"index_permissions\": [\n" +
-            "{\n" +
-            "\"index_patterns\": [\n" +
-            "\"$index\"\n" +
-            "],\n" +
-            "\"dls\": \"$dlsQuery\",\n" +
-            "\"fls\": [],\n" +
-            "\"masked_fields\": [],\n" +
-            "\"allowed_actions\": [\n" +
-            "\"crud\"\n" +
-            "]\n" +
-            "}\n" +
-            "],\n" +
-            "\"tenant_permissions\": []\n" +
-            "}"
+        val clusterPerms = if (clusterPermissions.isNullOrEmpty()) "[]" else "[\"$clusterPermissions\"]"
+        var entity = """
+            {
+                "cluster_permissions": $clusterPerms,
+                "index_permissions": [{
+                    "index_patterns": ["$index"],
+                    "dls": "$dlsQuery",
+                    "fls": [],
+                    "masked_fields": [],
+                    "allowed_actions": ["crud"]
+                }],
+                "tenant_permissions": []
+            }
+        """.trimIndent()
         request.setJsonEntity(entity)
         client().performRequest(request)
     }
@@ -1648,25 +1665,19 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
             )
 
         val request = Request("PUT", "/_plugins/_security/api/roles/$name")
-        var entity = "{\n" +
-            "\"cluster_permissions\": [\n" +
-            "$clusterPermissionsStr\n" +
-            "],\n" +
-            "\"index_permissions\": [\n" +
-            "{\n" +
-            "\"index_patterns\": [\n" +
-            "\"$index\"\n" +
-            "],\n" +
-            "\"dls\": \"$dlsQuery\",\n" +
-            "\"fls\": [],\n" +
-            "\"masked_fields\": [],\n" +
-            "\"allowed_actions\": [\n" +
-            "\"crud\"\n" +
-            "]\n" +
-            "}\n" +
-            "],\n" +
-            "\"tenant_permissions\": []\n" +
-            "}"
+        var entity = """
+            {
+                "cluster_permissions": [$clusterPermissionsStr],
+                "index_permissions": [{
+                    "index_patterns": ["$index"],
+                    "dls": "$dlsQuery",
+                    "fls": [],
+                    "masked_fields": [],
+                    "allowed_actions": ["crud"]
+                }],
+                "tenant_permissions": []
+            }
+        """.trimIndent()
         request.setJsonEntity(entity)
         client().performRequest(request)
     }
@@ -1674,11 +1685,13 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
     fun createUserRolesMapping(role: String, users: Array<String>) {
         val request = Request("PUT", "/_plugins/_security/api/rolesmapping/$role")
         val usersStr = users.joinToString { it -> "\"$it\"" }
-        var entity = "{                                  \n" +
-            "  \"backend_roles\" : [  ],\n" +
-            "  \"hosts\" : [  ],\n" +
-            "  \"users\" : [$usersStr]\n" +
-            "}"
+        var entity = """
+            {
+                "backend_roles": [],
+                "hosts": [],
+                "users": [$usersStr]
+            }
+        """.trimIndent()
         request.setJsonEntity(entity)
         client().performRequest(request)
     }
@@ -1689,11 +1702,13 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
 
         val op = if (addUser) "add" else "remove"
 
-        val entity = "[{\n" +
-            "  \"op\" : \"$op\",\n" +
-            "  \"path\" : \"/users\",\n" +
-            "  \"value\" : [$usersStr]\n" +
-            "}]"
+        val entity = """
+            [{
+                "op": "$op",
+                "path": "/users",
+                "value": [$usersStr]
+            }]
+        """.trimIndent()
 
         request.setJsonEntity(entity)
         client().performRequest(request)
@@ -2007,5 +2022,61 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         val deletedCommentId = deleteResponseBody["_id"] as String
 
         return deletedCommentId
+    }
+
+    protected fun isMonitorScheduled(monitorId: String, alertingStatsResponse: Map<String, Any>): Boolean {
+        val nodesInfo = alertingStatsResponse["nodes"] as Map<String, Any>
+        for (nodeId in nodesInfo.keys) {
+            val nodeInfo = nodesInfo[nodeId] as Map<String, Any>
+            val jobsInfo = nodeInfo["jobs_info"] as Map<String, Any>
+            if (jobsInfo.keys.contains(monitorId)) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    // this function is used for PPL Alerting testing.
+    // precondition: TEST_INDEX_NAME must be created before calling this
+    // indexes a doc from some time ago into index TEST_INDEX_NAME.
+    // this function only works on the TEST_INDEX_NAME index created
+    // specifically for this IT suite. It has fields
+    // "timestamp" (date), "abc" (string), "number" (integer)
+    protected fun indexDocFromSomeTimeAgo(
+        timeValue: Long,
+        timeUnit: ChronoUnit,
+        abc: String,
+        number: Int,
+        id: String = UUID.randomUUID().toString()
+    ) {
+        val someTimeAgo = ZonedDateTime.now().minus(timeValue, timeUnit).truncatedTo(MILLIS)
+        val testTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(someTimeAgo) // the timestamp string is given a random timezone offset
+        val testDoc = """{ "timestamp" : "$testTime", "abc": "$abc", "number" : "$number" }"""
+        indexDoc(TEST_INDEX_NAME, id, testDoc)
+    }
+
+    protected fun ensureNumMonitors(expectedNum: Int) {
+        // if a validation error is thrown but a monitor is still accidentally created,
+        // what happens is that this check runs before the workflows to create
+        // alerting-config index and index the monitor complete, meaning this check gets
+        // no search results, then afterwards, the monitor is created, leading this function
+        // to falsely believe no monitor was create. wait some amount of time to let the
+        // workflows incorrectly create whatever monitors it will
+        OpenSearchTestCase.waitUntil({
+            return@waitUntil false
+        }, 10, TimeUnit.SECONDS)
+
+        val search = SearchSourceBuilder().query(QueryBuilders.matchAllQuery()).toString()
+        val searchResponse = client().makeRequest(
+            "POST", "${AlertingPlugin.MONITOR_BASE_URI}/_search",
+            StringEntity(search, APPLICATION_JSON)
+        )
+
+        assertEquals("Search monitor failed", RestStatus.OK, searchResponse.restStatus())
+        val xcp = createParser(XContentType.JSON.xContent(), searchResponse.entity.content)
+        val hits = xcp.map()["hits"]!! as Map<String, Map<String, Any>>
+        val numberDocsFound = hits["total"]?.get("value")
+        assertEquals("Unexpected number of PPL Monitors found in Search Monitors", expectedNum, numberDocsFound)
     }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/TestHelpers.kt
@@ -47,6 +47,11 @@ import org.opensearch.commons.alerting.model.InputRunResults
 import org.opensearch.commons.alerting.model.IntervalSchedule
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.MonitorRunResult
+import org.opensearch.commons.alerting.model.PPLInput
+import org.opensearch.commons.alerting.model.PPLInput.QueryLanguage
+import org.opensearch.commons.alerting.model.PPLTrigger
+import org.opensearch.commons.alerting.model.PPLTrigger.ConditionType
+import org.opensearch.commons.alerting.model.PPLTrigger.NumResultsCondition
 import org.opensearch.commons.alerting.model.QueryLevelTrigger
 import org.opensearch.commons.alerting.model.QueryLevelTriggerRunResult
 import org.opensearch.commons.alerting.model.Schedule
@@ -79,9 +84,17 @@ import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.test.OpenSearchTestCase.randomBoolean
 import org.opensearch.test.OpenSearchTestCase.randomInt
 import org.opensearch.test.OpenSearchTestCase.randomIntBetween
+import org.opensearch.test.OpenSearchTestCase.randomLongBetween
 import org.opensearch.test.rest.OpenSearchRestTestCase
+import org.opensearch.test.rest.OpenSearchRestTestCase.assertEquals
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+
+// constants for PPL Alerting tests
+const val TIMESTAMP_FIELD = "timestamp"
+const val TEST_INDEX_NAME = "index"
+const val TEST_INDEX_MAPPINGS =
+    """"properties":{"timestamp":{"type":"date"},"abc":{"type":"keyword"},"number":{"type":"integer"}}"""
 
 fun randomQueryLevelMonitor(
     name: String = OpenSearchRestTestCase.randomAlphaOfLength(10),
@@ -227,6 +240,36 @@ fun randomDocumentLevelMonitor(
     )
 }
 
+fun randomPPLMonitor(
+    name: String = OpenSearchRestTestCase.randomAlphaOfLength(10),
+    enabled: Boolean = randomBoolean(),
+    schedule: Schedule = IntervalSchedule(interval = 5, unit = ChronoUnit.MINUTES),
+    lastUpdateTime: Instant = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+    enabledTime: Instant? = if (enabled) Instant.now().truncatedTo(ChronoUnit.MILLIS) else null,
+    triggers: List<PPLTrigger> = List(randomIntBetween(1, 5)) { randomPPLTrigger() },
+    user: User? = randomUser(),
+    queryLanguage: QueryLanguage = QueryLanguage.PPL,
+    query: String = "source = $TEST_INDEX_NAME | head 10"
+): Monitor {
+    return Monitor(
+        name = name,
+        enabled = enabled,
+        schedule = schedule,
+        lastUpdateTime = lastUpdateTime,
+        enabledTime = enabledTime,
+        monitorType = Monitor.MonitorType.PPL_MONITOR.value,
+        inputs = listOf(
+            PPLInput(
+                query = query,
+                queryLanguage = queryLanguage
+            )
+        ),
+        triggers = triggers,
+        user = user,
+        uiMetadata = mapOf()
+    )
+}
+
 fun randomWorkflow(
     id: String = Workflow.NO_ID,
     monitorIds: List<String>,
@@ -348,6 +391,35 @@ fun randomDocumentLevelTrigger(
     )
 }
 
+// random PPLTrigger defaults to a number_of_results trigger, because a custom condition
+// would require knowledge of the PPL Monitor's query
+// it is on the caller to be explicit and pass in valid arguments that would create either
+// a valid PPL Monitor or one that intentionally throws an error during testing.
+// e.g. to create a valid PPL Monitor, if conditionType is CUSTOM,
+// numResultsCondition and numResultsValue must be null, while
+// customCondition must not be null.
+fun randomPPLTrigger(
+    id: String = UUIDs.base64UUID(),
+    name: String = OpenSearchRestTestCase.randomAlphaOfLength(10),
+    severity: String = "1",
+    actions: List<Action> = mutableListOf(),
+    conditionType: ConditionType = ConditionType.NUMBER_OF_RESULTS,
+    numResultsCondition: NumResultsCondition? = NumResultsCondition.entries.random(),
+    numResultsValue: Long? = randomLongBetween(1L, 50L),
+    customCondition: String? = null
+): PPLTrigger {
+    return PPLTrigger(
+        id = id,
+        name = name,
+        severity = severity,
+        actions = actions,
+        conditionType = conditionType,
+        numResultsCondition = numResultsCondition,
+        numResultsValue = numResultsValue,
+        customCondition = customCondition
+    )
+}
+
 fun randomBucketSelectorExtAggregationBuilder(
     name: String = OpenSearchRestTestCase.randomAlphaOfLength(10),
     bucketsPathsMap: MutableMap<String, String> = mutableMapOf("avg" to "10"),
@@ -424,10 +496,11 @@ fun randomTemplateScript(
 fun randomAction(
     name: String = OpenSearchRestTestCase.randomUnicodeOfLength(10),
     template: Script = randomTemplateScript("Hello World"),
-    destinationId: String = "",
+    subjectTemplate: Script = template,
+    destinationId: String = "abc",
     throttleEnabled: Boolean = false,
     throttle: Throttle = randomThrottle()
-) = Action(name, destinationId, template, template, throttleEnabled, throttle, actionExecutionPolicy = null)
+) = Action(name, destinationId, subjectTemplate, template, throttleEnabled, throttle, actionExecutionPolicy = null)
 
 fun randomActionWithPolicy(
     name: String = OpenSearchRestTestCase.randomUnicodeOfLength(10),
@@ -809,4 +882,74 @@ fun randomAlertContext(
 /** helper that returns a field in a json map whose values are all json objects */
 fun Map<String, Any>.objectMap(key: String): Map<String, Map<String, Any>> {
     return this[key] as Map<String, Map<String, Any>>
+}
+
+fun assertPplMonitorsEqual(pplMonitor1: Monitor, pplMonitor2: Monitor) {
+    // note: Get and Search Monitor responses do not include User information by
+    // design, so that check is skipped
+
+    // note: Update Monitor API intentionally overrides the enabledTime of the new given monitor
+    // with the enabledTime of the existing monitor being updated to ensure execution correctness,
+    // so that check is skipped
+
+    assertEquals("Monitor enabled fields not equal", pplMonitor1.enabled, pplMonitor2.enabled)
+    assertEquals("Monitor schedules not equal", pplMonitor1.schedule, pplMonitor2.schedule)
+    assertEquals(
+        "Monitor query languages not equal",
+        (pplMonitor1.inputs[0] as PPLInput).queryLanguage,
+        (pplMonitor2.inputs[0] as PPLInput).queryLanguage
+    )
+    assertEquals(
+        "Monitor queries not equal",
+        (pplMonitor1.inputs[0] as PPLInput).query,
+        (pplMonitor2.inputs[0] as PPLInput).query
+    )
+    assertEquals("Number of triggers in monitor not equal", pplMonitor1.triggers.size, pplMonitor2.triggers.size)
+
+    val sortedTriggers1 = pplMonitor1.triggers.sortedBy { it.id }
+    val sortedTriggers2 = pplMonitor2.triggers.sortedBy { it.id }
+    for (i in sortedTriggers1.indices) {
+        assertPplTriggersEqual(sortedTriggers1[i] as PPLTrigger, sortedTriggers2[i] as PPLTrigger)
+    }
+}
+
+fun assertPplTriggersEqual(pplTrigger1: PPLTrigger, pplTrigger2: PPLTrigger) {
+    assertEquals(
+        "Monitor trigger IDs not equal",
+        pplTrigger1.id,
+        pplTrigger2.id
+    )
+
+    val id = pplTrigger1.id
+
+    assertEquals(
+        "Monitor trigger $id names not equal",
+        pplTrigger1.name,
+        pplTrigger2.name
+    )
+    assertEquals(
+        "Monitor trigger $id severities not equal",
+        pplTrigger1.severity,
+        pplTrigger2.severity
+    )
+    assertEquals(
+        "Monitor trigger $id condition types not equal",
+        pplTrigger1.conditionType,
+        pplTrigger2.conditionType
+    )
+    assertEquals(
+        "Monitor trigger $id number_of_results conditions not equal",
+        pplTrigger1.numResultsCondition,
+        pplTrigger2.numResultsCondition
+    )
+    assertEquals(
+        "Monitor trigger $id number_of_results values not equal",
+        pplTrigger1.numResultsValue,
+        pplTrigger2.numResultsValue
+    )
+    assertEquals(
+        "Monitor trigger $id custom conditions not equal",
+        pplTrigger1.customCondition,
+        pplTrigger2.customCondition
+    )
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -11,10 +11,14 @@ import org.apache.hc.core5.http.message.BasicHeader
 import org.opensearch.alerting.ALERTING_BASE_URI
 import org.opensearch.alerting.ALWAYS_RUN
 import org.opensearch.alerting.ANOMALY_DETECTOR_INDEX
+import org.opensearch.alerting.AlertingPlugin.Companion.MONITOR_BASE_URI
 import org.opensearch.alerting.AlertingRestTestCase
 import org.opensearch.alerting.LEGACY_OPENDISTRO_ALERTING_BASE_URI
+import org.opensearch.alerting.TEST_INDEX_MAPPINGS
+import org.opensearch.alerting.TEST_INDEX_NAME
 import org.opensearch.alerting.alerts.AlertIndices
 import org.opensearch.alerting.anomalyDetectorIndexMapping
+import org.opensearch.alerting.assertPplMonitorsEqual
 import org.opensearch.alerting.core.settings.ScheduledJobSettings
 import org.opensearch.alerting.makeRequest
 import org.opensearch.alerting.model.destination.Chime
@@ -30,15 +34,24 @@ import org.opensearch.alerting.randomDocLevelMonitorInput
 import org.opensearch.alerting.randomDocLevelQuery
 import org.opensearch.alerting.randomDocumentLevelMonitor
 import org.opensearch.alerting.randomDocumentLevelTrigger
+import org.opensearch.alerting.randomPPLMonitor
+import org.opensearch.alerting.randomPPLTrigger
 import org.opensearch.alerting.randomQueryLevelMonitor
 import org.opensearch.alerting.randomQueryLevelTrigger
+import org.opensearch.alerting.randomTemplateScript
 import org.opensearch.alerting.randomThrottle
 import org.opensearch.alerting.randomUser
 import org.opensearch.alerting.settings.AlertingSettings
+import org.opensearch.alerting.settings.AlertingSettings.Companion.ALERTING_MAX_MONITORS
+import org.opensearch.alerting.settings.AlertingSettings.Companion.NOTIFICATION_MESSAGE_SOURCE_MAX_LENGTH
+import org.opensearch.alerting.settings.AlertingSettings.Companion.NOTIFICATION_SUBJECT_SOURCE_MAX_LENGTH
+import org.opensearch.alerting.settings.AlertingSettings.Companion.PPL_MAX_QUERY_LENGTH
 import org.opensearch.alerting.toJsonString
 import org.opensearch.alerting.util.DestinationType
 import org.opensearch.client.ResponseException
 import org.opensearch.client.WarningFailureException
+import org.opensearch.common.UUIDs
+import org.opensearch.common.settings.Settings
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.alerting.model.Alert
@@ -47,6 +60,7 @@ import org.opensearch.commons.alerting.model.DocLevelMonitorInput
 import org.opensearch.commons.alerting.model.DocLevelQuery
 import org.opensearch.commons.alerting.model.DocumentLevelTrigger
 import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.PPLTrigger.ConditionType
 import org.opensearch.commons.alerting.model.QueryLevelTrigger
 import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.model.SearchInput
@@ -55,6 +69,8 @@ import org.opensearch.core.common.bytes.BytesReference
 import org.opensearch.core.rest.RestStatus
 import org.opensearch.core.xcontent.ToXContent
 import org.opensearch.core.xcontent.XContentBuilder
+import org.opensearch.core.xcontent.XContentParser
+import org.opensearch.core.xcontent.XContentParserUtils
 import org.opensearch.index.query.QueryBuilders
 import org.opensearch.script.Script
 import org.opensearch.search.aggregations.AggregationBuilders
@@ -72,7 +88,9 @@ import java.util.concurrent.TimeUnit
 @Suppress("UNCHECKED_CAST")
 class MonitorRestApiIT : AlertingRestTestCase() {
 
-    val USE_TYPED_KEYS = ToXContent.MapParams(mapOf("with_type" to "true"))
+    companion object {
+        val USE_TYPED_KEYS = ToXContent.MapParams(mapOf("with_type" to "true"))
+    }
 
     @Throws(Exception::class)
     fun `test plugin is loaded`() {
@@ -1534,19 +1552,6 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         assertEquals("More than $numberOfNodes successful node", numberOfNodes, nodesResponse["successful"])
     }
 
-    private fun isMonitorScheduled(monitorId: String, alertingStatsResponse: Map<String, Any>): Boolean {
-        val nodesInfo = alertingStatsResponse["nodes"] as Map<String, Any>
-        for (nodeId in nodesInfo.keys) {
-            val nodeInfo = nodesInfo[nodeId] as Map<String, Any>
-            val jobsInfo = nodeInfo["jobs_info"] as Map<String, Any>
-            if (jobsInfo.keys.contains(monitorId)) {
-                return true
-            }
-        }
-
-        return false
-    }
-
     private fun assertAlertingStatsSweeperEnabled(alertingStatsResponse: Map<String, Any>, expected: Boolean) {
         assertEquals(
             "Legacy scheduled job enabled field is not set to $expected",
@@ -1558,5 +1563,349 @@ class MonitorRestApiIT : AlertingRestTestCase() {
             expected,
             alertingStatsResponse[statsResponseOpenSearchSweeperEnabledField]
         )
+    }
+
+    /* PPL Monitor Simple Case Tests */
+    fun `test create ppl monitor`() {
+        createIndex(TEST_INDEX_NAME, Settings.EMPTY, TEST_INDEX_MAPPINGS)
+        val pplMonitor = randomPPLMonitor()
+
+        val response = client().makeRequest("POST", MONITOR_BASE_URI, emptyMap(), pplMonitor.toHttpEntity())
+        assertEquals("Unable to create a new monitor v2", RestStatus.CREATED, response.restStatus())
+
+        val responseBody = response.asMap()
+        val createdId = responseBody["_id"] as String
+        val createdVersion = responseBody["_version"] as Int
+        assertNotEquals("response is missing Id", Monitor.NO_ID, createdId)
+        assertEquals("incorrect version", 1, createdVersion)
+    }
+
+    fun `test update ppl monitor`() {
+        val originalMonitor = createRandomPPLMonitor()
+
+        val newMonitorConfig = randomPPLMonitor()
+
+        val updateResponse = client().makeRequest(
+            "PUT",
+            "$MONITOR_BASE_URI/${originalMonitor.id}",
+            emptyMap(), newMonitorConfig.toHttpEntity()
+        )
+
+        assertEquals("Update monitor failed", RestStatus.OK, updateResponse.restStatus())
+        val responseBody = updateResponse.asMap()
+        assertEquals("Updated monitor id doesn't match", originalMonitor.id, responseBody["_id"] as String)
+        assertEquals("Version not incremented", (originalMonitor.version + 1).toInt(), responseBody["_version"] as Int)
+
+        val updatedMonitor = getMonitor(originalMonitor.id)
+        assertPplMonitorsEqual(newMonitorConfig, updatedMonitor)
+    }
+
+    fun `test get ppl monitor`() {
+        // first create the monitor
+        createIndex(TEST_INDEX_NAME, Settings.EMPTY, TEST_INDEX_MAPPINGS)
+        val pplMonitor = randomPPLMonitor()
+
+        val createResponse = client().makeRequest("POST", MONITOR_BASE_URI, emptyMap(), pplMonitor.toHttpEntity())
+        assertEquals("Unable to create a new monitor v2", RestStatus.CREATED, createResponse.restStatus())
+
+        val responseBody = createResponse.asMap()
+        val pplMonitorId = responseBody["_id"] as String
+        val pplMonitorVersion = (responseBody["_version"] as Int).toLong()
+
+        // then attempt to get it
+        val response = client().makeRequest("GET", "$MONITOR_BASE_URI/$pplMonitorId")
+        assertEquals("Unable to get monitorV2 $pplMonitorId", RestStatus.OK, response.restStatus())
+
+        val parser = createParser(XContentType.JSON.xContent(), response.entity.content)
+        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser)
+
+        lateinit var id: String
+        var version: Long = 0
+        lateinit var storedPplMonitor: Monitor
+
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            parser.nextToken()
+
+            when (parser.currentName()) {
+                "_id" -> id = parser.text()
+                "_version" -> version = parser.longValue()
+                "monitor" -> storedPplMonitor = Monitor.parse(parser)
+                "associated_workflows" -> {
+                    XContentParserUtils.ensureExpectedToken(
+                        XContentParser.Token.START_ARRAY,
+                        parser.currentToken(),
+                        parser
+                    )
+                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                        // do nothing
+                    }
+                }
+            }
+        }
+
+        assertEquals(
+            "Monitor V2 ID from Get Monitor doesn't match one from Create Monitor response",
+            pplMonitorId, id
+        )
+        assertEquals(
+            "Monitor V2 version from Get Monitor doesn't match one from Create Monitor response",
+            pplMonitorVersion, version
+        )
+        assertPplMonitorsEqual(pplMonitor, storedPplMonitor)
+    }
+
+    fun `test head ppl monitor`() {
+        val submittedPplMonitor = createRandomPPLMonitor()
+        val response = client().makeRequest("HEAD", "$MONITOR_BASE_URI/${submittedPplMonitor.id}")
+        assertEquals("Unable to get monitorV2 ${submittedPplMonitor.id}", RestStatus.OK, response.restStatus())
+    }
+
+    fun `test search ppl monitor with GET and match_all`() {
+        createRandomPPLMonitor()
+
+        val search = SearchSourceBuilder().query(QueryBuilders.matchAllQuery()).toString()
+        val searchResponse = client().makeRequest(
+            "GET", "$MONITOR_BASE_URI/_search",
+            emptyMap(), StringEntity(search, ContentType.APPLICATION_JSON)
+        )
+
+        assertEquals("Search monitor failed", RestStatus.OK, searchResponse.restStatus())
+        val xcp = createParser(XContentType.JSON.xContent(), searchResponse.entity.content)
+        val hits = xcp.map()["hits"]!! as Map<String, Map<String, Any>>
+        val numberDocsFound = hits["total"]?.get("value")
+        assertEquals("PPL Monitor not found during search", 1, numberDocsFound)
+    }
+
+    fun `test search ppl monitor with POST and term query on ID`() {
+        val pplMonitor = createRandomPPLMonitor()
+
+        val search = SearchSourceBuilder().query(QueryBuilders.termQuery("_id", pplMonitor.id)).toString()
+        val searchResponse = client().makeRequest(
+            "POST", "$MONITOR_BASE_URI/_search",
+            emptyMap(), StringEntity(search, ContentType.APPLICATION_JSON)
+        )
+
+        assertEquals("Search monitor failed", RestStatus.OK, searchResponse.restStatus())
+        val xcp = createParser(XContentType.JSON.xContent(), searchResponse.entity.content)
+        val hits = xcp.map()["hits"]!! as Map<String, Map<String, Any>>
+        val numberDocsFound = hits["total"]?.get("value")
+        assertEquals("PPL Monitor not found during search", 1, numberDocsFound)
+    }
+
+    fun `test delete ppl monitor`() {
+        val pplMonitor = createRandomPPLMonitor()
+
+        val deleteResponse = client().makeRequest("DELETE", "$MONITOR_BASE_URI/${pplMonitor.id}")
+        assertEquals("Delete failed", RestStatus.OK, deleteResponse.restStatus())
+
+        val getResponse = client().makeRequest("HEAD", "$MONITOR_BASE_URI/${pplMonitor.id}")
+        assertEquals("Deleted monitor still exists", RestStatus.NOT_FOUND, getResponse.restStatus())
+    }
+
+    fun `test parsing ppl monitor as a scheduled job`() {
+        val monitorV2 = createRandomPPLMonitor()
+
+        val builder = monitorV2.toXContentWithUser(XContentBuilder.builder(XContentType.JSON.xContent()), USE_TYPED_KEYS)
+        val string = BytesReference.bytes(builder).utf8ToString()
+        val xcp = createParser(XContentType.JSON.xContent(), string)
+        val scheduledJob = ScheduledJob.parse(xcp, monitorV2.id, monitorV2.version)
+        assertEquals(monitorV2, scheduledJob)
+    }
+
+    /* PPL Monitor Validation Tests */
+    fun `test create ppl monitor that queries nonexistent index fails`() {
+        val pplMonitorConfig = randomPPLMonitor(
+            query = "source = nonexistent_index | head 10"
+        )
+
+        // ensure the request fails
+        try {
+            createRandomPPLMonitor(pplMonitorConfig)
+            fail("Expected request to fail with BAD_REQUEST but it succeeded")
+        } catch (e: ResponseException) {
+            assertEquals("Unexpected status", RestStatus.BAD_REQUEST, e.response.restStatus())
+        }
+
+        // ensure no monitor was created
+        ensureNumMonitors(0)
+    }
+
+    fun `test create ppl monitor with more than max allowed monitors fails`() {
+        adminClient().updateSettings(ALERTING_MAX_MONITORS.key, 1)
+
+        createRandomPPLMonitor()
+
+        // ensure the request fails
+        try {
+            createRandomPPLMonitor()
+            fail("Expected request to fail with BAD_REQUEST but it succeeded")
+        } catch (e: ResponseException) {
+            assertEquals("Unexpected status", RestStatus.BAD_REQUEST, e.response.restStatus())
+        }
+
+        // ensure no monitor was created
+        ensureNumMonitors(1)
+    }
+
+    fun `test create ppl monitor with invalid query fails`() {
+        // ensure the request fails
+        try {
+            createRandomPPLMonitor(
+                randomPPLMonitor(
+                    query = "source = $TEST_INDEX_NAME | not valid ppl"
+                )
+            )
+            fail("Expected request to fail with BAD_REQUEST but it succeeded")
+        } catch (e: ResponseException) {
+            assertEquals("Unexpected status", RestStatus.BAD_REQUEST, e.response.restStatus())
+        }
+
+        // ensure no monitor was created
+        ensureNumMonitors(0)
+    }
+
+    fun `test create ppl monitor with query that's too long fails`() {
+        adminClient().updateSettings(PPL_MAX_QUERY_LENGTH.key, 1)
+
+        // ensure the request fails
+        try {
+            createRandomPPLMonitor(
+                randomPPLMonitor(
+                    query = "source = $TEST_INDEX_NAME | head 10"
+                )
+            )
+            fail("Expected request to fail with BAD_REQUEST but it succeeded")
+        } catch (e: ResponseException) {
+            assertEquals("Unexpected status", RestStatus.BAD_REQUEST, e.response.restStatus())
+        }
+
+        // ensure no monitor was created
+        ensureNumMonitors(0)
+    }
+
+    fun `test create ppl monitor with invalid custom condition fails`() {
+        // ensure the request fails
+        try {
+            createRandomPPLMonitor(
+                randomPPLMonitor(
+                    triggers = listOf(
+                        randomPPLTrigger(
+                            conditionType = ConditionType.CUSTOM,
+                            customCondition = "eval result = 3 > 1",
+                            numResultsCondition = null,
+                            numResultsValue = null
+                        )
+                    ),
+                    query = "source = $TEST_INDEX_NAME | head 10"
+                )
+            )
+            fail("Expected request to fail with BAD_REQUEST but it succeeded")
+        } catch (e: ResponseException) {
+            assertEquals("Unexpected status", RestStatus.BAD_REQUEST, e.response.restStatus())
+        }
+
+        // ensure no monitor was created
+        ensureNumMonitors(0)
+    }
+
+    fun `test create ppl monitor with notification subject source too long fails`() {
+        adminClient().updateSettings(NOTIFICATION_SUBJECT_SOURCE_MAX_LENGTH.key, 100)
+
+        var subjectTooLong = ""
+        for (i in 0 until 101) {
+            subjectTooLong += "a"
+        }
+
+        // ensure the request fails
+        try {
+            createRandomPPLMonitor(
+                randomPPLMonitor(
+                    triggers = listOf(
+                        randomPPLTrigger(
+                            actions = listOf(
+                                randomAction(
+                                    template = randomTemplateScript(
+                                        source = "some message"
+                                    ),
+                                    subjectTemplate = randomTemplateScript(
+                                        source = subjectTooLong
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+            fail("Expected request to fail with BAD_REQUEST but it succeeded")
+        } catch (e: ResponseException) {
+            assertEquals("Unexpected status", RestStatus.BAD_REQUEST, e.response.restStatus())
+        }
+
+        // ensure no monitor was created
+        ensureNumMonitors(0)
+    }
+
+    fun `test create ppl monitor with notification message source too long fails`() {
+        adminClient().updateSettings(NOTIFICATION_MESSAGE_SOURCE_MAX_LENGTH.key, 1000)
+
+        var messageTooLong = ""
+        for (i in 0 until 1001) {
+            messageTooLong += "a"
+        }
+
+        // ensure the request fails
+        try {
+            createRandomPPLMonitor(
+                randomPPLMonitor(
+                    triggers = listOf(
+                        randomPPLTrigger(
+                            actions = listOf(
+                                randomAction(
+                                    template = randomTemplateScript(
+                                        source = messageTooLong
+                                    ),
+                                    subjectTemplate = randomTemplateScript(
+                                        source = "some subject"
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+            fail("Expected request to fail with BAD_REQUEST but it succeeded")
+        } catch (e: ResponseException) {
+            assertEquals("Unexpected status", RestStatus.BAD_REQUEST, e.response.restStatus())
+        }
+
+        // ensure no monitor was created
+        ensureNumMonitors(0)
+    }
+
+    fun `test update nonexistent ppl monitor fails`() {
+        // the random monitor query searches index TEST_INDEX_NAME,
+        // so we need to create that first to ensure at least the request body is valid
+        createIndex(TEST_INDEX_NAME, Settings.EMPTY, TEST_INDEX_MAPPINGS)
+
+        val monitorV2 = randomPPLMonitor()
+        val randomId = UUIDs.base64UUID()
+
+        try {
+            client().makeRequest("PUT", "$MONITOR_BASE_URI/$randomId", emptyMap(), monitorV2.toHttpEntity())
+            fail("Expected request to fail with NOT_FOUND but it succeeded")
+        } catch (e: ResponseException) {
+            assertEquals("Unexpected status", RestStatus.NOT_FOUND, e.response.restStatus())
+        }
+    }
+
+    fun `test delete nonexistent ppl monitor fails`() {
+        val randomId = UUIDs.base64UUID()
+
+        try {
+            client().makeRequest("DELETE", "$MONITOR_BASE_URI/$randomId")
+            fail("Expected request to fail with NOT_FOUND but it succeeded")
+        } catch (e: ResponseException) {
+            assertEquals("Unexpected status", RestStatus.NOT_FOUND, e.response.restStatus())
+        }
     }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -40,6 +40,8 @@ import org.opensearch.alerting.randomAlert
 import org.opensearch.alerting.randomBucketLevelMonitor
 import org.opensearch.alerting.randomBucketLevelTrigger
 import org.opensearch.alerting.randomDocumentLevelMonitor
+import org.opensearch.alerting.randomPPLMonitor
+import org.opensearch.alerting.randomPPLTrigger
 import org.opensearch.alerting.randomQueryLevelMonitor
 import org.opensearch.alerting.randomQueryLevelTrigger
 import org.opensearch.alerting.randomTemplateScript
@@ -53,6 +55,7 @@ import org.opensearch.common.xcontent.json.JsonXContent
 import org.opensearch.commons.alerting.aggregation.bucketselectorext.BucketSelectorExtAggregationBuilder
 import org.opensearch.commons.alerting.model.Alert
 import org.opensearch.commons.alerting.model.DocLevelMonitorInput
+import org.opensearch.commons.alerting.model.PPLTrigger
 import org.opensearch.commons.alerting.model.SearchInput
 import org.opensearch.commons.authuser.User
 import org.opensearch.commons.rest.SecureRestClientBuilder
@@ -1641,6 +1644,44 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
             assertEquals("Monitors found. Clean up unsuccessful", 0, numberDocsFound)
         } finally {
             deleteRoleAndRoleMapping(ALERTING_INDEX_MONITOR_ACCESS)
+        }
+    }
+
+    fun `test create PPL monitor fails when user lacks index permissions`() {
+        // Create a user with alerting permissions but only access to TEST_HR_INDEX
+        createUserWithTestDataAndCustomRole(
+            user,
+            TEST_HR_INDEX,
+            TEST_HR_ROLE,
+            listOf(TEST_HR_BACKEND_ROLE),
+            getClusterPermissionsFromCustomRole(ALERTING_INDEX_MONITOR_ACCESS)
+        )
+        try {
+            // Create a PPL monitor targeting TEST_NON_HR_INDEX which the user does NOT have access to
+            val monitor = randomPPLMonitor(
+                triggers = listOf(
+                    randomPPLTrigger(
+                        conditionType = PPLTrigger.ConditionType.NUMBER_OF_RESULTS,
+                        numResultsCondition = PPLTrigger.NumResultsCondition.GREATER_THAN,
+                        numResultsValue = 0L,
+                        customCondition = null
+                    )
+                ),
+                query = "source = $TEST_NON_HR_INDEX | head 10"
+            )
+
+            // Attempt to create the monitor — should fail because the user
+            // doesn't have read permissions on TEST_NON_HR_INDEX.
+            // PPL alerting validates index permissions at creation time via
+            // the SQL plugin's explain API.
+            try {
+                userClient?.makeRequest("POST", ALERTING_BASE_URI, emptyMap(), monitor.toHttpEntity())
+                fail("Expected create PPL monitor to fail due to missing index permissions")
+            } catch (e: ResponseException) {
+                assertEquals("Should be Bad Request", RestStatus.BAD_REQUEST.status, e.response.statusLine.statusCode)
+            }
+        } finally {
+            deleteRoleAndRoleMapping(TEST_HR_ROLE)
         }
     }
 }


### PR DESCRIPTION
* PPL Alerting: Create, Read, Update, Delete



* adding AlertingRestTestCase changes



* adding TestHelpers changes



* removing various vestiges of older implementations, simplifying thread allocation to thread dispatch



* adding Security IT for lacking index permissions in PPL query



* misc changes



* refactoring index ppl monitor to validate query with callback instead of suspend logic



---------



(cherry picked from commit 629ac1e8cdfedb330410ce652f52f4a278a3e102)

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
