### PR TITLE
Fix Jackson 3.x version conflict in dependency resolution

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -108,6 +108,11 @@ configurations.all {
         force "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:${versions.jackson}"
         force "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions.jackson}"
         force "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson}"
+        eachDependency { details ->
+            if (details.requested.group.startsWith('tools.jackson')) {
+                details.useVersion versions.jackson3
+            }
+        }
         force "commons-logging:commons-logging:${versions.commonslogging}"
         // force the version until OpenSearch upgrade to an invulnerable one, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
         force "commons-codec:commons-codec:1.13"


### PR DESCRIPTION
## Summary
- Fixes build failure caused by Jackson 3.x version conflict between `opensearch-remote-metadata-sdk` (3.2.0) and `opensearch-core` (3.2.1) after upstream [Jackson update](https://github.com/opensearch-project/OpenSearch/pull/22497)
- Adds force declarations for `tools.jackson` artifacts using `versions.jackson3` from the OpenSearch build system

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).