### PR TITLE
fix(build): Force tools.jackson 3.1.4 to resolve SNAPSHOT version con…

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -114,6 +114,15 @@ configurations.all {
 
         force "org.slf4j:slf4j-api:${versions.slf4j}" //Needed for http5
 
+        // Force tools.jackson (Jackson 3.x) to resolve SNAPSHOT conflict between
+        // opensearch-remote-metadata-sdk (3.1.3) and opensearch-core (3.1.4)
+        force "tools.jackson.core:jackson-databind:3.1.4"
+        force "tools.jackson.core:jackson-core:3.1.4"
+        force "tools.jackson.dataformat:jackson-dataformat-smile:3.1.4"
+        force "tools.jackson.dataformat:jackson-dataformat-yaml:3.1.4"
+        force "tools.jackson.dataformat:jackson-dataformat-cbor:3.1.4"
+        force "tools.jackson:jackson-bom:3.1.4"
+
         // This is required because kotlin-coroutines-core 1.1.1 still requires kotlin stdlib 1.3.20 and we're using a higher kotlin version
         force "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
         force "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"


### PR DESCRIPTION
### Description
The build fails with failOnVersionConflict due to a version mismatch in tools.jackson (Jackson 3.x) modules:
  
  - opensearch-remote-metadata-sdk:3.7.0.0-SNAPSHOT (published 2026-06-02) depends on tools.jackson 3.1.3
  - opensearch:3.7.0-SNAPSHOT (published 2026-06-05) upgraded to tools.jackson 3.1.4
  
  Since both are pulled transitively into alerting's runtime classpath, and the opensearchplugin Gradle plugin enforces failOnVersionConflict(), the
  build fails.
  
  Fix: Force all tools.jackson modules to 3.1.4 in the resolutionStrategy block, consistent with how other dependency conflicts (joda-time,
  commons-codec, fasterxml jackson) are already handled in this file.
  
  This is a temporary workaround until opensearch-remote-metadata-sdk publishes a new SNAPSHOT aligned with the latest OpenSearch core.


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
