### PR TITLE
Add ci.opensearch.org/m2/ mirror for plugin resolution (alerting)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ buildscript {
 
     repositories {
         mavenLocal()
+        maven { url "https://ci.opensearch.org/m2/" }
         maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven {
@@ -59,6 +60,7 @@ apply from: 'build-tools/merged-coverage.gradle'
 
 // Add explicit repository configuration for ktlint
 repositories {
+    maven { url "https://ci.opensearch.org/m2/" }
     maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
@@ -77,6 +79,7 @@ configurations {
 configurations.ktlint.incoming.beforeResolve {
     repositories.clear()
     repositories {
+        maven { url "https://ci.opensearch.org/m2/" }
         maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,8 @@ buildscript {
 
     repositories {
         mavenLocal()
-        maven { url "https://ci.opensearch.org/m2/" }
         maven { url "https://ci.opensearch.org/maven2/" }
+        maven { url "https://ci.opensearch.org/m2/" }
         mavenCentral()
         maven {
             url "https://ci.opensearch.org/ci/dbc/snapshots/maven/"
@@ -60,8 +60,8 @@ apply from: 'build-tools/merged-coverage.gradle'
 
 // Add explicit repository configuration for ktlint
 repositories {
-    maven { url "https://ci.opensearch.org/m2/" }
     maven { url "https://ci.opensearch.org/maven2/" }
+    maven { url "https://ci.opensearch.org/m2/" }
     mavenCentral()
 }
 
@@ -79,8 +79,8 @@ configurations {
 configurations.ktlint.incoming.beforeResolve {
     repositories.clear()
     repositories {
-        maven { url "https://ci.opensearch.org/m2/" }
         maven { url "https://ci.opensearch.org/maven2/" }
+        maven { url "https://ci.opensearch.org/m2/" }
         mavenCentral()
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,8 +5,8 @@
 
 pluginManagement {
     repositories {
-        maven { url = uri("https://ci.opensearch.org/m2/") }
         maven { url = uri("https://ci.opensearch.org/maven2/") }
+        maven { url = uri("https://ci.opensearch.org/m2/") }
         gradlePluginPortal()
         mavenCentral()
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,7 @@
 
 pluginManagement {
     repositories {
+        maven { url = uri("https://ci.opensearch.org/m2/") }
         maven { url = uri("https://ci.opensearch.org/maven2/") }
         gradlePluginPortal()
         mavenCentral()


### PR DESCRIPTION
### Description
Add ci.opensearch.org/m2/ mirror for plugin resolution (alerting)

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6278#issuecomment-5135909975

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).