### PR TITLE
Fix backend build against 3.x snapshot: jackson-core direct deps + httpcore5 pin

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -185,6 +185,14 @@ dependencies {
     // SQL/PPL plugin dependencies are included in alerting-core
     api project(":alerting-core")
     implementation 'org.json:json:20240303'
+    // jackson-core and jackson-annotations must be declared directly, not just forced.
+    // A force only overrides the version of a dependency already in the graph; it does
+    // not add one. When OpenSearch pulls Jackson 3 (tools.jackson), the com.fasterxml
+    // jackson-core/annotations can be evicted from the compile classpath, making the
+    // supertypes of jackson-databind types (TreeNode, ObjectCodec, Versioned) inaccessible
+    // and breaking compilation non-deterministically against the moving 3.x snapshot.
+    implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
 
     implementation "com.github.seancfoley:ipaddress:5.4.1"

--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -108,6 +108,11 @@ configurations.all {
         force "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:${versions.jackson}"
         force "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions.jackson}"
         force "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson}"
+        // opensearch-remote-metadata-sdk pulls httpcore5:5.4.3 while opensearch-rest-client
+        // pulls httpcore5:5.4, and Gradle cannot reconcile the two against the moving 3.x
+        // snapshot. Pin httpcore5 and its h2 variant to a single version to resolve it.
+        force "org.apache.httpcomponents.core5:httpcore5:5.4.3"
+        force "org.apache.httpcomponents.core5:httpcore5-h2:5.4.3"
         eachDependency { details ->
             if (details.requested.group.startsWith('tools.jackson')) {
                 details.useVersion versions.jackson3


### PR DESCRIPTION
### Description
`main` fails to build against the OpenSearch 3.9.0-SNAPSHOT dependencies. Two independent, snapshot-driven dependency problems, fixed here:

**1. `:alerting:compileKotlin` — Jackson (fixes the primary/reported failure)**
```
InputService.kt: Cannot access 'TreeNode' which is a supertype of 'JsonNode'
PPLUtils.kt: Cannot access 'ObjectCodec' / 'Versioned' which is a supertype of 'ObjectMapper'
```
`jackson-databind` is a direct dependency, but `jackson-core`/`jackson-annotations` were only `force`d — and a `force` overrides the version of a dep already in the graph, it does not add one. When the snapshot pulls Jackson 3 (`tools.jackson`), `com.fasterxml jackson-core` is evicted and its classes become inaccessible (non-deterministically). Fix: declare `jackson-core`/`jackson-annotations` as direct `implementation` deps.

**2. `:alerting:runtimeClasspath` — httpcore5 conflict (surfaces once compile succeeds)**
```
Conflict found for module 'org.apache.httpcomponents.core5:httpcore5': between versions 5.4.3 and 5.4
```
`opensearch-remote-metadata-sdk` requires `httpcore5:5.4.3` while `opensearch-rest-client` requires `httpcore5:5.4`; Gradle can't reconcile them. Fix: force `httpcore5`/`httpcore5-h2` to `5.4.3`.

### Validation (local, JDK 21)
- `./gradlew :alerting:compileKotlin --rerun-tasks --refresh-dependencies` ✅
- `./gradlew :alerting:assemble --refresh-dependencies` ✅
- `./gradlew :alerting:compileTestKotlin` ✅

(Confirmed the jackson fix is load-bearing: `compileKotlin` **fails on main** and **passes here** in CI.)

### Issues Resolved
Fixes #2227

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.