### PR TITLE
Fix common_utils_version to use opensearch_build instead of hardcoded snapshot (alerting)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,7 @@ buildscript {
             opensearch_build += "-SNAPSHOT"
         }
         opensearch_no_snapshot = opensearch_version.replace("-SNAPSHOT","")
-        // TODO: revert to opensearch_build after alerting version bump to 3.7.0
-        common_utils_version = System.getProperty("common_utils.version", "3.7.0.0-SNAPSHOT")
+        common_utils_version = System.getProperty("common_utils.version", opensearch_build)
         kotlin_version = '2.2.0'
     }
 


### PR DESCRIPTION
### Description
Fix common_utils_version to use opensearch_build instead of hardcoded snapshot (alerting)

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6278#issuecomment-5148963803