### PR TITLE
Skip searchAlerts for dry-run in query-level and bucket-level monitors

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/AlertService.kt
@@ -107,6 +107,11 @@ class AlertService(
     }
 
     suspend fun loadCurrentAlertsForQueryLevelMonitor(monitor: Monitor, workflowRunContext: WorkflowRunContext?): Map<Trigger, Alert?> {
+        // Return early for dry-run
+        if (monitor.id.isBlank()) {
+            return monitor.triggers.associateWith { null }
+        }
+
         val searchAlertsResponse: SearchResponse = searchAlerts(
             monitor = monitor,
             size = monitor.triggers.size * 2, // We expect there to be only a single in-progress alert so fetch 2 to check
@@ -130,6 +135,11 @@ class AlertService(
         monitor: Monitor,
         workflowRunContext: WorkflowRunContext?,
     ): Map<Trigger, MutableMap<String, Alert>> {
+        // Return early for dry-run
+        if (monitor.id.isBlank()) {
+            return monitor.triggers.associateWith { mutableMapOf() }
+        }
+
         val searchAlertsResponse: SearchResponse = searchAlerts(
             monitor = monitor,
             // TODO: This should be limited based on a circuit breaker that limits Alerts

--- a/alerting/src/test/kotlin/org/opensearch/alerting/AlertServiceTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/AlertServiceTests.kt
@@ -5,6 +5,7 @@
 
 package org.opensearch.alerting
 
+import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.mockito.Mockito
 import org.opensearch.Version
@@ -213,6 +214,32 @@ class AlertServiceTests : OpenSearchTestCase() {
         assertAlertsExistForBucketKeys(listOf(listOf("a")), categorizedAlerts[AlertCategory.DEDUPED] ?: error("Deduped alerts not found"))
         assertAlertsExistForBucketKeys(emptyList(), categorizedAlerts[AlertCategory.NEW] ?: error("New alerts found"))
         assertAlertsExistForBucketKeys(emptyList(), completedAlerts)
+    }
+
+    fun `test loadCurrentAlertsForQueryLevelMonitor returns empty alerts for dry-run monitor with blank id`() {
+        val trigger = randomQueryLevelTrigger()
+        val monitor = randomQueryLevelMonitor(triggers = listOf(trigger)).copy(id = Monitor.NO_ID)
+
+        val result = runBlocking {
+            alertService.loadCurrentAlertsForQueryLevelMonitor(monitor, null)
+        }
+
+        assertEquals(1, result.size)
+        assertTrue(result.containsKey(trigger))
+        assertNull(result[trigger])
+    }
+
+    fun `test loadCurrentAlertsForBucketLevelMonitor returns empty alerts for dry-run monitor with blank id`() {
+        val trigger = randomBucketLevelTrigger()
+        val monitor = randomBucketLevelMonitor(triggers = listOf(trigger)).copy(id = Monitor.NO_ID)
+
+        val result = runBlocking {
+            alertService.loadCurrentAlertsForBucketLevelMonitor(monitor, null)
+        }
+
+        assertEquals(1, result.size)
+        assertTrue(result.containsKey(trigger))
+        assertTrue(result[trigger]!!.isEmpty())
     }
 
     private fun createCurrentAlertsFromBucketKeys(


### PR DESCRIPTION
### Description
Skip making `searchAlerts` API call when `monitorId` is blank. `monitorId` is blank (i.e. `NO_ID`) only when it's dry-run. So, `searchAlerts` API call is not required to be made.

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
