### PR TITLE
Fix doc-level monitor failure on source indices with custom analysis or malformed mappings

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
@@ -65,14 +65,7 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
         const val INDEX_PATTERN_SUFFIX = "-000001"
         const val QUERY_INDEX_BASE_FIELDS_COUNT = 8 // 3 fields we defined and 5 builtin additional metadata fields
 
-        /**
-         * Field attributes that reference custom analysis resources (analyzers, normalizers, similarity
-         * configurations) defined in a source index's settings.analysis block.  The doc-level query index
-         * is created from a fixed settings resource with no custom analysis block, so including these
-         * attributes in a PutMappingRequest against the query index causes OpenSearch to reject the
-         * request with "analyzer [x] has not been configured in mappings".  Strip them before copying
-         * field mappings from the source index to the query index.
-         */
+        /** Analysis-resource attributes that must be stripped before copying mappings to the query index. */
         val ANALYSIS_ATTRIBUTES = setOf(
             "analyzer",
             "search_analyzer",
@@ -82,18 +75,15 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
         )
 
         /**
-         * Sanitizes a single field-mapping property map so it is safe to submit in a PutMappingRequest
-         * against the doc-level query index.
-         * @param fieldType the OpenSearch field type string (e.g. "text", "keyword"), or null when absent
-         * @param mapping   the mutable property map for the field; modified in-place
+         * Strips analysis attributes and invalid structural attributes from a field-mapping map in-place.
+         * @param fieldType the OpenSearch field type (e.g. "text", "keyword"), or null when absent
+         * @param mapping   the mutable property map to sanitize
          */
         fun sanitizeFieldMappingAttributes(fieldType: String?, mapping: MutableMap<String, Any>) {
             // Category 1: remove analysis resource references
             mapping.keys.removeAll(ANALYSIS_ATTRIBUTES)
 
-            // Category 2: remove "properties" from scalar (non-object, non-nested) fields.
-            // A null/absent type defaults to "object" in OpenSearch, so only strip when the type is
-            // explicitly set to something other than "object" or "nested".
+            // Category 2: strip "properties" from scalar fields (null type defaults to object — only strip when explicit).
             if (fieldType != null && fieldType != "object" && fieldType != NESTED) {
                 mapping.remove(PROPERTIES)
             }
@@ -103,6 +93,16 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
             (mapping["fields"] as? Map<*, *>)?.forEach { (_, subMapping) ->
                 (subMapping as? MutableMap<String, Any>)?.let {
                     sanitizeFieldMappingAttributes(it[TYPE] as? String, it)
+                }
+            }
+
+            // Recurse into sub-properties of object/implicit-object fields to strip analysis attributes.
+            if (fieldType == null || fieldType == "object" || fieldType == NESTED) {
+                @Suppress("UNCHECKED_CAST")
+                (mapping[PROPERTIES] as? Map<*, *>)?.forEach { (_, subMapping) ->
+                    (subMapping as? MutableMap<String, Any>)?.let {
+                        sanitizeFieldMappingAttributes(it[TYPE] as? String, it)
+                    }
                 }
             }
         }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
@@ -84,24 +84,6 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
         /**
          * Sanitizes a single field-mapping property map so it is safe to submit in a PutMappingRequest
          * against the doc-level query index.
-         *
-         * Two classes of attribute are removed:
-         *
-         * 1. Analysis resource references (analyzer, normalizer, similarity, search_analyzer,
-         *    search_quote_analyzer): these reference custom analysis objects defined in the source
-         *    index's settings.analysis block, which is never replicated to the query index.  Submitting
-         *    them causes an IllegalArgumentException from OpenSearch.
-         *
-         * 2. A "properties" sub-block on a scalar (non-object, non-nested) field type: this can appear
-         *    in cluster-state mappings when dynamic mapping collisions occur — a field is first mapped
-         *    as "text" from string-valued documents, then later documents send the same field as
-         *    structured objects causing OpenSearch to append "properties" to the existing scalar mapper.
-         *    OpenSearch accepts this at ingestion time (lenient) but rejects it via the explicit PUT
-         *    mapping API with MapperParsingException[unknown parameter [properties] on mapper of type
-         *    [text]].
-         *
-         * The sanitization is applied recursively to multi-fields (the "fields" sub-map).
-         *
          * @param fieldType the OpenSearch field type string (e.g. "text", "keyword"), or null when absent
          * @param mapping   the mutable property map for the field; modified in-place
          */

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
@@ -64,6 +64,67 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
         const val TYPE = "type"
         const val INDEX_PATTERN_SUFFIX = "-000001"
         const val QUERY_INDEX_BASE_FIELDS_COUNT = 8 // 3 fields we defined and 5 builtin additional metadata fields
