### PR TITLE
fix: correct inverted condition in DocLevelMonitorQueries causing query index churn

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
@@ -497,13 +497,14 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
         var targetQueryIndex = monitorMetadata.sourceToQueryIndexMapping[sourceIndex + monitor.id]
         if (
             targetQueryIndex == null || (
-                targetQueryIndex != monitor.dataSources.queryIndex &&
+                targetQueryIndex == monitor.dataSources.queryIndex &&
                     monitor.deleteQueryIndexInEveryRun == true
                 )
         ) {
-            // queryIndex is alias which will always have only 1 backing index which is writeIndex
-            // This is due to a fact that that _rollover API would maintain only single index under alias
-            // if you don't add is_write_index setting when creating index initially
+            // queryIndex is alias; its backing concrete index is the write index.
+            // The == guard handles the backwards-compat case where the alias name was mistakenly stored
+            // in metadata. Using != (the old code) caused this branch to fire on every run because
+            // the stored concrete index (e.g. "...-000001") always differs from the alias name.
             targetQueryIndex = getWriteIndexNameForAlias(monitor.dataSources.queryIndex)
             if (targetQueryIndex == null) {
                 val message = "Failed to get write index for queryIndex alias:${monitor.dataSources.queryIndex}"


### PR DESCRIPTION
## Summary

Fixes #2153

The condition in `DocLevelMonitorQueries.updateQueryIndexMappings` that decides when to re-fetch the write index from the query index alias was inverted (`!=` instead of `==`). This caused the re-fetch path to fire on every monitor execution rather than only in the backwards-compatibility case it was designed to handle.

## Root Cause

`monitorMetadata.sourceToQueryIndexMapping` stores the **concrete** backing index name (e.g. `.opensearch-sap-pre-packaged-rules-queries-000001`) after the first successful lookup. The condition was intended to re-resolve the alias only when the stored value is the **alias name itself** — a legacy situation where the metadata was written before this logic existed.

With `!=`, the condition evaluates to `true` on every subsequent run because the stored concrete index name is always different from the alias name. This triggers `getWriteIndexNameForAlias` and a metadata rewrite on every run, which cascades into a delete+recreate of the backing query index, generating 6–10 `MergeSchedulerConfig` log lines per node per cycle.

With `==`, the condition correctly fires only when the alias name itself is stored, which is the backwards-compat path it was designed for.

## Fix

```kotlin
// Before (broken)
targetQueryIndex != monitor.dataSources.queryIndex && monitor.deleteQueryIndexInEveryRun == true

// After (correct)
targetQueryIndex == monitor.dataSources.queryIndex && monitor.deleteQueryIndexInEveryRun == true
```

The comment block was also updated to document the correct invariant.

## Impact

At scale (3 master nodes, many detectors), the broken condition produced 23,000+ `MergeSchedulerConfig` log lines per minute. This fix eliminates that churn.

## Related

This bug is amplified by a separate issue in `opensearch-project/security-analytics` where `chained_findings` monitors are created with `deleteQueryIndexInEveryRun=true`, activating the broken code path on every detector run. Both fixes are needed to fully eliminate the log storm. The security-analytics fix prevents the flag from being set unnecessarily; this fix corrects the inverted logic that acts on it.