### PR TITLE
Apply Index Monitor API input validation to the Execute Monitor API

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestExecuteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestExecuteMonitorAction.kt
@@ -9,8 +9,10 @@ import org.apache.logging.log4j.LogManager
 import org.opensearch.alerting.AlertingPlugin
 import org.opensearch.alerting.action.ExecuteMonitorAction
 import org.opensearch.alerting.action.ExecuteMonitorRequest
+import org.opensearch.alerting.alerts.AlertIndices
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.core.xcontent.XContentParser.Token.START_OBJECT
 import org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken
@@ -73,6 +75,8 @@ class RestExecuteMonitorAction : BaseRestHandler() {
                     throw AlertingException.wrap(e)
                 }
 
+                validateDataSources(monitor)
+
                 val execMonitorRequest = ExecuteMonitorRequest(dryrun, requestEnd, null, monitor)
                 client.execute(ExecuteMonitorAction.INSTANCE, execMonitorRequest, RestToXContentListener(channel))
             }
@@ -81,5 +85,17 @@ class RestExecuteMonitorAction : BaseRestHandler() {
 
     override fun responseParams(): Set<String> {
         return setOf("dryrun", "period_end", "monitorID")
+    }
+
+    private fun validateDataSources(monitor: Monitor) { // Data Sources are only supported at the transport layer for stored monitors.
+        if (monitor.dataSources != null) {
+            if (
+                monitor.dataSources.queryIndex != ScheduledJob.DOC_LEVEL_QUERIES_INDEX ||
+                monitor.dataSources.findingsIndex != AlertIndices.FINDING_HISTORY_WRITE_INDEX ||
+                monitor.dataSources.alertsIndex != AlertIndices.ALERT_INDEX
+            ) {
+                throw IllegalArgumentException("Custom Data Sources are not allowed.")
+            }
+        }
     }
 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
@@ -10,7 +10,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.apache.logging.log4j.LogManager
+import org.opensearch.OpenSearchSecurityException
 import org.opensearch.OpenSearchStatusException
+import org.opensearch.action.search.SearchRequest
+import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.action.support.WriteRequest
@@ -22,6 +25,7 @@ import org.opensearch.alerting.action.ExecuteMonitorRequest
 import org.opensearch.alerting.action.ExecuteMonitorResponse
 import org.opensearch.alerting.settings.AlertingSettings
 import org.opensearch.alerting.util.DocLevelMonitorQueries
+import org.opensearch.alerting.util.IndexUtils
 import org.opensearch.alerting.util.isClusterMetricsMonitor
 import org.opensearch.alerting.util.isUnsupportedMultiTenantMonitorType
 import org.opensearch.alerting.util.use
@@ -33,8 +37,13 @@ import org.opensearch.common.xcontent.LoggingDeprecationHandler
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.ConfigConstants
+import org.opensearch.commons.alerting.model.DocLevelMonitorInput
+import org.opensearch.commons.alerting.model.DocLevelMonitorInput.Companion.DOC_LEVEL_INPUT_FIELD
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.ScheduledJob
+import org.opensearch.commons.alerting.model.SearchInput
+import org.opensearch.commons.alerting.model.remote.monitors.RemoteDocLevelMonitorInput
+import org.opensearch.commons.alerting.model.remote.monitors.RemoteDocLevelMonitorInput.Companion.REMOTE_DOC_LEVEL_MONITOR_INPUT_FIELD
 import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.commons.alerting.util.isMonitorOfStandardType
 import org.opensearch.commons.alerting.util.isPPLMonitor
@@ -43,9 +52,11 @@ import org.opensearch.commons.utils.TenantContext
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.rest.RestStatus
 import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.index.query.QueryBuilders
 import org.opensearch.remote.metadata.client.GetDataObjectRequest
 import org.opensearch.remote.metadata.client.SdkClient
 import org.opensearch.remote.metadata.common.SdkClientUtils
+import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService
 import org.opensearch.transport.client.Client
@@ -89,175 +100,281 @@ class TransportExecuteMonitorAction @Inject constructor(
         val user: User? = User.parse(userStr)
 
         val tenantId = client.threadPool().threadContext.getHeader(AlertingPlugin.TENANT_ID_HEADER)
-        client.threadPool().threadContext.stashContext().use {
-            val executeMonitor = fun(monitor: Monitor) {
-                // Launch the coroutine with the clients threadContext. This is needed to preserve authentication information
-                // stored on the threadContext set by the security plugin when using the Alerting plugin with the Security plugin.
-                // runner.launch(ElasticThreadContextElement(client.threadPool().threadContext)) {
-                runner.launch(TenantContext(tenantId)) {
-                    val (periodStart, periodEnd) = if (execMonitorRequest.requestStart != null) {
-                        Pair(
-                            Instant.ofEpochMilli(execMonitorRequest.requestStart.millis),
-                            Instant.ofEpochMilli(execMonitorRequest.requestEnd.millis)
-                        )
-                    } else {
-                        monitor.schedule.getPeriodEndingAt(Instant.ofEpochMilli(execMonitorRequest.requestEnd.millis))
-                    }
-                    try {
-                        log.info(
-                            "Executing monitor from API - id: ${monitor.id}, type: ${monitor.monitorType}, " +
-                                "periodStart: $periodStart, periodEnd: $periodEnd, dryrun: ${execMonitorRequest.dryrun}"
-                        )
-                        val monitorRunResult = runner.runJob(
-                            monitor,
-                            periodStart,
-                            periodEnd,
-                            execMonitorRequest.dryrun,
-                            transportService
-                        )
-                        withContext(Dispatchers.IO) {
-                            actionListener.onResponse(ExecuteMonitorResponse(monitorRunResult))
-                        }
-                    } catch (e: Exception) {
-                        log.error("Unexpected error running monitor", e)
-                        withContext(Dispatchers.IO) {
-                            actionListener.onFailure(AlertingException.wrap(e))
-                        }
-                    }
-                }
+
+        if (execMonitorRequest.monitorId != null && execMonitorRequest.monitor == null) {
+            val monitorId = execMonitorRequest.monitorId
+            // Existing monitor referenced by ID. Its inputs and data sources were already validated against
+            // the caller's permissions at creation time, and an explicit permission check is performed below,
+            // so it is safe to stash the context here.
+            client.threadPool().threadContext.stashContext().use {
+                executeExistingMonitor(execMonitorRequest, monitorId, user, tenantId, actionListener)
+            }
+        } else {
+            // Inline monitor definition supplied in the request body. Validate the caller's access to the
+            // configured input indices and data sources using the caller's OWN security context BEFORE
+            // stashing it, so the execute path performs the same validation as the monitor creation path.
+            val monitor = when (user?.name.isNullOrEmpty()) {
+                true -> execMonitorRequest.monitor as Monitor
+                false -> (execMonitorRequest.monitor as Monitor).copy(user = user)
             }
 
-            if (execMonitorRequest.monitorId != null && execMonitorRequest.monitor == null) {
-                val getRequest = GetDataObjectRequest.builder()
-                    .index(ScheduledJob.SCHEDULED_JOBS_INDEX)
-                    .id(execMonitorRequest.monitorId)
-                    .tenantId(tenantId)
-                    .build()
-                sdkClient.getDataObjectAsync(getRequest).whenComplete { response, throwable ->
-                    if (throwable != null) {
-                        actionListener.onFailure(AlertingException.wrap(SdkClientUtils.unwrapAndConvertToException(throwable)))
+            if (multiTenancyEnabled && monitor.isUnsupportedMultiTenantMonitorType()) {
+                actionListener.onFailure(
+                    AlertingException.wrap(
+                        OpenSearchStatusException(
+                            "${monitor.monitorType} monitors are not allowed when multi-tenancy is enabled.",
+                            RestStatus.METHOD_NOT_ALLOWED
+                        )
+                    )
+                )
+                return
+            }
+
+            // Block non-PPL monitors on pluggable dataformat domains
+            if (FeatureFlags.isEnabled(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG) &&
+                !monitor.isPPLMonitor() && !monitor.isClusterMetricsMonitor()
+            ) {
+                actionListener.onFailure(
+                    AlertingException.wrap(
+                        OpenSearchStatusException(
+                            "Monitor execution failed. ${monitor.monitorType} type and other DSL-based monitors " +
+                                "are not supported on this domain type. This domain supports PPL as the query language for " +
+                                "alert monitors. It also supports cluster metrics monitors. Please create one of these monitor " +
+                                "types instead.",
+                            RestStatus.FORBIDDEN
+                        )
+                    )
+                )
+                return
+            }
+
+            checkIndicesAndExecute(monitor, execMonitorRequest, tenantId, actionListener)
+        }
+    }
+
+    /**
+     * Verifies that the caller has read access to the inline monitor's configured input indices using the
+     * caller's own security context, and only then stashes the context and executes the monitor. This mirrors
+     * [TransportIndexMonitorAction.checkIndicesAndExecute] so the execute path applies the same permission
+     * check as the monitor creation path.
+     */
+    private fun checkIndicesAndExecute(
+        monitor: Monitor,
+        execMonitorRequest: ExecuteMonitorRequest,
+        tenantId: String?,
+        actionListener: ActionListener<ExecuteMonitorResponse>,
+    ) {
+        val indices = mutableListOf<String>()
+        val searchInputs = monitor.inputs.filter {
+            it.name() == SearchInput.SEARCH_FIELD ||
+                it.name() == DOC_LEVEL_INPUT_FIELD ||
+                it.name() == REMOTE_DOC_LEVEL_MONITOR_INPUT_FIELD
+        }
+        searchInputs.forEach {
+            val inputIndices = if (it.name() == SearchInput.SEARCH_FIELD) (it as SearchInput).indices
+            else if (it.name() == DOC_LEVEL_INPUT_FIELD) (it as DocLevelMonitorInput).indices
+            else (it as RemoteDocLevelMonitorInput).docLevelMonitorInput.indices
+            indices.addAll(inputIndices)
+        }
+
+        // No configured input indices to validate; safe to stash and execute.
+        if (indices.isEmpty()) {
+            client.threadPool().threadContext.stashContext().use {
+                executeInlineMonitor(monitor, execMonitorRequest, tenantId, actionListener)
+            }
+            return
+        }
+
+        val updatedIndices = indices.map { index ->
+            if (IndexUtils.isAlias(index, clusterService.state()) || IndexUtils.isDataStream(index, clusterService.state())) {
+                val metadata = clusterService.state().metadata.indicesLookup[index]?.writeIndex
+                metadata?.index?.name ?: index
+            } else {
+                index
+            }
+        }
+
+        // Test search executed with the caller's security context (context not yet stashed).
+        val searchRequest = SearchRequest().indices(*updatedIndices.toTypedArray())
+            .source(SearchSourceBuilder.searchSource().size(1).query(QueryBuilders.matchAllQuery()))
+        client.search(
+            searchRequest,
+            object : ActionListener<SearchResponse> {
+                override fun onResponse(searchResponse: SearchResponse) {
+                    // Caller has read access to the configured indices; now stash context and execute.
+                    client.threadPool().threadContext.stashContext().use {
+                        executeInlineMonitor(monitor, execMonitorRequest, tenantId, actionListener)
+                    }
+                }
+
+                //  Due to below issue with security plugin, we get security_exception when invalid index name is mentioned.
+                //  https://github.com/opendistro-for-elasticsearch/security/issues/718
+                override fun onFailure(t: Exception) {
+                    actionListener.onFailure(
+                        AlertingException.wrap(
+                            when (t is OpenSearchSecurityException) {
+                                true -> OpenSearchStatusException(
+                                    "User doesn't have read permissions for one or more configured index $indices",
+                                    RestStatus.FORBIDDEN
+                                )
+                                false -> t
+                            }
+                        )
+                    )
+                }
+            }
+        )
+    }
+
+    private fun executeExistingMonitor(
+        execMonitorRequest: ExecuteMonitorRequest,
+        monitorId: String,
+        user: User?,
+        tenantId: String?,
+        actionListener: ActionListener<ExecuteMonitorResponse>,
+    ) {
+        val getRequest = GetDataObjectRequest.builder()
+            .index(ScheduledJob.SCHEDULED_JOBS_INDEX)
+            .id(monitorId)
+            .tenantId(tenantId)
+            .build()
+        sdkClient.getDataObjectAsync(getRequest).whenComplete { response, throwable ->
+            if (throwable != null) {
+                actionListener.onFailure(AlertingException.wrap(SdkClientUtils.unwrapAndConvertToException(throwable)))
+                return@whenComplete
+            }
+            try {
+                val getResponse = response.getResponse()
+                if (getResponse == null || !getResponse.isExists) {
+                    actionListener.onFailure(
+                        AlertingException.wrap(
+                            OpenSearchStatusException(
+                                "Can't find monitor with id: $monitorId",
+                                RestStatus.NOT_FOUND
+                            )
+                        )
+                    )
+                    return@whenComplete
+                }
+                if (getResponse.isSourceEmpty) {
+                    actionListener.onFailure(
+                        AlertingException.wrap(
+                            OpenSearchStatusException(
+                                "Monitor source is empty for id: $monitorId",
+                                RestStatus.NOT_FOUND
+                            )
+                        )
+                    )
+                    return@whenComplete
+                }
+                XContentHelper.createParser(
+                    xContentRegistry, LoggingDeprecationHandler.INSTANCE,
+                    getResponse.sourceAsBytesRef, XContentType.JSON
+                ).use { xcp ->
+                    val monitor = ScheduledJob.parse(xcp, getResponse.id, getResponse.version) as Monitor
+
+                    if (multiTenancyEnabled && monitor.isUnsupportedMultiTenantMonitorType()) {
+                        actionListener.onFailure(
+                            AlertingException.wrap(
+                                OpenSearchStatusException(
+                                    "${monitor.monitorType} monitors are not allowed when multi-tenancy is enabled.",
+                                    RestStatus.METHOD_NOT_ALLOWED
+                                )
+                            )
+                        )
                         return@whenComplete
                     }
-                    try {
-                        val getResponse = response.getResponse()
-                        if (getResponse == null || !getResponse.isExists) {
-                            actionListener.onFailure(
-                                AlertingException.wrap(
-                                    OpenSearchStatusException(
-                                        "Can't find monitor with id: ${execMonitorRequest.monitorId}",
-                                        RestStatus.NOT_FOUND
-                                    )
-                                )
-                            )
-                            return@whenComplete
-                        }
-                        if (getResponse.isSourceEmpty) {
-                            actionListener.onFailure(
-                                AlertingException.wrap(
-                                    OpenSearchStatusException(
-                                        "Monitor source is empty for id: ${execMonitorRequest.monitorId}",
-                                        RestStatus.NOT_FOUND
-                                    )
-                                )
-                            )
-                            return@whenComplete
-                        }
-                        XContentHelper.createParser(
-                            xContentRegistry, LoggingDeprecationHandler.INSTANCE,
-                            getResponse.sourceAsBytesRef, XContentType.JSON
-                        ).use { xcp ->
-                            val monitor = ScheduledJob.parse(xcp, getResponse.id, getResponse.version) as Monitor
 
-                            if (multiTenancyEnabled && monitor.isUnsupportedMultiTenantMonitorType()) {
-                                actionListener.onFailure(
-                                    AlertingException.wrap(
-                                        OpenSearchStatusException(
-                                            "${monitor.monitorType} monitors are not allowed when multi-tenancy is enabled.",
-                                            RestStatus.METHOD_NOT_ALLOWED
-                                        )
-                                    )
-                                )
-                                return@whenComplete
-                            }
-
-                            // RBAC check: verify calling user has permissions to this monitor
-                            if (!checkUserPermissionsWithResource(
-                                    user, monitor.user, actionListener,
-                                    "monitor", execMonitorRequest.monitorId
-                                )
-                            ) {
-                                return@whenComplete
-                            }
-
-                            executeMonitor(monitor)
-                        }
-                    } catch (e: Exception) {
-                        log.error("Failed to get monitor ${execMonitorRequest.monitorId} for execution", e)
-                        actionListener.onFailure(AlertingException.wrap(e))
+                    // RBAC check: verify calling user has permissions to this monitor
+                    if (!checkUserPermissionsWithResource(
+                            user, monitor.user, actionListener,
+                            "monitor", monitorId
+                        )
+                    ) {
+                        return@whenComplete
                     }
+
+                    launchExecuteMonitor(monitor, execMonitorRequest, tenantId, actionListener)
                 }
+            } catch (e: Exception) {
+                log.error("Failed to get monitor $monitorId for execution", e)
+                actionListener.onFailure(AlertingException.wrap(e))
+            }
+        }
+    }
+
+    private fun executeInlineMonitor(
+        monitor: Monitor,
+        execMonitorRequest: ExecuteMonitorRequest,
+        tenantId: String?,
+        actionListener: ActionListener<ExecuteMonitorResponse>,
+    ) {
+        if (
+            monitor.isMonitorOfStandardType() &&
+            Monitor.MonitorType.valueOf(monitor.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.DOC_LEVEL_MONITOR
+        ) {
+            try {
+                scope.launch(TenantContext(tenantId)) {
+                    if (!docLevelMonitorQueries.docLevelQueryIndexExists(monitor.dataSources)) {
+                        docLevelMonitorQueries.initDocLevelQueryIndex(monitor.dataSources)
+                        log.info("Central Percolation index ${ScheduledJob.DOC_LEVEL_QUERIES_INDEX} created")
+                    }
+                    val (metadata, _) = MonitorMetadataService.getOrCreateMetadata(monitor, skipIndex = true)
+                    docLevelMonitorQueries.indexDocLevelQueries(
+                        monitor,
+                        monitor.id,
+                        metadata,
+                        WriteRequest.RefreshPolicy.IMMEDIATE,
+                        indexTimeout
+                    )
+                    log.info("Queries inserted into Percolate index ${ScheduledJob.DOC_LEVEL_QUERIES_INDEX}")
+                    launchExecuteMonitor(monitor, execMonitorRequest, tenantId, actionListener)
+                }
+            } catch (t: Exception) {
+                actionListener.onFailure(AlertingException.wrap(t))
+            }
+        } else {
+            launchExecuteMonitor(monitor, execMonitorRequest, tenantId, actionListener)
+        }
+    }
+
+    private fun launchExecuteMonitor(
+        monitor: Monitor,
+        execMonitorRequest: ExecuteMonitorRequest,
+        tenantId: String?,
+        actionListener: ActionListener<ExecuteMonitorResponse>,
+    ) {
+        // Launch the coroutine with the clients threadContext. This is needed to preserve authentication information
+        // stored on the threadContext set by the security plugin when using the Alerting plugin with the Security plugin.
+        // runner.launch(ElasticThreadContextElement(client.threadPool().threadContext)) {
+        runner.launch(TenantContext(tenantId)) {
+            val (periodStart, periodEnd) = if (execMonitorRequest.requestStart != null) {
+                Pair(
+                    Instant.ofEpochMilli(execMonitorRequest.requestStart.millis),
+                    Instant.ofEpochMilli(execMonitorRequest.requestEnd.millis)
+                )
             } else {
-                val monitor = when (user?.name.isNullOrEmpty()) {
-                    true -> execMonitorRequest.monitor as Monitor
-                    false -> (execMonitorRequest.monitor as Monitor).copy(user = user)
+                monitor.schedule.getPeriodEndingAt(Instant.ofEpochMilli(execMonitorRequest.requestEnd.millis))
+            }
+            try {
+                log.info(
+                    "Executing monitor from API - id: ${monitor.id}, type: ${monitor.monitorType}, " +
+                        "periodStart: $periodStart, periodEnd: $periodEnd, dryrun: ${execMonitorRequest.dryrun}"
+                )
+                val monitorRunResult = runner.runJob(
+                    monitor,
+                    periodStart,
+                    periodEnd,
+                    execMonitorRequest.dryrun,
+                    transportService
+                )
+                withContext(Dispatchers.IO) {
+                    actionListener.onResponse(ExecuteMonitorResponse(monitorRunResult))
                 }
-
-                if (multiTenancyEnabled && monitor.isUnsupportedMultiTenantMonitorType()) {
-                    actionListener.onFailure(
-                        AlertingException.wrap(
-                            OpenSearchStatusException(
-                                "${monitor.monitorType} monitors are not allowed when multi-tenancy is enabled.",
-                                RestStatus.METHOD_NOT_ALLOWED
-                            )
-                        )
-                    )
-                    return@use
-                }
-
-                // Block non-PPL monitors on pluggable dataformat domains
-                if (FeatureFlags.isEnabled(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG) &&
-                    !monitor.isPPLMonitor() && !monitor.isClusterMetricsMonitor()
-                ) {
-                    actionListener.onFailure(
-                        AlertingException.wrap(
-                            OpenSearchStatusException(
-                                "Monitor execution failed. ${monitor.monitorType} type and other DSL-based monitors " +
-                                    "are not supported on this domain type. This domain supports PPL as the query language for " +
-                                    "alert monitors. It also supports cluster metrics monitors. Please create one of these monitor " +
-                                    "types instead.",
-                                RestStatus.FORBIDDEN
-                            )
-                        )
-                    )
-                    return@use
-                }
-
-                if (
-                    monitor.isMonitorOfStandardType() &&
-                    Monitor.MonitorType.valueOf(monitor.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.DOC_LEVEL_MONITOR
-                ) {
-                    try {
-                        scope.launch(TenantContext(tenantId)) {
-                            if (!docLevelMonitorQueries.docLevelQueryIndexExists(monitor.dataSources)) {
-                                docLevelMonitorQueries.initDocLevelQueryIndex(monitor.dataSources)
-                                log.info("Central Percolation index ${ScheduledJob.DOC_LEVEL_QUERIES_INDEX} created")
-                            }
-                            val (metadata, _) = MonitorMetadataService.getOrCreateMetadata(monitor, skipIndex = true)
-                            docLevelMonitorQueries.indexDocLevelQueries(
-                                monitor,
-                                monitor.id,
-                                metadata,
-                                WriteRequest.RefreshPolicy.IMMEDIATE,
-                                indexTimeout
-                            )
-                            log.info("Queries inserted into Percolate index ${ScheduledJob.DOC_LEVEL_QUERIES_INDEX}")
-                            executeMonitor(monitor)
-                        }
-                    } catch (t: Exception) {
-                        actionListener.onFailure(AlertingException.wrap(t))
-                    }
-                } else {
-                    executeMonitor(monitor)
+            } catch (e: Exception) {
+                log.error("Unexpected error running monitor", e)
+                withContext(Dispatchers.IO) {
+                    actionListener.onFailure(AlertingException.wrap(e))
                 }
             }
         }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/RestExecuteMonitorActionTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/RestExecuteMonitorActionTests.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.resthandler
+
+import org.opensearch.alerting.alerts.AlertIndices
+import org.opensearch.commons.alerting.model.DataSources
+import org.opensearch.commons.alerting.model.DocLevelMonitorInput
+import org.opensearch.commons.alerting.model.IntervalSchedule
+import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.ScheduledJob
+import org.opensearch.test.OpenSearchTestCase
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class RestExecuteMonitorActionTests : OpenSearchTestCase() {
+
+    fun `test validateDataSources rejects custom queryIndex`() {
+        val action = RestExecuteMonitorAction()
+        val monitor = createMonitor(
+            dataSources = DataSources(queryIndex = "attacker-controlled-index")
+        )
+
+        val exception = expectThrows(java.lang.reflect.InvocationTargetException::class.java) {
+            invokeValidateDataSources(action, monitor)
+        }
+        assertTrue(exception.cause is IllegalArgumentException)
+        assertEquals("Custom Data Sources are not allowed.", exception.cause!!.message)
+    }
+
+    fun `test validateDataSources rejects custom findingsIndex`() {
+        val action = RestExecuteMonitorAction()
+        val monitor = createMonitor(
+            dataSources = DataSources(findingsIndex = "attacker-findings-index")
+        )
+
+        val exception = expectThrows(java.lang.reflect.InvocationTargetException::class.java) {
+            invokeValidateDataSources(action, monitor)
+        }
+        assertTrue(exception.cause is IllegalArgumentException)
+        assertEquals("Custom Data Sources are not allowed.", exception.cause!!.message)
+    }
+
+    fun `test validateDataSources rejects custom alertsIndex`() {
+        val action = RestExecuteMonitorAction()
+        val monitor = createMonitor(
+            dataSources = DataSources(alertsIndex = "attacker-alerts-index")
+        )
+
+        val exception = expectThrows(java.lang.reflect.InvocationTargetException::class.java) {
+            invokeValidateDataSources(action, monitor)
+        }
+        assertTrue(exception.cause is IllegalArgumentException)
+        assertEquals("Custom Data Sources are not allowed.", exception.cause!!.message)
+    }
+
+    fun `test validateDataSources allows default data sources`() {
+        val action = RestExecuteMonitorAction()
+        val monitor = createMonitor(
+            dataSources = DataSources(
+                queryIndex = ScheduledJob.DOC_LEVEL_QUERIES_INDEX,
+                findingsIndex = AlertIndices.FINDING_HISTORY_WRITE_INDEX,
+                alertsIndex = AlertIndices.ALERT_INDEX
+            )
+        )
+
+        // Should not throw
+        invokeValidateDataSources(action, monitor)
+    }
+
+    private fun createMonitor(dataSources: DataSources = DataSources()): Monitor {
+        return Monitor(
+            name = "test",
+            monitorType = Monitor.MonitorType.DOC_LEVEL_MONITOR.value,
+            enabled = false,
+            schedule = IntervalSchedule(5, ChronoUnit.MINUTES),
+            lastUpdateTime = Instant.now(),
+            enabledTime = null,
+            user = null,
+            inputs = listOf(DocLevelMonitorInput("desc", listOf("test-index"), emptyList())),
+            triggers = emptyList(),
+            uiMetadata = mapOf(),
+            dataSources = dataSources
+        )
+    }
+
+    private fun invokeValidateDataSources(action: RestExecuteMonitorAction, monitor: Monitor) {
+        val method = action.javaClass.getDeclaredMethod("validateDataSources", Monitor::class.java)
+        method.isAccessible = true
+        method.invoke(action, monitor)
+    }
+}

--- a/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -2400,11 +2400,10 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         createUserRolesMapping(ALERTING_FULL_ACCESS_ROLE, arrayOf(user))
 
         try {
-            val response = executeMonitor(userClient as RestClient, modifiedMonitor, params = DRYRUN_MONITOR)
-            val output = entityAsMap(response)
-            val inputResults = output.stringMap("input_results")
-            assertTrue("Missing monitor error message", (inputResults?.get("error") as String).isNotEmpty())
-            assertTrue((inputResults.get("error") as String).contains("no permissions for [indices:data/read/search]"))
+            executeMonitor(userClient as RestClient, modifiedMonitor, params = DRYRUN_MONITOR)
+            fail("Expected FORBIDDEN response for inline monitor with restricted input indices")
+        } catch (e: ResponseException) {
+            assertEquals("Expected 403 status", RestStatus.FORBIDDEN.status, e.response.statusLine.statusCode)
         } finally {
             deleteRoleMapping(ALERTING_FULL_ACCESS_ROLE)
         }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorActionTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorActionTests.kt
@@ -1,0 +1,199 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting.transport
+
+import com.carrotsearch.randomizedtesting.ThreadFilter
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters
+import org.junit.Before
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito
+import org.mockito.Mockito.never
+import org.mockito.Mockito.timeout
+import org.mockito.Mockito.verify
+import org.opensearch.OpenSearchSecurityException
+import org.opensearch.action.search.SearchRequest
+import org.opensearch.action.search.SearchResponse
+import org.opensearch.action.support.ActionFilters
+import org.opensearch.alerting.MonitorRunnerService
+import org.opensearch.alerting.action.ExecuteMonitorRequest
+import org.opensearch.alerting.action.ExecuteMonitorResponse
+import org.opensearch.alerting.settings.AlertingSettings
+import org.opensearch.alerting.util.DocLevelMonitorQueries
+import org.opensearch.cluster.ClusterState
+import org.opensearch.cluster.metadata.Metadata
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.ClusterSettings
+import org.opensearch.common.settings.Setting
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.unit.TimeValue
+import org.opensearch.common.util.concurrent.ThreadContext
+import org.opensearch.commons.alerting.model.DocLevelMonitorInput
+import org.opensearch.commons.alerting.model.IntervalSchedule
+import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.model.SearchInput
+import org.opensearch.commons.alerting.util.AlertingException
+import org.opensearch.core.action.ActionListener
+import org.opensearch.core.rest.RestStatus
+import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.index.query.QueryBuilders
+import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.search.builder.SearchSourceBuilder
+import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.threadpool.ThreadPool
+import org.opensearch.transport.TransportService
+import org.opensearch.transport.client.Client
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+@ThreadLeakFilters(filters = [TransportExecuteMonitorActionTests.CoroutineThreadFilter::class])
+class TransportExecuteMonitorActionTests : OpenSearchTestCase() {
+
+    class CoroutineThreadFilter : ThreadFilter {
+        override fun reject(t: Thread): Boolean = t.name.startsWith("DefaultDispatcher-worker")
+    }
+
+    private lateinit var client: Client
+    private lateinit var clusterService: ClusterService
+    private lateinit var threadPool: ThreadPool
+    private lateinit var threadContext: ThreadContext
+
+    @Before
+    fun setup() {
+        client = Mockito.mock(Client::class.java)
+        clusterService = Mockito.mock(ClusterService::class.java)
+        threadPool = Mockito.mock(ThreadPool::class.java)
+        threadContext = ThreadContext(Settings.EMPTY)
+
+        Mockito.`when`(client.threadPool()).thenReturn(threadPool)
+        Mockito.`when`(threadPool.threadContext).thenReturn(threadContext)
+
+        // SecureTransportAction.listenFilterBySettingChange registers update consumers for both of these,
+        // so they must be present in the ClusterSettings used by the mocked ClusterService.
+        val settingSet = hashSetOf<Setting<*>>()
+        settingSet.addAll(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        settingSet.add(AlertingSettings.FILTER_BY_BACKEND_ROLES)
+        settingSet.add(AlertingSettings.FILTER_BY_BACKEND_ROLES_ACCESS_STRATEGY)
+        val clusterSettings = ClusterSettings(Settings.EMPTY, settingSet)
+        Mockito.`when`(clusterService.clusterSettings).thenReturn(clusterSettings)
+
+        val metadata = Mockito.mock(Metadata::class.java)
+        Mockito.`when`(metadata.indicesLookup).thenReturn(sortedMapOf())
+        Mockito.`when`(metadata.hasAlias(any())).thenReturn(false)
+        Mockito.`when`(metadata.dataStreams()).thenReturn(mapOf())
+        val clusterState = Mockito.mock(ClusterState::class.java)
+        Mockito.`when`(clusterState.metadata).thenReturn(metadata)
+        Mockito.`when`(clusterState.metadata()).thenReturn(metadata)
+        Mockito.`when`(clusterService.state()).thenReturn(clusterState)
+    }
+
+    fun `test inline monitor with search input triggers index access check`() {
+        Mockito.doAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            val listener = invocation.getArgument<ActionListener<SearchResponse>>(1)
+            listener.onFailure(OpenSearchSecurityException("no permissions for [indices:data/read/search]"))
+            null
+        }.`when`(client).search(any(SearchRequest::class.java), any())
+
+        val action = createAction()
+        val monitor = Monitor(
+            name = "test", monitorType = Monitor.MonitorType.QUERY_LEVEL_MONITOR.value,
+            enabled = false, schedule = IntervalSchedule(5, ChronoUnit.MINUTES),
+            lastUpdateTime = Instant.now(), enabledTime = null, user = null,
+            inputs = listOf(SearchInput(listOf("sensitive-index"), SearchSourceBuilder().query(QueryBuilders.matchAllQuery()))),
+            triggers = emptyList(), uiMetadata = mapOf()
+        )
+        val request = ExecuteMonitorRequest(true, TimeValue(Instant.now().toEpochMilli()), null, monitor)
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<ExecuteMonitorResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        val captor = org.mockito.ArgumentCaptor.forClass(Exception::class.java)
+        verify(listener, timeout(1000)).onFailure(captor.capture())
+        val exception = captor.value
+        assertTrue("Expected AlertingException but got ${exception.javaClass}", exception is AlertingException)
+        assertEquals(RestStatus.FORBIDDEN, (exception as AlertingException).status())
+    }
+
+    fun `test inline doc-level monitor with custom indices triggers index access check`() {
+        Mockito.doAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            val listener = invocation.getArgument<ActionListener<SearchResponse>>(1)
+            listener.onFailure(OpenSearchSecurityException("no permissions for [indices:data/read/search]"))
+            null
+        }.`when`(client).search(any(SearchRequest::class.java), any())
+
+        val action = createAction()
+        val monitor = Monitor(
+            name = "test", monitorType = Monitor.MonitorType.DOC_LEVEL_MONITOR.value,
+            enabled = false, schedule = IntervalSchedule(5, ChronoUnit.MINUTES),
+            lastUpdateTime = Instant.now(), enabledTime = null, user = null,
+            inputs = listOf(DocLevelMonitorInput("desc", listOf("unauthorized-index"), emptyList())),
+            triggers = emptyList(), uiMetadata = mapOf()
+        )
+        val request = ExecuteMonitorRequest(true, TimeValue(Instant.now().toEpochMilli()), null, monitor)
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<ExecuteMonitorResponse>
+
+        invokeDoExecute(action, request, listener)
+
+        val captor = org.mockito.ArgumentCaptor.forClass(Exception::class.java)
+        verify(listener, timeout(1000)).onFailure(captor.capture())
+        val exception = captor.value
+        assertTrue("Expected AlertingException but got ${exception.javaClass}", exception is AlertingException)
+        assertEquals(RestStatus.FORBIDDEN, (exception as AlertingException).status())
+    }
+
+    fun `test inline monitor with no inputs does not trigger access check`() {
+        val action = createAction()
+        val monitor = Monitor(
+            name = "test", monitorType = Monitor.MonitorType.QUERY_LEVEL_MONITOR.value,
+            enabled = false, schedule = IntervalSchedule(5, ChronoUnit.MINUTES),
+            lastUpdateTime = Instant.now(), enabledTime = null, user = null,
+            inputs = emptyList(),
+            triggers = emptyList(), uiMetadata = mapOf()
+        )
+        val request = ExecuteMonitorRequest(true, TimeValue(Instant.now().toEpochMilli()), null, monitor)
+        @Suppress("UNCHECKED_CAST")
+        val listener = Mockito.mock(ActionListener::class.java) as ActionListener<ExecuteMonitorResponse>
+
+        try {
+            invokeDoExecute(action, request, listener)
+        } catch (e: java.lang.reflect.InvocationTargetException) {
+            // MonitorRunnerService is not initialized in unit tests — expected once execution is launched
+        }
+
+        verify(client, never()).search(any(SearchRequest::class.java), any())
+    }
+
+    private fun invokeDoExecute(
+        action: TransportExecuteMonitorAction,
+        request: ExecuteMonitorRequest,
+        listener: ActionListener<ExecuteMonitorResponse>
+    ) {
+        val method = action.javaClass.getDeclaredMethod(
+            "doExecute",
+            org.opensearch.tasks.Task::class.java,
+            ExecuteMonitorRequest::class.java,
+            ActionListener::class.java
+        )
+        method.isAccessible = true
+        method.invoke(action, Mockito.mock(org.opensearch.tasks.Task::class.java), request, listener)
+    }
+
+    private fun createAction(): TransportExecuteMonitorAction {
+        return TransportExecuteMonitorAction(
+            Mockito.mock(TransportService::class.java),
+            client, clusterService,
+            MonitorRunnerService,
+            Mockito.mock(ActionFilters::class.java),
+            Mockito.mock(NamedXContentRegistry::class.java),
+            DocLevelMonitorQueries(client, clusterService),
+            Settings.EMPTY,
+            Mockito.mock(SdkClient::class.java)
+        )
+    }
+}


### PR DESCRIPTION
### Description
Add validation to Execute Monitor API


### Behavior change
The Execute Monitor API's pre-flight input check now fails the request on any search failure, not only security exceptions. Previously, an inline dry-run against a nonexistent (or otherwise unqueryable) index returned HTTP 200 with the error captured in input_results; it now returns an error response. API consumers relying on the old dry-run debugging behavior should be aware of this.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
