### PR TITLE
Add ci.opensearch.org/m2/ mirror for plugin marker resolution (alerting)

### DIFF
--- a/build-tools/repositories.gradle
+++ b/build-tools/repositories.gradle
@@ -6,6 +6,7 @@
 repositories {
     mavenLocal()
     maven { url "https://ci.opensearch.org/maven2/" }
+    maven { url "https://ci.opensearch.org/m2/" }
     mavenCentral()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
 }


### PR DESCRIPTION
### Description
Add ci.opensearch.org/m2/ mirror for plugin marker resolution (alerting)

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6278#issuecomment-5169921924