### PR TITLE
PPL Alerting: fix PPL Monitor execution to skip base query if it only…

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/InputService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/InputService.kt
@@ -242,7 +242,7 @@ class InputService(
                 // custom triggers (which are each running their own queries), and no
                 // number of results triggers, then the base query does not need to be
                 // run, return early saying there were 0 base query results.
-                InputRunResults(emptyList(), null, null, listOf(), 0)
+                return InputRunResults(emptyList(), null, null, listOf(), 0)
             }
 
             // PPL Alerting:


### PR DESCRIPTION
… has custom triggers

### Description
Fixes a miss where an early return to skip base PPL query execution for PPL Monitors didn't actually return early.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
