### PR TITLE
fix: Add reinjectHeaders for PPL monitor execution path

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/QueryLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/QueryLevelMonitorRunner.kt
@@ -76,6 +76,7 @@ object QueryLevelMonitorRunner : MonitorRunner() {
                     monitor.user
                 )
             ) {
+                reinjectHeaders(monitor, monitorCtx)
                 monitorResult = monitorResult.copy(
                     inputResults = monitorCtx.inputService!!.collectInputResultsForPPLMonitor(monitor, monitorCtx)
                 )


### PR DESCRIPTION
The PPL monitor path in QueryLevelMonitorRunner was missing the reinjectHeaders call that the regular query path has. This caused header propagation failures when executing PPL queries against remote targets in multi-tenant mode.