+
+        /**
+         * Field attributes that reference custom analysis resources (analyzers, normalizers, similarity
+         * configurations) defined in a source index's settings.analysis block.  The doc-level query index
+         * is created from a fixed settings resource with no custom analysis block, so including these
+         * attributes in a PutMappingRequest against the query index causes OpenSearch to reject the
+         * request with "analyzer [x] has not been configured in mappings".  Strip them before copying
+         * field mappings from the source index to the query index.
+         */
+        val ANALYSIS_ATTRIBUTES = setOf(
+            "analyzer",
+            "search_analyzer",
+            "search_quote_analyzer",
+            "normalizer",
+            "similarity"
+        )
+
+        /**
+         * Sanitizes a single field-mapping property map so it is safe to submit in a PutMappingRequest
+         * against the doc-level query index.
+         *
+         * Two classes of attribute are removed:
+         *
+         * 1. Analysis resource references (analyzer, normalizer, similarity, search_analyzer,
+         *    search_quote_analyzer): these reference custom analysis objects defined in the source
+         *    index's settings.analysis block, which is never replicated to the query index.  Submitting
+         *    them causes an IllegalArgumentException from OpenSearch.
+         *
+         * 2. A "properties" sub-block on a scalar (non-object, non-nested) field type: this can appear
+         *    in cluster-state mappings when dynamic mapping collisions occur — a field is first mapped
+         *    as "text" from string-valued documents, then later documents send the same field as
+         *    structured objects causing OpenSearch to append "properties" to the existing scalar mapper.
+         *    OpenSearch accepts this at ingestion time (lenient) but rejects it via the explicit PUT
+         *    mapping API with MapperParsingException[unknown parameter [properties] on mapper of type
+         *    [text]].
+         *
+         * The sanitization is applied recursively to multi-fields (the "fields" sub-map).
+         *
+         * @param fieldType the OpenSearch field type string (e.g. "text", "keyword"), or null when absent
+         * @param mapping   the mutable property map for the field; modified in-place
+         */
+        fun sanitizeFieldMappingAttributes(fieldType: String?, mapping: MutableMap<String, Any>) {
+            // Category 1: remove analysis resource references
+            mapping.keys.removeAll(ANALYSIS_ATTRIBUTES)
+
+            // Category 2: remove "properties" from scalar (non-object, non-nested) fields.
+            // A null/absent type defaults to "object" in OpenSearch, so only strip when the type is
+            // explicitly set to something other than "object" or "nested".
+            if (fieldType != null && fieldType != "object" && fieldType != NESTED) {
+                mapping.remove(PROPERTIES)
+            }
+
+            // Recurse into multi-fields
+            @Suppress("UNCHECKED_CAST")
+            (mapping["fields"] as? Map<*, *>)?.forEach { (_, subMapping) ->
+                (subMapping as? MutableMap<String, Any>)?.let {
+                    sanitizeFieldMappingAttributes(it[TYPE] as? String, it)
+                }
+            }
+        }
+
         @JvmStatic
         fun docLevelQueriesMappings(): String {
             return DocLevelMonitorQueries::class.java.classLoader.getResource("mappings/doc-level-queries.json").readText()
@@ -306,7 +367,9 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
                         val leafNodeProcessor =
                             fun(fieldName: String, fullPath: String, props: MutableMap<String, Any>):
                                 Triple<String, String, MutableMap<String, Any>> {
-                                val newProps = props.toMutableMap()
+                                val newProps = props.toMutableMap().also {
+                                    sanitizeFieldMappingAttributes(it[TYPE] as? String, it)
+                                }
                                 if (monitor.dataSources.queryIndexMappingsByType.isNotEmpty()) {
                                     val mappingsByType = monitor.dataSources.queryIndexMappingsByType
                                     if (props.containsKey("type") && mappingsByType.containsKey(props["type"]!!)) {

--- a/alerting/src/test/kotlin/org/opensearch/alerting/util/AlertingUtilsTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/util/AlertingUtilsTests.kt
@@ -360,4 +360,122 @@ class AlertingUtilsTests : OpenSearchTestCase() {
         assertTrue("Expected 'message' in flatten paths", flattenPaths.containsKey("message"))
         assertTrue("Expected 'dll.name' in flatten paths", flattenPaths.containsKey("dll.name"))
     }
+
+    // sanitizeFieldMappingAttributes — sub-property recursion (Gap 1 regression tests)
+
+    fun `test sanitizeFieldMappingAttributes strips analyzer from sub-field inside object field`() {
+        // Regression: sanitizer must recurse into object sub-properties, not just multi-fields.
+        val urlField = mutableMapOf<String, Any>("type" to "text", "analyzer" to "custom_analyzer")
+        val mapping = mutableMapOf<String, Any>(
+            "type" to "object",
+            "properties" to mutableMapOf<String, Any>("url" to urlField)
+        )
+        DocLevelMonitorQueries.sanitizeFieldMappingAttributes("object", mapping)
+        @Suppress("UNCHECKED_CAST")
+        val urlProps = ((mapping["properties"] as Map<*, *>)["url"] as Map<*, *>)
+        assertFalse("analyzer must be stripped from sub-field inside object", urlProps.containsKey("analyzer"))
+        assertEquals("type of sub-field must be preserved", "text", urlProps["type"])
+        assertTrue("properties must be kept on object field", mapping.containsKey("properties"))
+    }
+
+    fun `test sanitizeFieldMappingAttributes strips analyzer from sub-field inside implicit-object field`() {
+        // Implicit object (no "type" key) must also have its sub-properties sanitized.
+        val titleField = mutableMapOf<String, Any>(
+            "type" to "text", "analyzer" to "custom_analyzer", "search_analyzer" to "standard"
+        )
+        val mapping = mutableMapOf<String, Any>("properties" to mutableMapOf<String, Any>("title" to titleField))
+        DocLevelMonitorQueries.sanitizeFieldMappingAttributes(null, mapping)
+        @Suppress("UNCHECKED_CAST")
+        val titleProps = ((mapping["properties"] as Map<*, *>)["title"] as Map<*, *>)
+        assertFalse("analyzer must be stripped", titleProps.containsKey("analyzer"))
+        assertFalse("search_analyzer must be stripped", titleProps.containsKey("search_analyzer"))
+        assertTrue("properties must be kept", mapping.containsKey("properties"))
+    }
+
+    fun `test sanitizeFieldMappingAttributes recurses into deeply nested object properties`() {
+        // Three levels: outer object -> inner object -> leaf with normalizer.
+        val leafField = mutableMapOf<String, Any>("type" to "keyword", "normalizer" to "my_normalizer")
+        val innerObject = mutableMapOf<String, Any>(
+            "type" to "object",
+            "properties" to mutableMapOf<String, Any>("code" to leafField)
+        )
+        val mapping = mutableMapOf<String, Any>(
+            "type" to "object",
+            "properties" to mutableMapOf<String, Any>("status" to innerObject)
+        )
+        DocLevelMonitorQueries.sanitizeFieldMappingAttributes("object", mapping)
+        @Suppress("UNCHECKED_CAST")
+        val statusProps = ((mapping["properties"] as Map<*, *>)["status"] as Map<*, *>)
+        @Suppress("UNCHECKED_CAST")
+        val codeProps = ((statusProps["properties"] as Map<*, *>)["code"] as Map<*, *>)
+        assertFalse("normalizer must be stripped at depth-3 leaf", codeProps.containsKey("normalizer"))
+        assertEquals("type at depth-3 leaf must be preserved", "keyword", codeProps["type"])
+    }
+
+    // traverseMappingsAndUpdate — implicit-object writeback (Gap 2 regression tests)
+
+    fun `test traverseMappingsAndUpdate propagates sanitization through implicit-object field`() {
+        // Regression: mutations inside the recursive call must write back to the original tree.
+        val docLevelMonitorQueries = DocLevelMonitorQueries(mock(Client::class.java), mock(ClusterService::class.java))
+        val subField = mutableMapOf<String, Any>("type" to "text", "analyzer" to "custom_analyzer")
+        val mappings = mutableMapOf<String, Any>(
+            "request" to mutableMapOf<String, Any>("properties" to mutableMapOf<String, Any>("url" to subField))
+        )
+        val sanitizingLeaf =
+            fun(fieldName: String, _: String, props: MutableMap<String, Any>):
+                Triple<String, String, MutableMap<String, Any>> {
+                DocLevelMonitorQueries.sanitizeFieldMappingAttributes(props["type"] as? String, props)
+                return Triple(fieldName, fieldName, props)
+            }
+        val flattenPaths = mutableMapOf<String, MutableMap<String, Any>>()
+        docLevelMonitorQueries.traverseMappingsAndUpdate(mappings, "", sanitizingLeaf, flattenPaths)
+        @Suppress("UNCHECKED_CAST")
+        val urlProps = ((mappings["request"] as Map<*, *>)["properties"] as Map<*, *>)["url"] as Map<*, *>
+        assertFalse("analyzer must be absent after traversal", urlProps.containsKey("analyzer"))
+        assertEquals("type must be preserved", "text", urlProps["type"])
+    }
+
+    fun `test traverseMappingsAndUpdate sanitizes sub-field inside explicit object-typed field`() {
+        // End-to-end Gap 1: traversal classifies type="object" as a leaf; sanitizer must recurse into its properties.
+        val docLevelMonitorQueries = DocLevelMonitorQueries(mock(Client::class.java), mock(ClusterService::class.java))
+        val urlField = mutableMapOf<String, Any>("type" to "text", "analyzer" to "custom_analyzer")
+        val mappings = mutableMapOf<String, Any>(
+            "request" to mutableMapOf<String, Any>(
+                "type" to "object",
+                "properties" to mutableMapOf<String, Any>("url" to urlField)
+            )
+        )
+        val sanitizingLeaf =
+            fun(fieldName: String, _: String, props: MutableMap<String, Any>):
+                Triple<String, String, MutableMap<String, Any>> {
+                DocLevelMonitorQueries.sanitizeFieldMappingAttributes(props["type"] as? String, props)
+                return Triple(fieldName, fieldName, props)
+            }
+        val flattenPaths = mutableMapOf<String, MutableMap<String, Any>>()
+        docLevelMonitorQueries.traverseMappingsAndUpdate(mappings, "", sanitizingLeaf, flattenPaths)
+        assertTrue("request must be in flattenPaths as a leaf", flattenPaths.containsKey("request"))
+        @Suppress("UNCHECKED_CAST")
+        val urlProps = ((mappings["request"] as Map<*, *>)["properties"] as Map<*, *>)["url"] as Map<*, *>
+        assertFalse("analyzer must be stripped from sub-field of explicit object field", urlProps.containsKey("analyzer"))
+        assertEquals("type must be preserved", "text", urlProps["type"])
+    }
+
+    fun `test sanitizeFieldMappingAttributes sanitizes field with both fields and properties`() {
+        // A field with both multi-fields and sub-properties: both must be sanitized.
+        val multiField = mutableMapOf<String, Any>("type" to "keyword", "normalizer" to "my_normalizer")
+        val subPropField = mutableMapOf<String, Any>("type" to "text", "analyzer" to "custom_analyzer")
+        val mapping = mutableMapOf<String, Any>(
+            "type" to "object",
+            "fields" to mutableMapOf<String, Any>("raw" to multiField),
+            "properties" to mutableMapOf<String, Any>("desc" to subPropField)
+        )
+        DocLevelMonitorQueries.sanitizeFieldMappingAttributes("object", mapping)
+        @Suppress("UNCHECKED_CAST")
+        val rawField = (mapping["fields"] as Map<*, *>)["raw"] as Map<*, *>
+        assertFalse("normalizer must be stripped from multi-field", rawField.containsKey("normalizer"))
+        @Suppress("UNCHECKED_CAST")
+        val descField = (mapping["properties"] as Map<*, *>)["desc"] as Map<*, *>
+        assertFalse("analyzer must be stripped from sub-property field", descField.containsKey("analyzer"))
+        assertEquals("type of sub-property field must be preserved", "text", descField["type"])
+    }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/util/AlertingUtilsTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/util/AlertingUtilsTests.kt
@@ -213,6 +213,110 @@ class AlertingUtilsTests : OpenSearchTestCase() {
         }
     }
 
+    // ----- sanitizeFieldMappingAttributes -----
+
+    fun `test sanitizeFieldMappingAttributes strips analyzer from text field`() {
+        val mapping = mutableMapOf<String, Any>(
+            "type" to "text",
+            "analyzer" to "my_custom_analyzer",
+            "search_analyzer" to "my_custom_analyzer"
+        )
+        DocLevelMonitorQueries.sanitizeFieldMappingAttributes("text", mapping)
+        assertFalse("analyzer must be removed", mapping.containsKey("analyzer"))
+        assertFalse("search_analyzer must be removed", mapping.containsKey("search_analyzer"))
+        assertEquals("type must be preserved", "text", mapping["type"])
+    }
+
+    fun `test sanitizeFieldMappingAttributes strips all analysis attributes`() {
+        val mapping = mutableMapOf<String, Any>(
+            "type" to "keyword",
+            "normalizer" to "my_normalizer",
+            "similarity" to "my_similarity",
+            "search_quote_analyzer" to "my_analyzer",
+            "doc_values" to true
+        )
+        DocLevelMonitorQueries.sanitizeFieldMappingAttributes("keyword", mapping)
+        assertFalse("normalizer must be removed", mapping.containsKey("normalizer"))
+        assertFalse("similarity must be removed", mapping.containsKey("similarity"))
+        assertFalse("search_quote_analyzer must be removed", mapping.containsKey("search_quote_analyzer"))
+        // Non-analysis attributes must not be affected
+        assertTrue("doc_values must be preserved", mapping.containsKey("doc_values"))
+        assertEquals("type must be preserved", "keyword", mapping["type"])
+    }
+
+    fun `test sanitizeFieldMappingAttributes strips properties from scalar field`() {
+        // Reproduces the MapperParsingException[unknown parameter [properties] on mapper of type [text]]
+        // failure caused by dynamic mapping collisions on the source index.
+        val mapping = mutableMapOf<String, Any>(
+            "type" to "text",
+            "properties" to mutableMapOf<String, Any>(
+                "subfield" to mutableMapOf<String, Any>("type" to "keyword")
+            )
+        )
+        DocLevelMonitorQueries.sanitizeFieldMappingAttributes("text", mapping)
+        assertFalse("properties must be removed from scalar-typed field", mapping.containsKey("properties"))
+        assertEquals("type must be preserved", "text", mapping["type"])
+    }
+
+    fun `test sanitizeFieldMappingAttributes preserves properties on object field`() {
+        val subProperties = mutableMapOf<String, Any>("sub" to mutableMapOf<String, Any>("type" to "keyword"))
+        val mapping = mutableMapOf<String, Any>(
+            "type" to "object",
+            "properties" to subProperties
+        )
+        DocLevelMonitorQueries.sanitizeFieldMappingAttributes("object", mapping)
+        assertTrue("properties must be kept on object field", mapping.containsKey("properties"))
+    }
+
+    fun `test sanitizeFieldMappingAttributes preserves properties on nested field`() {
+        val subProperties = mutableMapOf<String, Any>("sub" to mutableMapOf<String, Any>("type" to "keyword"))
+        val mapping = mutableMapOf<String, Any>(
+            "type" to "nested",
+            "properties" to subProperties
+        )
+        DocLevelMonitorQueries.sanitizeFieldMappingAttributes("nested", mapping)
+        assertTrue("properties must be kept on nested field", mapping.containsKey("properties"))
+    }
+
+    fun `test sanitizeFieldMappingAttributes preserves properties when type is absent`() {
+        // Absent type defaults to object in OpenSearch — must not strip properties
+        val subProperties = mutableMapOf<String, Any>("sub" to mutableMapOf<String, Any>("type" to "keyword"))
+        val mapping = mutableMapOf<String, Any>(
+            "properties" to subProperties
+        )
+        DocLevelMonitorQueries.sanitizeFieldMappingAttributes(null, mapping)
+        assertTrue("properties must be kept when type is absent", mapping.containsKey("properties"))
+    }
+
+    fun `test sanitizeFieldMappingAttributes recurses into multi-fields`() {
+        val subField = mutableMapOf<String, Any>(
+            "type" to "keyword",
+            "normalizer" to "my_normalizer"
+        )
+        val mapping = mutableMapOf<String, Any>(
+            "type" to "text",
+            "analyzer" to "my_analyzer",
+            "fields" to mutableMapOf<String, Any>("raw" to subField)
+        )
+        DocLevelMonitorQueries.sanitizeFieldMappingAttributes("text", mapping)
+        assertFalse("analyzer must be removed from top-level field", mapping.containsKey("analyzer"))
+        @Suppress("UNCHECKED_CAST")
+        val rawField = (mapping["fields"] as Map<*, *>)["raw"] as Map<*, *>
+        assertFalse("normalizer must be removed from multi-field", rawField.containsKey("normalizer"))
+        assertEquals("type must be preserved in multi-field", "keyword", rawField["type"])
+    }
+
+    fun `test sanitizeFieldMappingAttributes does not modify clean field`() {
+        val mapping = mutableMapOf<String, Any>(
+            "type" to "keyword",
+            "doc_values" to true,
+            "index" to false
+        )
+        val original = mapping.toMap()
+        DocLevelMonitorQueries.sanitizeFieldMappingAttributes("keyword", mapping)
+        assertEquals("clean mapping must be unchanged", original, mapping)
+    }
+
     fun `test traverseMappingsAndUpdate with nested field type without properties succeeds`() {
         // Verifies fix for https://github.com/opensearch-project/security-analytics/issues/1472
         val docLevelMonitorQueries = DocLevelMonitorQueries(mock(Client::class.java), mock(ClusterService::class.java))


### PR DESCRIPTION
## Problem

Doc-level monitors fail at creation time when the source index has field mappings that contain attributes incompatible with the query index. Two distinct failure categories have been observed.

**Category 1 — analysis resource references**

Fields such as `text` or `keyword` can carry `analyzer`, `normalizer`, `search_analyzer`, `search_quote_analyzer`, or `similarity` attributes that reference custom analysis objects defined in the source index's `settings.analysis.*` block. The doc-level query index is created from a fixed settings resource with no custom analysis block. When `DocLevelMonitorQueries` copies field mappings verbatim via `props.toMutableMap()` and submits them in a `PutMappingRequest`, OpenSearch rejects the request:

```
IllegalArgumentException: analyzer [my_analyzer] has not been configured in mappings
```

**Category 2 — `properties` on a scalar field type**

Dynamic mapping collisions can leave a field in cluster state with both `"type": "text"` (or any scalar type) and a `properties` sub-block, which is only valid on `object`/`nested` mappers. OpenSearch stores this silently at ingestion time but rejects it when submitted explicitly via the PUT mapping API:

```
MapperParsingException: unknown parameter [properties] on mapper [field] of type [text]
```

Both failures block monitor creation on any real-world index that uses custom analyzers, normalizers, or has experienced dynamic mapping collisions — a common production pattern. The issue is actively tracked in [alerting#961](https://github.com/opensearch-project/alerting/issues/961) and affects Security Analytics detector creation as reported in [security-analytics#697](https://github.com/opensearch-project/security-analytics/issues/697) and [security-analytics#1798](https://github.com/opensearch-project/security-analytics/issues/1798).

## Root cause

`leafNodeProcessor` in `DocLevelMonitorQueries.kt` performs an unconditional `props.toMutableMap()` copy of every source field attribute before building the `PutMappingRequest`. No filtering is applied to remove attributes that are invalid on the query index.

## Fix

Add `sanitizeFieldMappingAttributes(fieldType, mapping)` to the `DocLevelMonitorQueries` companion object and call it on `newProps` immediately after the `toMutableMap()` copy inside `leafNodeProcessor`.

The function:
- Strips all five analysis-reference attributes (`analyzer`, `search_analyzer`, `search_quote_analyzer`, `normalizer`, `similarity`) — Category 1
- Strips `properties` from any field whose type is explicitly set to something other than `object` or `nested` — Category 2
- Recurses into multi-fields via the `fields` sub-map

No index close/open cycle is required. The change is confined to the in-memory `PutMappingRequest` payload. The query index stores Percolator query documents for doc-level matching only, not user-facing search data, so dropping these attributes is safe and lossless for its purpose.

This approach resolves the architectural concern raised in [alerting#961](https://github.com/opensearch-project/alerting/issues/961): the original "won't fix" closure described Strategy B (copying `settings.analysis.*` from the source index into the query index), which is genuinely blocked because the shared query index cannot safely merge conflicting analysis configurations from multiple source indices. This fix implements Strategy A (strip the incompatible attributes before the PUT), which is independent of that constraint.

## Changes

- `alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt`: add `ANALYSIS_ATTRIBUTES` constant and `sanitizeFieldMappingAttributes()` to companion object; wire into `leafNodeProcessor`
- `alerting/src/test/kotlin/org/opensearch/alerting/util/AlertingUtilsTests.kt`: 7 unit tests covering both failure categories, edge cases (object/nested/absent type), multi-field recursion, and clean pass-through

## Related issues

- Fixes opensearch-project/alerting#961
- Relates to opensearch-project/security-analytics#697
- Relates to opensearch-project/security-analytics#1798

## Testing

Unit tests added in `AlertingUtilsTests`. All existing tests in that file continue to pass unchanged.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

cudos: claude