### PR TITLE
Update test-workflow.yml to refresh dependencies per execution

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build and run with Gradle
         run: |
           chown -R 1000:1000 `pwd`
-          su `id -un 1000` -c "whoami && java -version && ./gradlew assemble integTest"
+          su `id -un 1000` -c "whoami && java -version && ./gradlew assemble integTest --refresh-dependencies"
 
       - name: Create Artifact Path
         run: |


### PR DESCRIPTION
Backports merged to common utils aren't immediately picked up by alerting backport CIs because the gradle cache doesn't always immediately refresh. This change addresses that by adding `--refresh-dependencies` arg to the workflow run command.

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
