### PR TITLE
fix: guard against EmptyMap cast in doc-level monitor recreateRunContext and mapping traversal

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
@@ -193,7 +193,7 @@ class DocumentLevelMonitorRunner : MonitorRunner() {
                         indexLastRunContext.toMutableMap(),
                         concreteIndexName,
                         shardCount
-                    ) as MutableMap<String, Any>
+                    )
                     if (IndexUtils.isAlias(indexName, monitorCtx.clusterService!!.state()) ||
                         IndexUtils.isDataStream(indexName, monitorCtx.clusterService!!.state())
                     ) {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorFanOutUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorFanOutUtils.kt
@@ -59,7 +59,7 @@ fun initializeNewLastRunContext(
     lastRunContext: Map<String, Any>,
     index: String,
     shardCount: Int,
-): Map<String, Any> {
+): MutableMap<String, Any> {
     val updatedLastRunContext = lastRunContext.toMutableMap()
 
     // Only initialize shards that don't already have a sequence number

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt
@@ -206,9 +206,12 @@ object MonitorMetadataService :
             else if (monitor.monitorType.endsWith(Monitor.MonitorType.DOC_LEVEL_MONITOR.value))
                 (monitor.inputs[0] as RemoteDocLevelMonitorInput).docLevelMonitorInput.indices[0]
             else null
-            val runContext = if (monitor.monitorType.endsWith(Monitor.MonitorType.DOC_LEVEL_MONITOR.value))
-                createFullRunContext(monitorIndex, metadata.lastRunContext as MutableMap<String, MutableMap<String, Any>>)
-            else null
+            val runContext = if (monitor.monitorType.endsWith(Monitor.MonitorType.DOC_LEVEL_MONITOR.value)) {
+                @Suppress("UNCHECKED_CAST")
+                val lastRunCtx = if (metadata.lastRunContext.isEmpty()) null
+                else (metadata.lastRunContext as MutableMap<String, MutableMap<String, Any>>)
+                createFullRunContext(monitorIndex, lastRunCtx)
+            } else null
             return if (runContext != null) {
                 metadata.copy(
                     lastRunContext = runContext

--- a/alerting/src/main/kotlin/org/opensearch/alerting/remote/monitors/RemoteDocumentLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/remote/monitors/RemoteDocumentLevelMonitorRunner.kt
@@ -126,7 +126,7 @@ class RemoteDocumentLevelMonitorRunner : MonitorRunner() {
                         indexLastRunContext.toMutableMap(),
                         concreteIndexName,
                         shardCount
-                    ) as MutableMap<String, Any>
+                    )
                     if (IndexUtils.isAlias(indexName, monitorCtx.clusterService!!.state()) ||
                         IndexUtils.isDataStream(indexName, monitorCtx.clusterService!!.state())
                     ) {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
@@ -228,18 +228,18 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
             // Compute full path relative to root
             val fullPath = if (currentPath.isEmpty()) it.key
             else "$currentPath.${it.key}"
-            val nodeProps = it.value as MutableMap<String, Any>
+            val nodeProps = (it.value as Map<String, Any>).toMutableMap()
             // If it has type property and type is not "nested" then this is a leaf
             if (nodeProps.containsKey(TYPE) && nodeProps[TYPE] != NESTED) {
                 // At this point we know full path of node, so we add it to output array
                 flattenPaths.put(fullPath, nodeProps)
                 // Calls processLeafFn and gets old node name, new node name and new properties of node.
                 // This is all information we need to update this node
-                val (oldName, newName, props) = processLeafFn(it.key, fullPath, it.value as MutableMap<String, Any>)
+                val (oldName, newName, props) = processLeafFn(it.key, fullPath, (it.value as Map<String, Any>).toMutableMap())
                 newNodes.add(Triple(oldName, newName, props))
             } else if (nodeProps.containsKey(PROPERTIES) && nodeProps[PROPERTIES] != null) {
                 // Internal(non-leaf) node - visit children
-                traverseMappingsAndUpdate(nodeProps[PROPERTIES] as MutableMap<String, Any>, fullPath, processLeafFn, flattenPaths)
+                traverseMappingsAndUpdate((nodeProps[PROPERTIES] as Map<String, Any>).toMutableMap(), fullPath, processLeafFn, flattenPaths)
             }
         }
         // Here we can update all processed leaves in tree


### PR DESCRIPTION
## Summary

This PR adds defence-in-depth guards against `ClassCastException` / `UnsupportedOperationException`
caused by immutable empty maps being cast to `MutableMap` in the doc-level monitor subsystem.

Closes: #2220
Related: opensearch-project/common-utils#967 (root-cause fix belongs there)

---

## Root cause

`MonitorMetadata.lastRunContext` defaults to `kotlin.collections.EmptyMap` (the immutable
singleton returned by `mapOf()`) when deserialized from `.opensearch-alerting-config` and
the stored document has no `last_run_context` field (monitor never ran, or created under
an older plugin version).

`MonitorMetadataService.recreateRunContext()` line 210 casts this directly to
`MutableMap<String, MutableMap<String, Any>>`. `EmptyMap` is not a `MutableMap`, so the
JVM throws `ClassCastException` on any `PUT` update to such a monitor.

The correct fix — changing `mapOf()` to `mutableMapOf()` in `MonitorMetadata.kt` — is
tracked in opensearch-project/common-utils#967. This PR adds a guard at the cast site so
that the crash cannot occur regardless of which `common-utils` version is deployed.

---

## Changes

### Fix A — `MonitorMetadataService.kt` (critical)

Guard the cast at line 210: if `lastRunContext.isEmpty()`, pass `null` to
`createFullRunContext()` (which accepts `null` and builds a fresh context).

### Fix B — `DocLevelMonitorQueries.kt` (plausible crash path)

`traverseMappingsAndUpdate()` casts values from `indexMetadata.mapping()?.sourceAsMap`
directly to `MutableMap`. Java's `Collections.emptyMap()` (returned for empty nested
objects `{}`) is not mutable; `.put()` / `.remove()` would throw
`UnsupportedOperationException`. Replace bare casts with `.toMutableMap()` defensive
copies at the three cast sites inside `traverseMappingsAndUpdate()`.

### Fix C — `MonitorFanOutUtils.kt` / `DocumentLevelMonitorRunner.kt` (contract)

`initializeNewLastRunContext()` always returns a `MutableMap` but its return type is
declared as `Map`. Update the declaration and remove the now-unnecessary `as MutableMap`
cast at the call site in `DocumentLevelMonitorRunner.kt` and
`RemoteDocumentLevelMonitorRunner.kt`.

---

## Files changed

- `alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt`
- `alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt`
- `alerting/src/main/kotlin/org/opensearch/alerting/MonitorFanOutUtils.kt`
- `alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt`
- `alerting/src/main/kotlin/org/opensearch/alerting/remote/monitors/RemoteDocumentLevelMonitorRunner.kt`

---

## Testing

- [ ] All existing unit and integration tests pass (`./gradlew test`)
- [ ] Manual verification: create a doc-level monitor, delete its metadata entry from
      `.opensearch-alerting-config`, then `PUT` an update to the monitor — no
      `ClassCastException` thrown
- [ ] Doc-level monitor mapping traversal with an index containing empty nested objects
      (`{}`) does not throw `UnsupportedOperationException`