### PR TITLE
fix: stop DestinationMigrationCoordinator cycling on unrelated cluster events

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/DestinationMigrationCoordinator.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/destinationmigration/DestinationMigrationCoordinator.kt
@@ -16,6 +16,7 @@ import org.opensearch.cluster.ClusterStateListener
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.lifecycle.LifecycleListener
 import org.opensearch.common.unit.TimeValue
+import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.threadpool.Scheduler
 import org.opensearch.threadpool.ThreadPool
 import org.opensearch.transport.client.Client
@@ -45,6 +46,8 @@ class DestinationMigrationCoordinator(
     }
 
     override fun clusterChanged(event: ClusterChangedEvent) {
+        if (!event.indexRoutingTableChanged(ScheduledJob.SCHEDULED_JOBS_INDEX)) return
+
         if (DestinationMigrationUtilService.finishFlag) {
             logger.info("Reset destination migration process.")
             scheduledMigration?.cancel()


### PR DESCRIPTION
## Problem
`DestinationMigrationCoordinator.clusterChanged()` has no index-scope filter. Any cluster state event resets `finishFlag` and reschedules the migration job — even events completely unrelated to the scheduled-jobs index (e.g., datastream mapping updates from security-analytics). On a cluster where destinations have already been migrated, this causes an infinite Reset→Cancel→Perform cycle that generates continuous log noise.

## Root cause
The `clusterChanged` callback resets `finishFlag = false` and reschedules unconditionally. Once migration completes and `finishFlag = true`, the next unrelated cluster event immediately restarts the cycle.

## Fix
Add the same index-scope guard used by `JobSweeper`:
\`\`\`kotlin
if (!event.indexRoutingTableChanged(ScheduledJob.SCHEDULED_JOBS_INDEX)) return
\`\`\`
This ensures the coordinator only acts on routing-table changes to `.opensearch-alerting-scheduled-jobs` — the only index whose state is actually relevant to destination migration.

## Testing
- Verified guard fires correctly: unrelated cluster events (mapping updates, etc.) return early without touching `finishFlag` or the migration scheduler
- Migration still completes correctly when `.opensearch-alerting-scheduled-jobs` routing changes