### PR TITLE
Add CI mirror to avoid Maven Central throttling

### DIFF
--- a/build-tools/repositories.gradle
+++ b/build-tools/repositories.gradle
@@ -6,5 +6,6 @@
 repositories {
     mavenLocal()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ buildscript {
                 snapshotsOnly()
             }
         }
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
     }
@@ -58,6 +59,7 @@ apply from: 'build-tools/merged-coverage.gradle'
 
 // Add explicit repository configuration for ktlint
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 
@@ -75,6 +77,7 @@ configurations {
 configurations.ktlint.incoming.beforeResolve {
     repositories.clear()
     repositories {
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
     }
 }

--- a/sample-remote-monitor-plugin/build.gradle
+++ b/sample-remote-monitor-plugin/build.gradle
@@ -29,8 +29,9 @@ ext {
 
 repositories {
     mavenLocal()
-    mavenCentral()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    maven { url "https://ci.opensearch.org/maven2/" }
+    mavenCentral()
 }
 
 configurations {

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+pluginManagement {
+    repositories {
+        maven { url = uri("https://ci.opensearch.org/maven2/") }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'opensearch-alerting'
 include 'alerting'
 include 'core'


### PR DESCRIPTION
### Description

Adds `https://ci.opensearch.org/maven2/` as a priority repository for plugin and dependency resolution to avoid Maven Central HTTP 429 throttling during builds on Jenkins, such as integration tests run against release candidates during the release process.

### Changes
- `settings.gradle` — Add `pluginManagement` block with CI mirror before Gradle Plugin Portal and Maven Central
- `build.gradle` and repository helper files — Add CI mirror before Maven Central for dependency resolution

### Testing
- Ran `git diff --check`
- Ran `./gradlew assemble`; dependency/plugin resolution completed, but the build failed later on existing Kotlin compile errors in `AlertService.kt` for unresolved `currentTenantId` references