### PR TITLE
Pluggable Dataformat: Unblocking Cluster Metrics Monitors

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
@@ -22,6 +22,7 @@ import org.opensearch.alerting.action.ExecuteMonitorRequest
 import org.opensearch.alerting.action.ExecuteMonitorResponse
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.util.DocLevelMonitorQueries
+import org.opensearch.alerting.util.isClusterMetricsMonitor
 import org.opensearch.alerting.util.isUnsupportedMultiTenantMonitorType
 import org.opensearch.alerting.util.use
 import org.opensearch.cluster.service.ClusterService
@@ -50,6 +51,7 @@ import org.opensearch.transport.TransportService
 import org.opensearch.transport.client.Client
 import java.time.Instant
 import java.util.Locale
+
 private val log = LogManager.getLogger(TransportExecuteMonitorAction::class.java)
 private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 
@@ -211,13 +213,15 @@ class TransportExecuteMonitorAction @Inject constructor(
 
                 // Block non-PPL monitors on pluggable dataformat domains
                 if (FeatureFlags.isEnabled(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG) &&
-                    !monitor.isPPLMonitor()
+                    !monitor.isPPLMonitor() && !monitor.isClusterMetricsMonitor()
                 ) {
                     actionListener.onFailure(
                         AlertingException.wrap(
                             OpenSearchStatusException(
-                                "Only PPL monitors are supported on this domain." +
-                                    " ${monitor.monitorType} monitors are not allowed.",
+                                "Monitor execution failed. ${monitor.monitorType} type and other DSL-based monitors " +
+                                    "are not supported on this domain type. This domain supports PPL as the query language for " +
+                                    "alert monitors. It also supports cluster metrics monitors. Please create one of these monitor " +
+                                    "types instead.",
                                 RestStatus.FORBIDDEN
                             )
                         )

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -57,6 +57,7 @@ import org.opensearch.alerting.util.addUserBackendRolesFilter
 import org.opensearch.alerting.util.await
 import org.opensearch.alerting.util.getRoleFilterEnabled
 import org.opensearch.alerting.util.isADMonitor
+import org.opensearch.alerting.util.isClusterMetricsMonitor
 import org.opensearch.alerting.util.isUnsupportedMultiTenantMonitorType
 import org.opensearch.alerting.util.use
 import org.opensearch.cluster.service.ClusterService
@@ -218,13 +219,15 @@ class TransportIndexMonitorAction @Inject constructor(
 
         // Block non-PPL monitors on pluggable dataformat domains
         if (FeatureFlags.isEnabled(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG) &&
-            !transformedRequest.monitor.isPPLMonitor()
+            !transformedRequest.monitor.isPPLMonitor() &&
+            !transformedRequest.monitor.isClusterMetricsMonitor()
         ) {
             actionListener.onFailure(
                 AlertingException.wrap(
                     OpenSearchStatusException(
-                        "Only PPL monitors are supported on this domain." +
-                            " ${transformedRequest.monitor.monitorType} monitors are not allowed.",
+                        "Monitor creation/update failed. ${transformedRequest.monitor.monitorType} type and other DSL-based monitors " +
+                            "are not supported on this domain type. This domain supports PPL as the query language for " +
+                            "alert monitors. It also supports cluster metrics monitors. Please create one of these monitor types instead.",
                         RestStatus.FORBIDDEN
                     )
                 )

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
@@ -159,7 +159,9 @@ class TransportIndexWorkflowAction @Inject constructor(
             actionListener.onFailure(
                 AlertingException.wrap(
                     OpenSearchStatusException(
-                        "Workflow operations are not supported on this domain.",
+                        "Monitor creation/update failed. Composite monitors and DSL-based monitors " +
+                            "are not supported on this domain type. This domain supports PPL as the query language for " +
+                            "alert monitors. It also supports cluster metrics monitors. Please create one of these monitor types instead.",
                         RestStatus.FORBIDDEN
                     )
                 )

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
@@ -93,6 +93,10 @@ fun Destination.isAllowed(allowList: List<String>): Boolean = allowList.contains
 
 fun Destination.isTestAction(): Boolean = this.type == DestinationType.TEST_ACTION
 
+fun Monitor.isClusterMetricsMonitor(): Boolean =
+    this.isMonitorOfStandardType() &&
+        Monitor.MonitorType.valueOf(this.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.CLUSTER_METRICS_MONITOR
+
 fun Monitor.isDocLevelMonitor(): Boolean =
     this.isMonitorOfStandardType() &&
         Monitor.MonitorType.valueOf(this.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.DOC_LEVEL_MONITOR

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/PluggableDataFormatMonitorBlockIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/PluggableDataFormatMonitorBlockIT.kt
@@ -64,7 +64,7 @@ class PluggableDataFormatMonitorBlockIT : AlertingRestTestCase() {
             val message = e.message ?: ""
             assertTrue(
                 "Expected FORBIDDEN error for non-PPL monitor on pluggable dataformat domain, got: $message",
-                message.contains("Only PPL monitors are supported") || message.contains("monitors are not allowed")
+                message.contains("Monitor creation/update failed")
             )
         }
     }
@@ -107,7 +107,7 @@ class PluggableDataFormatMonitorBlockIT : AlertingRestTestCase() {
             val message = e.message ?: ""
             assertFalse(
                 "PPL monitor should not be blocked by pluggable dataformat gate, got: $message",
-                message.contains("Only PPL monitors are supported") || message.contains("monitors are not allowed")
+                message.contains("Monitor creation/update failed")
             )
         }
     }
@@ -147,7 +147,7 @@ class PluggableDataFormatMonitorBlockIT : AlertingRestTestCase() {
             val message = e.message ?: ""
             assertTrue(
                 "Expected FORBIDDEN error for non-PPL monitor update on pluggable dataformat domain, got: $message",
-                message.contains("Only PPL monitors are supported") || message.contains("monitors are not allowed")
+                message.contains("Monitor creation/update failed")
             )
         }
     }
@@ -187,7 +187,7 @@ class PluggableDataFormatMonitorBlockIT : AlertingRestTestCase() {
             val message = e.message ?: ""
             assertTrue(
                 "Expected FORBIDDEN error for non-PPL monitor execution on pluggable dataformat domain, got: $message",
-                message.contains("Only PPL monitors are supported") || message.contains("monitors are not allowed")
+                message.contains("Monitor execution failed")
             )
         }
     }
@@ -230,7 +230,7 @@ class PluggableDataFormatMonitorBlockIT : AlertingRestTestCase() {
             val message = e.message ?: ""
             assertFalse(
                 "PPL monitor execution should not be blocked by pluggable dataformat gate, got: $message",
-                message.contains("Only PPL monitors are supported") || message.contains("monitors are not allowed")
+                message.contains("Monitor execution failed")
             )
         }
     }
@@ -267,12 +267,12 @@ class PluggableDataFormatMonitorBlockIT : AlertingRestTestCase() {
             val message = e.message ?: ""
             assertTrue(
                 "Expected FORBIDDEN error for non-PPL monitor, got: $message",
-                message.contains("Only PPL monitors are supported") || message.contains("monitors are not allowed")
+                message.contains("Monitor creation/update failed")
             )
         }
     }
 
-    fun `test create cluster-metrics monitor blocked on pluggable dataformat domain`() {
+    fun `test create cluster-metrics monitor not blocked on pluggable dataformat domain`() {
         val testIndex = createTestIndex()
         val monitor = Monitor(
             name = "test-cluster-metrics-monitor",
@@ -301,14 +301,9 @@ class PluggableDataFormatMonitorBlockIT : AlertingRestTestCase() {
 
         try {
             createMonitor(monitor)
-            fail("Expected monitor creation to be blocked on pluggable dataformat domain")
         } catch (e: ResponseException) {
-            assertEquals(RestStatus.FORBIDDEN.status, e.response.statusLine.statusCode)
             val message = e.message ?: ""
-            assertTrue(
-                "Expected FORBIDDEN error for non-PPL monitor, got: $message",
-                message.contains("Only PPL monitors are supported") || message.contains("monitors are not allowed")
-            )
+            fail("Cluster metrics monitor creation should not fail, but got: $message")
         }
     }
 
@@ -321,7 +316,7 @@ class PluggableDataFormatMonitorBlockIT : AlertingRestTestCase() {
             val message = e.message ?: ""
             assertTrue(
                 "Expected FORBIDDEN error for workflow on pluggable dataformat domain, got: $message",
-                message.contains("Workflow operations are not supported") || message.contains("not supported on this domain")
+                message.contains("Monitor creation/update failed")
             )
         }
     }


### PR DESCRIPTION
### Description
Unblocking cluster metrics monitors for pluggable data format clusters. Testing was done on a pluggable data format cluster to ensure Cluster metrics monitors worked as expected.

### Check List
- [Y] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [Y] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
