### PR TITLE
feat: Propagate tenant headers for remote monitor execution

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertingPlugin.kt
@@ -389,6 +389,10 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             AlertingSettings.JOB_QUEUE_NAME.get(settings) ?: "",
             AlertingSettings.TARGET_TYPE_TO_SERVICE_NAME.get(settings).let {
                 it.keySet().associateWith { key -> it.get(key) }
+            },
+            AlertingSettings.TENANT_ACCOUNT_ID_HEADER.get(settings) ?: "",
+            AlertingSettings.TENANT_RESOURCE_ID_HEADER.get(settings).let {
+                it.keySet().associateWith { key -> it.get(key) }
             }
         )
 
@@ -519,7 +523,9 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
             AlertingSettings.EXTERNAL_SCHEDULER_EXECUTION_ROLE_NAME,
             AlertingSettings.JOB_QUEUE_ACCOUNT_ID,
             AlertingSettings.JOB_QUEUE_ACCOUNT_PROVIDER_TYPE,
-            AlertingSettings.TARGET_TYPE_TO_SERVICE_NAME
+            AlertingSettings.TARGET_TYPE_TO_SERVICE_NAME,
+            AlertingSettings.TENANT_ACCOUNT_ID_HEADER,
+            AlertingSettings.TENANT_RESOURCE_ID_HEADER
         )
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/BucketLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/BucketLevelMonitorRunner.kt
@@ -140,6 +140,7 @@ object BucketLevelMonitorRunner : MonitorRunner() {
                     monitor.user
                 )
             ) {
+                reinjectHeaders(monitor, monitorCtx)
                 // Storing the first page of results in the case of pagination input results to prevent empty results
                 // in the final output of monitorResult which occurs when all pages have been exhausted.
                 // If it's favorable to return the last page, will need to check how to accomplish that with multiple aggregation paths

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunner.kt
@@ -9,6 +9,9 @@ import org.opensearch.alerting.opensearchapi.InjectorContextElement
 import org.opensearch.alerting.opensearchapi.withClosableContext
 import org.opensearch.alerting.script.QueryLevelTriggerExecutionContext
 import org.opensearch.alerting.script.TriggerExecutionContext
+import org.opensearch.alerting.service.MonitorJobPoller
+import org.opensearch.alerting.settings.AlertingSettings
+import org.opensearch.alerting.util.ArnHelper
 import org.opensearch.alerting.util.getConfigAndSendNotification
 import org.opensearch.alerting.util.use
 import org.opensearch.commons.ConfigConstants
@@ -83,6 +86,40 @@ abstract class MonitorRunner {
             ActionRunResult(action.id, action.name, actionOutput, false, MonitorRunnerService.currentTime(), null)
         } catch (e: Exception) {
             ActionRunResult(action.id, action.name, mapOf(), false, MonitorRunnerService.currentTime(), e)
+        }
+    }
+
+    protected fun reinjectHeaders(monitor: Monitor, monitorCtx: MonitorRunnerExecutionContext) {
+        val target = monitor.target ?: return
+        val threadContext = monitorCtx.client!!.threadPool().threadContext
+        val settings = monitorCtx.settings!!
+
+        if (threadContext.getHeader(MonitorJobPoller.IS_BACKGROUND_JOB_HEADER) == null) {
+            threadContext.putHeader(MonitorJobPoller.IS_BACKGROUND_JOB_HEADER, "true")
+        }
+        if (threadContext.getHeader(MonitorJobPoller.OPENSEARCH_ENDPOINT_HEADER) == null) {
+            threadContext.putHeader(MonitorJobPoller.OPENSEARCH_ENDPOINT_HEADER, target.endpoint)
+        }
+        if (threadContext.getHeader(MonitorJobPoller.SERVICE_NAME_HEADER) == null) {
+            val serviceNameMap = AlertingSettings.TARGET_TYPE_TO_SERVICE_NAME.get(settings)
+                .let { it.keySet().associateWith { key -> it.get(key) } }
+            threadContext.putHeader(MonitorJobPoller.SERVICE_NAME_HEADER, serviceNameMap[target.type] ?: target.type)
+        }
+        if (threadContext.getHeader(MonitorJobPoller.REGION_HEADER) == null) {
+            threadContext.putHeader(MonitorJobPoller.REGION_HEADER, AlertingSettings.REMOTE_METADATA_REGION.get(settings) ?: "")
+        }
+
+        if (target.arn.isNotBlank()) {
+            val (accountId, resourceId) = ArnHelper.parseArn(target.arn)
+            val accountHeader = AlertingSettings.TENANT_ACCOUNT_ID_HEADER.get(settings) ?: ""
+            if (accountHeader.isNotEmpty() && threadContext.getTransient<String>(accountHeader) == null) {
+                threadContext.putTransient(accountHeader, accountId)
+            }
+            val resourceHeaders = AlertingSettings.TENANT_RESOURCE_ID_HEADER.get(settings)
+            val resourceHeader = resourceHeaders?.get(target.type)
+            if (!resourceHeader.isNullOrEmpty() && threadContext.getTransient<String>(resourceHeader) == null) {
+                threadContext.putTransient(resourceHeader, resourceId)
+            }
         }
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/QueryLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/QueryLevelMonitorRunner.kt
@@ -66,6 +66,7 @@ object QueryLevelMonitorRunner : MonitorRunner() {
                     monitor.user
                 )
             ) {
+                reinjectHeaders(monitor, monitorCtx)
                 monitorResult = monitorResult.copy(
                     inputResults = monitorCtx.inputService!!.collectInputResults(monitor, periodStart, periodEnd, null, workflowRunContext)
                 )
@@ -86,6 +87,7 @@ object QueryLevelMonitorRunner : MonitorRunner() {
             Monitor.MonitorType.valueOf(monitor.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.QUERY_LEVEL_MONITOR &&
             monitorResult.inputResults.results.isNotEmpty()
         ) {
+            reinjectHeaders(monitor, monitorCtx)
             val searchInput = monitor.inputs[0] as SearchInput
             val queryLevelTriggers = monitor.triggers.filterIsInstance<QueryLevelTrigger>()
             RemoteQueryLevelTriggerEvaluator.evaluate(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/service/MonitorJobPoller.kt
@@ -17,6 +17,7 @@ import org.opensearch.alerting.action.ExecuteMonitorAction
 import org.opensearch.alerting.action.ExecuteMonitorRequest
 import org.opensearch.alerting.action.ExecuteMonitorResponse
 import org.opensearch.alerting.opensearchapi.suspendUntil
+import org.opensearch.alerting.util.ArnHelper
 import org.opensearch.common.lifecycle.AbstractLifecycleComponent
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
@@ -51,7 +52,9 @@ class MonitorJobPoller(
     private val accountIdProvider: JobQueueAccountIdProvider?,
     private val region: String,
     private val queueName: String,
-    private val targetTypeToServiceName: Map<String, String>
+    private val targetTypeToServiceName: Map<String, String>,
+    private val tenantAccountIdHeaderName: String = "",
+    private val tenantResourceIdHeaderNames: Map<String, String> = emptyMap()
 ) : AbstractLifecycleComponent() {
 
     private val logger = LogManager.getLogger(MonitorJobPoller::class.java)
@@ -248,6 +251,19 @@ class MonitorJobPoller(
         val tenantId = monitor.metadata?.get(AlertingPlugin.TENANT_ID_METADATA_KEY)
         if (!tenantId.isNullOrEmpty()) {
             threadContext.putHeader(AlertingPlugin.TENANT_ID_HEADER, tenantId)
+        }
+
+        // Set transient headers for account ID and resource ID parsed from target ARN.
+        // to route the search request to the correct remote data source.
+        if (target.arn.isNotBlank()) {
+            val (accountId, resourceId) = ArnHelper.parseArn(target.arn)
+            if (tenantAccountIdHeaderName.isNotEmpty()) {
+                threadContext.putTransient(tenantAccountIdHeaderName, accountId)
+            }
+            val resourceHeader = tenantResourceIdHeaderNames[target.type]
+            if (!resourceHeader.isNullOrEmpty()) {
+                threadContext.putTransient(resourceHeader, resourceId)
+            }
         }
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
@@ -461,5 +461,19 @@ class AlertingSettings {
             "plugins.alerting.monitor.target_type_to_service_name.",
             Setting.Property.NodeScope, Setting.Property.Dynamic
         )
+
+        /** Header name used to propagate the account ID parsed from the monitor target ARN
+         * into the thread context as a transient header. */
+        val TENANT_ACCOUNT_ID_HEADER = Setting.simpleString(
+            "plugins.alerting.tenant.account_id_header",
+            Setting.Property.NodeScope, Setting.Property.Dynamic
+        )
+
+        /** Mappings from Monitor target type to the header name used to propagate the resource ID
+         * (collection ID or domain name) parsed from the monitor target ARN. */
+        val TENANT_RESOURCE_ID_HEADER = Setting.groupSetting(
+            "plugins.alerting.tenant.resource_id_header.",
+            Setting.Property.NodeScope, Setting.Property.Dynamic
+        )
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -49,6 +49,7 @@ import org.opensearch.alerting.settings.AlertingSettings.Companion.PPL_MAX_QUERY
 import org.opensearch.alerting.settings.AlertingSettings.Companion.PPL_QUERY_RESULTS_MAX_DATAROWS
 import org.opensearch.alerting.settings.AlertingSettings.Companion.REQUEST_TIMEOUT
 import org.opensearch.alerting.settings.DestinationSettings.Companion.ALLOW_LIST
+import org.opensearch.alerting.util.ArnValidator
 import org.opensearch.alerting.util.DocLevelMonitorQueries
 import org.opensearch.alerting.util.IndexUtils
 import org.opensearch.alerting.util.addUserBackendRolesFilter
@@ -683,6 +684,7 @@ class TransportIndexMonitorAction @Inject constructor(
             try {
                 validateActionThrottle(request.monitor, maxActionThrottle, TimeValue.timeValueMinutes(1))
                 validateTriggerCount(request.monitor)
+                ArnValidator.validateTargetArn(request.monitor.target)
             } catch (e: RuntimeException) {
                 actionListener.onFailure(AlertingException.wrap(e))
                 return

--- a/alerting/src/main/kotlin/org/opensearch/alerting/trigger/RemoteQueryLevelTriggerEvaluator.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/trigger/RemoteQueryLevelTriggerEvaluator.kt
@@ -123,7 +123,7 @@ object RemoteQueryLevelTriggerEvaluator {
     ): Map<String, Boolean> {
         return triggerIds.associateWith { triggerId ->
             val aggKey = "$TRIGGER_AGG_PREFIX$triggerId"
-            val aggResult = aggResults[aggKey]
+            val aggResult = aggResults.entries.firstOrNull { it.key.endsWith(aggKey) }?.value
             if (aggResult == null) {
                 logger.warn("Missing evaluation result for trigger $triggerId, defaulting to not triggered")
                 false

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/ArnHelper.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/ArnHelper.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.util
+
+import software.amazon.awssdk.arns.Arn
+
+/**
+ * Consolidated ARN parsing utility using the AWS SDK v2 [Arn] parser.
+ */
+object ArnHelper {
+
+    /**
+     * Parses an ARN string and returns the account ID and resource ID.
+     * @throws IllegalArgumentException if the ARN is malformed, missing account ID, or missing resource.
+     */
+    fun parseArn(arn: String): Pair<String, String> {
+        val parsed = try {
+            Arn.fromString(arn)
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Invalid ARN format: $arn", e)
+        }
+        val accountId = parsed.accountId()
+            .orElseThrow { IllegalArgumentException("Missing account ID in ARN: $arn") }
+        require(accountId.isNotBlank()) { "Blank account ID in ARN: $arn" }
+        val resource = parsed.resourceAsString()
+        require(resource.isNotBlank()) { "Missing resource in ARN: $arn" }
+        val resourceId = resource.substringAfter("/")
+        return accountId to resourceId
+    }
+}

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/ArnValidator.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/ArnValidator.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.util
+
+import org.opensearch.OpenSearchStatusException
+import org.opensearch.commons.alerting.model.Target
+import org.opensearch.core.rest.RestStatus
+
+/**
+ * Validates the ARN in a monitor's [Target] using [ArnHelper].
+ * Throws [OpenSearchStatusException] with 400 status if the ARN is invalid.
+ */
+object ArnValidator {
+
+    fun validateTargetArn(target: Target?) {
+        if (target == null || target.type == Target.LOCAL) return
+        if (target.arn.isBlank()) {
+            throw OpenSearchStatusException(
+                "target.arn is required when target type is not LOCAL",
+                RestStatus.BAD_REQUEST
+            )
+        }
+        try {
+            ArnHelper.parseArn(target.arn)
+        } catch (e: IllegalArgumentException) {
+            throw OpenSearchStatusException(
+                "target.arn is not a valid ARN: ${target.arn}",
+                RestStatus.BAD_REQUEST
+            )
+        }
+    }
+}

--- a/alerting/src/test/kotlin/org/opensearch/alerting/service/MonitorJobPollerTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/service/MonitorJobPollerTests.kt
@@ -9,6 +9,7 @@ import com.carrotsearch.randomizedtesting.ThreadFilter
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
+import org.opensearch.alerting.util.ArnHelper
 import org.opensearch.common.settings.Settings
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.SearchInput
@@ -376,14 +377,21 @@ class MonitorJobPollerTests : OpenSearchTestCase() {
         )
 
         val mockTargetType = mappingProvider().entries.first().key
-        val target = Target(type = mockTargetType, endpoint = "https://test.aoss.amazonaws.com")
+        val target = Target(
+            type = mockTargetType,
+            endpoint = "https://my-domain.us-west-2.es.amazonaws.com",
+            arn = "arn:aws:es:us-west-2:123456789012:domain/my-domain"
+        )
         val monitor = org.opensearch.alerting.randomQueryLevelMonitor().copy(target = target)
 
         poller.populateThreadContext(monitor)
 
         assertEquals("true", mockThreadContext.getHeader(MonitorJobPoller.IS_BACKGROUND_JOB_HEADER))
         assertEquals(mappingProvider()[mockTargetType], mockThreadContext.getHeader(MonitorJobPoller.SERVICE_NAME_HEADER))
-        assertEquals("https://test.aoss.amazonaws.com", mockThreadContext.getHeader(MonitorJobPoller.OPENSEARCH_ENDPOINT_HEADER))
+        assertEquals(
+            "https://my-domain.us-west-2.es.amazonaws.com",
+            mockThreadContext.getHeader(MonitorJobPoller.OPENSEARCH_ENDPOINT_HEADER)
+        )
         assertEquals("us-east-1", mockThreadContext.getHeader(MonitorJobPoller.REGION_HEADER))
 
         poller.close()
@@ -398,12 +406,100 @@ class MonitorJobPollerTests : OpenSearchTestCase() {
             mappingProvider()
         )
 
-        val target = Target(type = "non_existent_type", endpoint = "https://test.aoss.amazonaws.com")
+        val target = Target(
+            type = "non_existent_type",
+            endpoint = "https://my-domain.us-west-2.es.amazonaws.com",
+            arn = "arn:aws:es:us-west-2:123456789012:domain/my-domain"
+        )
         val monitor = org.opensearch.alerting.randomQueryLevelMonitor().copy(target = target)
 
         expectThrows(Exception::class.java) {
             poller.populateThreadContext(monitor)
         }
+
+        poller.close()
+    }
+
+    fun `test ArnHelper parseArn extracts account and resource from domain ARN`() {
+        val (accountId, resourceId) = ArnHelper.parseArn(
+            "arn:aws:es:us-west-2:790849549214:domain/test-domain"
+        )
+        assertEquals("790849549214", accountId)
+        assertEquals("test-domain", resourceId)
+    }
+
+    fun `test ArnHelper parseArn extracts account and resource from AOS ARN`() {
+        val (accountId, resourceId) = ArnHelper.parseArn(
+            "arn:aws:es:us-east-1:123456789012:domain/my-domain"
+        )
+        assertEquals("123456789012", accountId)
+        assertEquals("my-domain", resourceId)
+    }
+
+    fun `test ArnHelper parseArn throws on invalid ARN`() {
+        expectThrows(IllegalArgumentException::class.java) {
+            ArnHelper.parseArn("not-an-arn")
+        }
+    }
+
+    fun `test populateThreadContext sets transient headers from ARN`() {
+        val mockClient = mockClient()
+        val mockThreadPool = mock(org.opensearch.threadpool.ThreadPool::class.java)
+        val mockThreadContext = org.opensearch.common.util.concurrent.ThreadContext(Settings.EMPTY)
+
+        `when`(mockClient.threadPool()).thenReturn(mockThreadPool)
+        `when`(mockThreadPool.threadContext).thenReturn(mockThreadContext)
+
+        val poller = MonitorJobPoller(
+            testXContentRegistry(), mockClient, true,
+            testAccountIdProvider(), "us-east-1", "test-queue",
+            mappingProvider(),
+            tenantAccountIdHeaderName = "x-account-id",
+            tenantResourceIdHeaderNames = mapOf("target_1" to "x-resource-id")
+        )
+
+        val target = Target(
+            type = "target_1",
+            endpoint = "https://my-domain.us-west-2.es.amazonaws.com",
+            arn = "arn:aws:es:us-west-2:790849549214:domain/test-domain"
+        )
+        val monitor = org.opensearch.alerting.randomQueryLevelMonitor().copy(target = target)
+
+        poller.populateThreadContext(monitor)
+
+        assertEquals("790849549214", mockThreadContext.getTransient<String>("x-account-id"))
+        assertEquals("test-domain", mockThreadContext.getTransient<String>("x-resource-id"))
+
+        poller.close()
+    }
+
+    fun `test populateThreadContext skips transient headers when settings empty`() {
+        val mockClient = mockClient()
+        val mockThreadPool = mock(org.opensearch.threadpool.ThreadPool::class.java)
+        val mockThreadContext = org.opensearch.common.util.concurrent.ThreadContext(Settings.EMPTY)
+
+        `when`(mockClient.threadPool()).thenReturn(mockThreadPool)
+        `when`(mockThreadPool.threadContext).thenReturn(mockThreadContext)
+
+        val poller = MonitorJobPoller(
+            testXContentRegistry(), mockClient, true,
+            testAccountIdProvider(), "us-east-1", "test-queue",
+            mappingProvider(),
+            tenantAccountIdHeaderName = "",
+            tenantResourceIdHeaderNames = emptyMap()
+        )
+
+        val target = Target(
+            type = "target_1",
+            endpoint = "https://my-domain.us-west-2.es.amazonaws.com",
+            arn = "arn:aws:es:us-west-2:790849549214:domain/test-domain"
+        )
+        val monitor = org.opensearch.alerting.randomQueryLevelMonitor().copy(target = target)
+
+        poller.populateThreadContext(monitor)
+
+        assertNull(mockThreadContext.getTransient<String>("x-account-id"))
+        assertNull(mockThreadContext.getTransient<String>("x-resource-id"))
 
         poller.close()
     }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/util/ArnValidatorTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/util/ArnValidatorTests.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.util
+
+import org.opensearch.OpenSearchStatusException
+import org.opensearch.commons.alerting.model.Target
+import org.opensearch.test.OpenSearchTestCase
+
+class ArnValidatorTests : OpenSearchTestCase() {
+
+    fun `test valid AOS domain ARN passes validation`() {
+        val target = Target(
+            "AOS_DOMAIN",
+            "https://my-domain.us-west-2.es.amazonaws.com",
+            "arn:aws:es:us-west-2:123456789012:domain/my-domain"
+        )
+        ArnValidator.validateTargetArn(target)
+    }
+
+    fun `test valid ARN with govcloud partition passes validation`() {
+        val target = Target(
+            "AOS_DOMAIN",
+            "https://my-domain.us-gov-west-1.es.amazonaws.com",
+            "arn:aws-us-gov:es:us-gov-west-1:123456789012:domain/my-domain"
+        )
+        ArnValidator.validateTargetArn(target)
+    }
+
+    fun `test null target passes validation`() {
+        ArnValidator.validateTargetArn(null)
+    }
+
+    fun `test LOCAL target skips validation`() {
+        val target = Target(Target.LOCAL, "", "")
+        ArnValidator.validateTargetArn(target)
+    }
+
+    fun `test blank arn for non-LOCAL target throws at construction`() {
+        // Target init block rejects blank/whitespace arn for non-LOCAL types
+        expectThrows(IllegalArgumentException::class.java) {
+            Target("AOS_DOMAIN", "https://my-domain.us-west-2.es.amazonaws.com", "")
+        }
+    }
+
+    fun `test malformed arn throws`() {
+        val target = Target("AOS_DOMAIN", "https://my-domain.us-west-2.es.amazonaws.com", "not-an-arn")
+        expectThrows(OpenSearchStatusException::class.java) {
+            ArnValidator.validateTargetArn(target)
+        }
+    }
+
+    fun `test arn missing account ID throws`() {
+        val target = Target("AOS_DOMAIN", "https://my-domain.us-west-2.es.amazonaws.com", "arn:aws:es:us-west-2::domain/my-domain")
+        expectThrows(OpenSearchStatusException::class.java) {
+            ArnValidator.validateTargetArn(target)
+        }
+    }
+
+    fun `test arn missing resource throws`() {
+        val target = Target("AOS_DOMAIN", "https://my-domain.us-west-2.es.amazonaws.com", "arn:aws:es:us-west-2:123456789012:")
+        expectThrows(OpenSearchStatusException::class.java) {
+            ArnValidator.validateTargetArn(target)
+        }
+    }
+}


### PR DESCRIPTION
Parse monitor target ARN to extract account ID and resource ID, then set them as thread context headers so search requests can be routed to the correct remote data source.

Changes:
- Add plugins.alerting.tenant.account_id_header setting
- Add plugins.alerting.tenant.resource_id_header.<TYPE> group setting
- Add ARN parsing and putTransient() in MonitorJobPoller.populateThreadContext
- Add reinjectHeaders() in QueryLevelMonitorRunner and BucketLevelMonitorRunner to re-set headers inside withClosableContext
- Add ArnValidator for create monitor request validation
- Fix RemoteQueryLevelTriggerEvaluator to handle typed_keys agg key prefix
- Register new settings in AlertingPlugin.getSettings()
- Add tests for ARN parsing and tenant header propagation

