### PR TITLE
fix: Handle typed_keys prefix and remote target in bucket-level monitors

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/BucketLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/BucketLevelMonitorRunner.kt
@@ -166,7 +166,7 @@ object BucketLevelMonitorRunner : MonitorRunner() {
 
             for (trigger in monitor.triggers) {
                 // The currentAlerts map is formed by iterating over the Monitor's Triggers as keys so null should not be returned here
-                val currentAlertsForTrigger = currentAlerts[trigger]!!
+                val currentAlertsForTrigger = currentAlerts[trigger] ?: mutableMapOf()
                 val triggerCtx = BucketLevelTriggerExecutionContext(
                     monitor, trigger as BucketLevelTrigger, monitorResult,
                     clusterSettings = monitorCtx.clusterService!!.clusterSettings

--- a/alerting/src/main/kotlin/org/opensearch/alerting/InputService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/InputService.kt
@@ -43,6 +43,7 @@ import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.PPLInput
 import org.opensearch.commons.alerting.model.PPLTrigger
 import org.opensearch.commons.alerting.model.SearchInput
+import org.opensearch.commons.alerting.model.Target
 import org.opensearch.commons.alerting.model.TriggerAfterKey
 import org.opensearch.commons.alerting.model.WorkflowRunContext
 import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput
@@ -387,7 +388,9 @@ class InputService(
 
         val indexes = CrossClusterMonitorUtils.parseIndexesForRemoteSearch(searchInput.indices, clusterService)
 
-        val resolvedIndexes = if (searchInput.query.query() == null) indexes else {
+        val isRemoteTarget = monitor.target != null &&
+            monitor.target!!.type != Target.LOCAL
+        val resolvedIndexes = if (searchInput.query.query() == null || isRemoteTarget) indexes else {
             val query = searchInput.query.query()
             resolveOnlyQueryableIndicesFromLocalClusterAliases(
                 monitor,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/TriggerService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/TriggerService.kt
@@ -206,7 +206,7 @@ class TriggerService(val scriptService: ScriptService) {
             require(aggs is Map<*, *>) { "Unexpected aggregations type: ${aggs?.javaClass}" }
             var parentAgg: Map<*, *> = aggs
             aggregationPath.pathElementsAsStringList.forEach { subAgg ->
-                val child = parentAgg[subAgg]
+                val child = parentAgg[subAgg] ?: parentAgg.entries.firstOrNull { it.key.toString().endsWith(subAgg) }?.value
                 require(child is Map<*, *>) { "Unexpected type for agg '$subAgg': ${child?.javaClass}" }
                 parentAgg = child
             }


### PR DESCRIPTION
- Skip local index alias resolution when monitor target is remote (InputService.resolveOnlyQueryableIndicesFromLocalClusterAliases NPEs for remote targets that don't exist locally)
- Handle typed_keys prefix in TriggerService agg key lookup (endsWith fallback for keys like 'sterms#by_message')
- Safe access on currentAlerts map to avoid NPE when alerts index is empty or newly created


