### PR TITLE
fix(alerting): restructure pluggable dataformat gradle task

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -393,48 +393,43 @@ integTest {
         }
     }
 
-    task integTestPluggableDataformat(type: RestIntegTestTask) {
-        description = "Runs integration tests with pluggable dataformat feature flag enabled"
-        dependsOn bundlePlugin
-        testClassesDirs = sourceSets.test.output.classesDirs
-        classpath = sourceSets.test.runtimeClasspath
-
-        systemProperty 'tests.security.manager', 'false'
-        systemProperty 'java.io.tmpdir', opensearch_tmp_dir.absolutePath
-        systemProperty 'tests.pluggable_dataformat_enabled', 'true'
-
-        filter {
-            includeTestsMatching "org.opensearch.alerting.transport.PluggableDataFormatMonitorBlockIT"
-        }
+    filter {
+        excludeTestsMatching "org.opensearch.alerting.transport.PluggableDataFormatMonitorBlockIT"
     }
+}
 
-    testClusters.integTestPluggableDataformat {
-        testDistribution = "ARCHIVE"
-        systemProperty 'opensearch.experimental.feature.pluggable.dataformat.enabled', 'true'
+task integTestPluggableDataformat(type: RestIntegTestTask) {
+    description = "Runs integration tests with pluggable dataformat feature flag enabled"
+    dependsOn bundlePlugin
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
 
-        // Include same plugins as main integTest cluster
-        plugin(provider({ new RegularFile() { @Override File getAsFile() { return configurations.zipArchive.asFileTree.matching { include '**/opensearch-notifications-core*' }.singleFile } } }))
-        plugin(provider({ new RegularFile() { @Override File getAsFile() { return configurations.zipArchive.asFileTree.matching { include '**/notifications*' }.singleFile } } }))
-        plugin(provider({ new RegularFile() { @Override File getAsFile() { return configurations.zipArchive.asFileTree.matching { include '**/opensearch-job-scheduler*' }.singleFile } } }))
-        plugin(provider({ new RegularFile() { @Override File getAsFile() { return configurations.zipArchive.asFileTree.matching { include '**/opensearch-sql-plugin*' }.singleFile } } }))
+    systemProperty 'tests.security.manager', 'false'
+    systemProperty 'java.io.tmpdir', opensearch_tmp_dir.absolutePath
+    systemProperty 'tests.pluggable_dataformat_enabled', 'true'
 
+    filter {
+        includeTestsMatching "org.opensearch.alerting.transport.PluggableDataFormatMonitorBlockIT"
+        failOnNoMatchingTests false
     }
+}
 
-    // Install alerting plugin on the pluggable dataformat test cluster
-    integTestPluggableDataformat.dependsOn(bundle)
-    integTestPluggableDataformat.getClusters().forEach{c -> c.plugin(project.getObjects().fileProperty().value(bundle.getArchiveFile()))}
+testClusters.integTestPluggableDataformat {
+    testDistribution = "ARCHIVE"
+    systemProperty 'opensearch.experimental.feature.pluggable.dataformat.enabled', 'true'
 
-    // Exclude pluggable dataformat tests from the main integTest task
-    integTest {
-        filter {
-            excludeTestsMatching "org.opensearch.alerting.transport.PluggableDataFormatMonitorBlockIT"
-        }
-    }
+    plugin(provider({ new RegularFile() { @Override File getAsFile() { return configurations.zipArchive.asFileTree.matching { include '**/opensearch-notifications-core*' }.singleFile } } }))
+    plugin(provider({ new RegularFile() { @Override File getAsFile() { return configurations.zipArchive.asFileTree.matching { include '**/notifications*' }.singleFile } } }))
+    plugin(provider({ new RegularFile() { @Override File getAsFile() { return configurations.zipArchive.asFileTree.matching { include '**/opensearch-job-scheduler*' }.singleFile } } }))
+    plugin(provider({ new RegularFile() { @Override File getAsFile() { return configurations.zipArchive.asFileTree.matching { include '**/opensearch-sql-plugin*' }.singleFile } } }))
+}
 
-    check.dependsOn integTestPluggableDataformat
-    if (!usingRemoteCluster) {
-        integTest.finalizedBy integTestPluggableDataformat
-    }
+integTestPluggableDataformat.dependsOn(bundle)
+integTestPluggableDataformat.getClusters().forEach{c -> c.plugin(project.getObjects().fileProperty().value(bundle.getArchiveFile()))}
+
+check.dependsOn integTestPluggableDataformat
+if (!usingRemoteCluster) {
+    integTest.finalizedBy integTestPluggableDataformat
 }
 
 task integTestRemote(type: RestIntegTestTask) {


### PR DESCRIPTION
Move integTestPluggableDataformat task and cluster config outside the integTest closure to avoid interfering with individual test targeting. Add failOnNoMatchingTests false so the task does not fail when triggered via finalizedBy with specific test filters.

### Description
Restructure the `integTestPluggableDataformat` gradle task by moving it outside the `integTest` closure to top level. This fixes two issues:

1. Running specific tests via `--tests.method` or `--tests.class` will not fail as `integTestPluggableDataformat` (triggered via finalizedBy) now has `failOnNoMatchingTests` `false`
2. The exclude filter for `PluggableDataFormatMonitorBlockIT` is now directly inside the `integTest` block instead of a nested re-opening, ensuring proper scoping

Validated 3 scenarios locally:

1. `./gradlew :alerting:integTest`- runs both regular `integTest` and `integTestPluggableDataformat` (`BUILD SUCCESSFUL`)
2. `./gradlew :alerting:integTest -Dtests.method="test execute PPL monitor with size exceeded query results"`- specific method targeting passes without `integTestPluggableDataformat` failing (`BUILD SUCCESSFUL`)
3. `./gradlew :alerting:integTest -Dtests.class="*MonitorRunnerServiceIT"`- specific class targeting passes without `integTestPluggableDataformat` failing (`BUILD SUCCESSFUL`)


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
Follow-up to #2164 . Addresses Gradle task interference when targeting individual integration tests.


### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
