### PR TITLE
[backport 3.7] fix(alerting): skip pluggable dataformat ITs on external clusters

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -401,6 +401,7 @@ integTest {
 
         systemProperty 'tests.security.manager', 'false'
         systemProperty 'java.io.tmpdir', opensearch_tmp_dir.absolutePath
+        systemProperty 'tests.pluggable_dataformat_enabled', 'true'
 
         filter {
             includeTestsMatching "org.opensearch.alerting.transport.PluggableDataFormatMonitorBlockIT"
@@ -431,7 +432,9 @@ integTest {
     }
 
     check.dependsOn integTestPluggableDataformat
-    integTest.finalizedBy integTestPluggableDataformat
+    if (!usingRemoteCluster) {
+        integTest.finalizedBy integTestPluggableDataformat
+    }
 }
 
 task integTestRemote(type: RestIntegTestTask) {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/PluggableDataFormatMonitorBlockIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/PluggableDataFormatMonitorBlockIT.kt
@@ -5,6 +5,7 @@
 
 package org.opensearch.alerting.transport
 
+import org.junit.Before
 import org.opensearch.alerting.AlertingRestTestCase
 import org.opensearch.alerting.randomWorkflow
 import org.opensearch.client.ResponseException
@@ -25,6 +26,14 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 
 class PluggableDataFormatMonitorBlockIT : AlertingRestTestCase() {
+
+    @Before
+    fun checkPluggableDataformatEnabled() {
+        assumeTrue(
+            "Skipping — pluggable dataformat tests require feature flag enabled on cluster",
+            System.getProperty("tests.pluggable_dataformat_enabled", "false").toBoolean()
+        )
+    }
 
     fun `test create doc-level monitor blocked on pluggable dataformat domain`() {
         val testIndex = createTestIndex()


### PR DESCRIPTION
### Description
Backport of [#2164](https://github.com/opensearch-project/alerting/pull/2164). Add `assumeTrue` guard to `PluggableDataFormatMonitorBlockIT` so tests skip gracefully when the `opensearch.experimental.feature.pluggable.dataformat.enabled` feature flag is not enabled on the cluster. Also gate `integTest.finalizedBy ` with `usingRemoteCluster ` so  `integTestPluggableDataformat` does not trigger when running against a remote/external cluster.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
Fixes integration test failures during release CI where `PluggableDataFormatMonitorBlockIT` was triggered against an external cluster without the feature flag JVM system property.

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
