### PR TITLE
Fix flaky AlertIndicesIT by handling missing index during monitor count check

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -20,6 +20,7 @@ import org.opensearch.action.admin.cluster.health.ClusterHealthRequest
 import org.opensearch.action.admin.cluster.health.ClusterHealthResponse
 import org.opensearch.action.admin.indices.create.CreateIndexResponse
 import org.opensearch.action.index.IndexResponse
+import org.opensearch.action.search.SearchPhaseExecutionException
 import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
@@ -98,6 +99,7 @@ import org.opensearch.core.rest.RestStatus
 import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.core.xcontent.ToXContent
 import org.opensearch.core.xcontent.ToXContentObject
+import org.opensearch.index.IndexNotFoundException
 import org.opensearch.index.query.QueryBuilders
 import org.opensearch.index.reindex.BulkByScrollResponse
 import org.opensearch.index.reindex.DeleteByQueryAction
@@ -747,7 +749,17 @@ class TransportIndexMonitorAction @Inject constructor(
                         }
 
                         override fun onFailure(t: Exception) {
-                            actionListener.onFailure(AlertingException.wrap(t))
+                            val cause = ExceptionsHelper.unwrapCause(t)
+                            if (cause is IndexNotFoundException ||
+                                cause is SearchPhaseExecutionException
+                            ) {
+                                log.info("$SCHEDULED_JOBS_INDEX index not available for monitor count validation, proceeding with indexing.")
+                                scope.launch(TenantContext(tenantId)) {
+                                    indexMonitor()
+                                }
+                            } else {
+                                actionListener.onFailure(AlertingException.wrap(t))
+                            }
                         }
                     }
                 )


### PR DESCRIPTION
### Description
The prepareMonitorIndexing() method searches SCHEDULED_JOBS_INDEX to validate the monitor count limit. When a preceding test wipes all indices, this search can fail with SearchPhaseExecutionException (all shards failed) or IndexNotFoundException if the index hasn't been recreated yet.

Handle these cases gracefully by proceeding to index the monitor, since an unavailable index implies zero existing monitors.


### Related Issues
Resolves #2199 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
