### PR TITLE
Fix/workflow validation ~10 delegation monitor limit

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
@@ -748,7 +748,7 @@ class TransportIndexWorkflowAction @Inject constructor(
         val compositeInput = request.workflow.inputs[0] as CompositeInput
         val monitorIds = compositeInput.sequence.delegates.stream().map { it.monitorId }.collect(Collectors.toList())
         val query = QueryBuilders.boolQuery().filter(QueryBuilders.termsQuery("_id", monitorIds))
-        val searchSource = SearchSourceBuilder().query(query)
+        val searchSource = SearchSourceBuilder().query(query).size(monitorIds.size)
         val searchRequest = SearchRequest(SCHEDULED_JOBS_INDEX).source(searchSource)
 
         if (user != null && !isAdmin(user) && filterByEnabled) {


### PR DESCRIPTION
### Description

This PR fixes a bug in workflow validation where creating a Security Analytics detector with more than 10 rules fails with an "invalid monitor ids" error (#2144).

**Root Cause:**
The `validateMonitorAccess()` function in `TransportIndexWorkflowAction.kt` was not setting an explicit size parameter on the search query. This caused OpenSearch to default to returning only the first 10 results. When a [Security Analytics](https://github.com/opensearch-project/security-analytics) detector referenced more than 10 rules (generating more than 10 delegate monitors), the validation would incorrectly report that the additional monitor IDs were invalid.

**The Fix:**
Added `.size(monitorIds.size)` to the `SearchSourceBuilder` on line 716 to ensure all delegate monitor IDs are returned and validated correctly.

**Code Change:**
```kotlin
// Before
val searchSource = SearchSourceBuilder().query(query)

// After
val searchSource = SearchSourceBuilder().query(query).size(monitorIds.size)
```

**Impact:**
- Fixes detector creation for rule sets with more than 10 rules
- Eliminates misleading "invalid monitor ids" error messages
- Ensures workflow validation correctly handles workflows of any size (up to the existing 25 delegate limit)

### Related Issues

#2144 

**Example Error (Before Fix):**
```
Error 400 (Bad Request): 0uhbOp4BCrnc_R8wysGB, 1-hbOp4BCrnc_R8wysGD, 2uhbOp4BCrnc_R8wysGG are not valid monitor ids [type=security_analytics_exception]
```

### Check List

- [ ] New functionality includes testing.
  - *Not applicable: This is a bug fix for existing functionality. The existing test suite in `WorkflowRestApiIT.kt` validates workflow creation and monitor validation scenarios.*
- [ ] New functionality has been documented.
  - *Not applicable: This is a bug fix, not new functionality.*
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
  - *Not applicable: No API changes.*
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).