### PR TITLE
[Backport] Add CI mirror to avoid Maven Central throttling (#2160)

### DIFF
--- a/build-tools/repositories.gradle
+++ b/build-tools/repositories.gradle
@@ -6,5 +6,6 @@
 repositories {
     mavenLocal()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ buildscript {
                 snapshotsOnly()
             }
         }
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
     }
@@ -58,6 +59,7 @@ apply from: 'build-tools/merged-coverage.gradle'
 
 // Add explicit repository configuration for ktlint
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 
@@ -75,6 +77,7 @@ configurations {
 configurations.ktlint.incoming.beforeResolve {
     repositories.clear()
     repositories {
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
     }
 }

--- a/sample-remote-monitor-plugin/build.gradle
+++ b/sample-remote-monitor-plugin/build.gradle
@@ -29,8 +29,9 @@ ext {
 
 repositories {
     mavenLocal()
-    mavenCentral()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    maven { url "https://ci.opensearch.org/maven2/" }
+    mavenCentral()
 }
 
 configurations {

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+pluginManagement {
+    repositories {
+        maven { url = uri("https://ci.opensearch.org/maven2/") }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'opensearch-alerting'
 include 'alerting'
 include 'core'


### PR DESCRIPTION
### Description
Add CI mirror to avoid Maven Central throttling (#2160)

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
